### PR TITLE
sync: add the 46 sre-agent skills (sre-agent/.claude/skills/)

### DIFF
--- a/sre-agent/.claude/skills/alerting-context/SKILL.md
+++ b/sre-agent/.claude/skills/alerting-context/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: alerting-context
+description: Pull incident context from alerting platforms (PagerDuty). Use when investigating who's on-call, incident history, alert patterns, or MTTR metrics.
+allowed-tools: Bash(python *)
+---
+
+# Alerting Context
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `PAGERDUTY_API_KEY` in environment variables - it won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+---
+
+## Why Alerting Context Matters
+
+Before diving into logs and metrics, understand:
+- **Has this happened before?** Check similar past incidents
+- **Who's responding?** Know who's on-call and assigned
+- **What else is alerting?** Correlated alerts reveal scope
+- **How long do similar issues take?** MTTR sets expectations
+
+## Available Scripts
+
+All scripts are in `.claude/skills/alerting-context/scripts/`
+
+### get_incident.py - Get Incident Details
+```bash
+python .claude/skills/alerting-context/scripts/get_incident.py --id INCIDENT_ID [--timeline]
+
+# Examples:
+python .claude/skills/alerting-context/scripts/get_incident.py --id P123ABC
+python .claude/skills/alerting-context/scripts/get_incident.py --id P123ABC --timeline
+```
+
+### list_incidents.py - List Incidents with Filters
+```bash
+python .claude/skills/alerting-context/scripts/list_incidents.py [--status STATUS] [--days N] [--limit N]
+
+# Examples:
+python .claude/skills/alerting-context/scripts/list_incidents.py
+python .claude/skills/alerting-context/scripts/list_incidents.py --status triggered
+python .claude/skills/alerting-context/scripts/list_incidents.py --status acknowledged --limit 10
+python .claude/skills/alerting-context/scripts/list_incidents.py --days 30
+```
+
+### calculate_mttr.py - Calculate Mean Time To Resolve
+```bash
+python .claude/skills/alerting-context/scripts/calculate_mttr.py [--service SERVICE_ID] [--days N]
+
+# Examples:
+python .claude/skills/alerting-context/scripts/calculate_mttr.py
+python .claude/skills/alerting-context/scripts/calculate_mttr.py --days 30
+python .claude/skills/alerting-context/scripts/calculate_mttr.py --service PSERVICE123 --days 90
+```
+
+---
+
+## Investigation Workflow
+
+### Step 1: Get Current Incident Context
+
+```bash
+# Get details of the current incident
+python get_incident.py --id P123ABC --timeline
+```
+
+**Returns:**
+- Incident title, status, urgency
+- Service affected
+- Who acknowledged, when
+- Timeline of actions taken
+
+### Step 2: Find Similar Past Incidents
+
+```bash
+# Get incidents from the last 30 days
+python list_incidents.py --days 30 --status resolved
+
+# Check for patterns in a specific service
+python list_incidents.py --service PSERVICE123 --days 90
+```
+
+**Look for:**
+- Same alert title recurring → Known issue or flapping
+- Cluster of alerts → Systemic problem
+- Low ack rate → Possible alert fatigue
+
+### Step 3: Check Historical MTTR
+
+```bash
+# Get MTTR for this service
+python calculate_mttr.py --service PSERVICE123 --days 30
+```
+
+**Returns:**
+- Average MTTR (minutes/hours)
+- Median MTTR
+- 95th percentile
+- Fastest/slowest resolution
+
+---
+
+## Quick Commands Reference
+
+| Goal | Command |
+|------|---------|
+| Get incident | `get_incident.py --id P123ABC` |
+| With timeline | `get_incident.py --id P123ABC --timeline` |
+| Active incidents | `list_incidents.py --status triggered` |
+| Acknowledged | `list_incidents.py --status acknowledged` |
+| Last 30 days | `list_incidents.py --days 30` |
+| Calculate MTTR | `calculate_mttr.py --service X --days 30` |
+
+---
+
+## Common Patterns
+
+### Pattern 1: "Is this a known issue?"
+
+```bash
+# Search for similar alerts in last 30 days
+python list_incidents.py --days 30
+
+# Check the output for recurring alert titles
+# Look for same service, similar patterns
+```
+
+### Pattern 2: "Escalation Investigation"
+
+```bash
+# Get full incident details with timeline
+python get_incident.py --id P123ABC --timeline
+
+# Check 'assignments' and 'acknowledgements' in output
+# Timeline shows escalation events
+```
+
+### Pattern 3: "SLA/MTTR Tracking"
+
+```bash
+# Get MTTR for incident comparison
+python calculate_mttr.py --service PSERVICE123 --days 30
+
+# Compare current incident duration to historical average
+# If current > p95, this is an unusually long incident
+```
+
+---
+
+## Output Format
+
+```markdown
+## Alerting Context Summary
+
+### Current Incident
+- **ID**: [incident_id]
+- **Title**: [title]
+- **Status**: [triggered/acknowledged/resolved]
+- **Service**: [service_name]
+- **Urgency**: [high/low]
+- **Created**: [timestamp]
+- **Duration**: [how long since created]
+
+### On-Call
+- **Primary**: [name] ([email])
+- **Secondary**: [name] ([email])
+- **Escalation Policy**: [policy_name]
+
+### Historical Context
+- **Similar incidents (30d)**: N incidents with same/similar title
+- **Average MTTR for this service**: X minutes
+- **This alert fires**: Z times/week on average
+
+### Recommendations
+- [If recurring] Review runbook for this alert
+- [If long duration] Consider escalating
+- [If noisy] Consider tuning alert threshold
+```
+
+---
+
+## Anti-Patterns to Avoid
+
+1. ❌ **Ignoring past incidents** - Always check if it's a known issue
+2. ❌ **Not checking on-call** - Know who's responding before investigating
+3. ❌ **Missing correlated alerts** - One incident might mask the real issue
+4. ❌ **Forgetting MTTR context** - Know what "normal" resolution looks like
+5. ❌ **Unbounded queries** - Always use time ranges to avoid timeout

--- a/sre-agent/.claude/skills/alerting-context/scripts/__init__.py
+++ b/sre-agent/.claude/skills/alerting-context/scripts/__init__.py
@@ -1,0 +1,1 @@
+# PagerDuty alerting context scripts

--- a/sre-agent/.claude/skills/alerting-context/scripts/calculate_mttr.py
+++ b/sre-agent/.claude/skills/alerting-context/scripts/calculate_mttr.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Calculate Mean Time To Resolve (MTTR) for PagerDuty incidents.
+
+Usage:
+    python calculate_mttr.py [--service SERVICE_ID] [--days N]
+
+Examples:
+    python calculate_mttr.py
+    python calculate_mttr.py --days 30
+    python calculate_mttr.py --service PSERVICE123 --days 90
+"""
+
+import argparse
+import json
+import sys
+
+from pagerduty_client import calculate_mttr
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Calculate MTTR for PagerDuty incidents"
+    )
+    parser.add_argument(
+        "--service",
+        help="Filter by service ID",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=30,
+        help="Number of days to analyze (default: 30)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    try:
+        result = calculate_mttr(
+            service_id=args.service,
+            days=args.days,
+        )
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print("=" * 60)
+            print("MEAN TIME TO RESOLVE (MTTR)")
+            print("=" * 60)
+            print(f"Days analyzed: {result.get('days_analyzed', args.days)}")
+            if args.service:
+                print(f"Service: {args.service}")
+            print(f"Sample size: {result.get('sample_size', 0)} resolved incidents")
+            print()
+
+            if result.get("sample_size", 0) == 0:
+                print(result.get("message", "No data available"))
+            else:
+                mttr = result.get("mttr_minutes", {})
+
+                def format_duration(minutes):
+                    if minutes is None:
+                        return "N/A"
+                    if minutes < 60:
+                        return f"{minutes:.1f} minutes"
+                    hours = minutes / 60
+                    if hours < 24:
+                        return f"{hours:.1f} hours"
+                    days = hours / 24
+                    return f"{days:.1f} days"
+
+                print("RESOLUTION TIME STATISTICS:")
+                print("-" * 40)
+                print(f"  Mean:   {format_duration(mttr.get('mean'))}")
+                print(f"  Median: {format_duration(mttr.get('median'))}")
+                if mttr.get("p95"):
+                    print(f"  P95:    {format_duration(mttr.get('p95'))}")
+                print(f"  Min:    {format_duration(mttr.get('min'))}")
+                print(f"  Max:    {format_duration(mttr.get('max'))}")
+                print()
+
+                # Interpretation
+                mean_mins = mttr.get("mean", 0)
+                if mean_mins < 30:
+                    print("✅ Excellent MTTR - incidents resolved quickly")
+                elif mean_mins < 60:
+                    print("🟢 Good MTTR - within typical SLO targets")
+                elif mean_mins < 240:
+                    print("🟡 Moderate MTTR - room for improvement")
+                else:
+                    print("🔴 High MTTR - consider process improvements")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/alerting-context/scripts/get_incident.py
+++ b/sre-agent/.claude/skills/alerting-context/scripts/get_incident.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Get details of a PagerDuty incident.
+
+Usage:
+    python get_incident.py --id INCIDENT_ID
+
+Examples:
+    python get_incident.py --id P123ABC
+"""
+
+import argparse
+import json
+import sys
+
+from pagerduty_client import format_incident, get_incident, get_incident_log_entries
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get details of a PagerDuty incident")
+    parser.add_argument(
+        "--id",
+        required=True,
+        help="PagerDuty incident ID",
+    )
+    parser.add_argument(
+        "--timeline",
+        action="store_true",
+        help="Include incident timeline/log entries",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    try:
+        incident = get_incident(args.id)
+
+        log_entries = []
+        if args.timeline:
+            log_entries = get_incident_log_entries(args.id)
+
+        if args.json:
+            output = {
+                "incident": {
+                    "id": incident.get("id"),
+                    "title": incident.get("title"),
+                    "status": incident.get("status"),
+                    "urgency": incident.get("urgency"),
+                    "created_at": incident.get("created_at"),
+                    "service": incident.get("service", {}).get("summary"),
+                    "escalation_policy": incident.get("escalation_policy", {}).get(
+                        "summary"
+                    ),
+                    "assignments": [
+                        a.get("assignee", {}).get("summary")
+                        for a in incident.get("assignments", [])
+                    ],
+                    "acknowledgements": [
+                        {
+                            "acknowledger": a.get("acknowledger", {}).get("summary"),
+                            "at": a.get("at"),
+                        }
+                        for a in incident.get("acknowledgements", [])
+                    ],
+                    "html_url": incident.get("html_url"),
+                },
+            }
+            if log_entries:
+                output["timeline"] = [
+                    {
+                        "type": e.get("type"),
+                        "created_at": e.get("created_at"),
+                        "summary": e.get("summary"),
+                        "agent": e.get("agent", {}).get("summary"),
+                    }
+                    for e in log_entries
+                ]
+            print(json.dumps(output, indent=2))
+        else:
+            print("=" * 60)
+            print("PAGERDUTY INCIDENT")
+            print("=" * 60)
+            print(format_incident(incident))
+            print()
+            print(
+                f"Escalation Policy: {incident.get('escalation_policy', {}).get('summary', 'N/A')}"
+            )
+            print(f"URL: {incident.get('html_url', 'N/A')}")
+
+            assignments = incident.get("assignments", [])
+            if assignments:
+                print()
+                print("ASSIGNMENTS:")
+                for a in assignments:
+                    print(f"  • {a.get('assignee', {}).get('summary', 'Unknown')}")
+
+            acks = incident.get("acknowledgements", [])
+            if acks:
+                print()
+                print("ACKNOWLEDGEMENTS:")
+                for a in acks:
+                    print(
+                        f"  • {a.get('acknowledger', {}).get('summary', 'Unknown')} at {a.get('at', 'N/A')}"
+                    )
+
+            if log_entries:
+                print()
+                print("TIMELINE:")
+                print("-" * 40)
+                for entry in log_entries[:20]:
+                    entry_type = entry.get("type", "").replace("_", " ")
+                    created = entry.get("created_at", "")
+                    summary = entry.get("summary", "")[:100]
+                    agent = entry.get("agent", {}).get("summary", "")
+                    print(f"  [{created}] {entry_type}")
+                    if summary:
+                        print(f"    {summary}")
+                    if agent:
+                        print(f"    By: {agent}")
+                    print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/alerting-context/scripts/list_incidents.py
+++ b/sre-agent/.claude/skills/alerting-context/scripts/list_incidents.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""List PagerDuty incidents with optional filters.
+
+Usage:
+    python list_incidents.py [--status STATUS] [--days N] [--limit N]
+
+Examples:
+    python list_incidents.py
+    python list_incidents.py --status triggered
+    python list_incidents.py --status acknowledged --limit 10
+    python list_incidents.py --days 7
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+from pagerduty_client import format_incident, list_incidents
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List PagerDuty incidents")
+    parser.add_argument(
+        "--status",
+        choices=["triggered", "acknowledged", "resolved"],
+        help="Filter by status",
+    )
+    parser.add_argument(
+        "--service",
+        help="Filter by service ID",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=7,
+        help="Number of days to look back (default: 7)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=25,
+        help="Maximum incidents to return (default: 25)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    try:
+        since = (
+            (datetime.now(timezone.utc) - timedelta(days=args.days))
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+        until = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+        service_ids = [args.service] if args.service else None
+
+        incidents = list_incidents(
+            status=args.status,
+            service_ids=service_ids,
+            since=since,
+            until=until,
+            limit=args.limit,
+        )
+
+        if args.json:
+            output = {
+                "filters": {
+                    "status": args.status,
+                    "service_id": args.service,
+                    "days": args.days,
+                },
+                "count": len(incidents),
+                "incidents": [
+                    {
+                        "id": inc.get("id"),
+                        "title": inc.get("title"),
+                        "status": inc.get("status"),
+                        "urgency": inc.get("urgency"),
+                        "created_at": inc.get("created_at"),
+                        "service": inc.get("service", {}).get("summary"),
+                        "html_url": inc.get("html_url"),
+                    }
+                    for inc in incidents
+                ],
+            }
+            print(json.dumps(output, indent=2))
+        else:
+            print("=" * 60)
+            print("PAGERDUTY INCIDENTS")
+            print("=" * 60)
+            if args.status:
+                print(f"Status: {args.status}")
+            print(f"Time range: last {args.days} days")
+            print(f"Found: {len(incidents)} incidents")
+            print()
+
+            if not incidents:
+                print("No incidents found matching criteria.")
+            else:
+                # Group by status
+                by_status = {}
+                for inc in incidents:
+                    status = inc.get("status", "unknown")
+                    if status not in by_status:
+                        by_status[status] = []
+                    by_status[status].append(inc)
+
+                for status in ["triggered", "acknowledged", "resolved"]:
+                    if status in by_status:
+                        print(f"\n{status.upper()} ({len(by_status[status])})")
+                        print("-" * 40)
+                        for inc in by_status[status]:
+                            print(format_incident(inc))
+                            print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/alerting-context/scripts/pagerduty_client.py
+++ b/sre-agent/.claude/skills/alerting-context/scripts/pagerduty_client.py
@@ -1,0 +1,338 @@
+"""Shared PagerDuty API client with credential proxy support.
+
+This client is designed to work with the OpenSRE credential proxy.
+Credentials are injected automatically - scripts should NOT check for
+PAGERDUTY_API_KEY in environment variables.
+"""
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+def get_config() -> dict[str, Any]:
+    """Load configuration from standard locations."""
+    config = {}
+
+    # Check for config file
+    config_paths = [
+        Path.home() / ".opensre" / "config.json",
+        Path("/etc/opensre/config.json"),
+    ]
+
+    for path in config_paths:
+        if path.exists():
+            with open(path) as f:
+                config = json.load(f)
+                break
+
+    # Environment overrides
+    if os.getenv("TENANT_ID"):
+        config["tenant_id"] = os.getenv("TENANT_ID")
+    if os.getenv("TEAM_ID"):
+        config["team_id"] = os.getenv("TEAM_ID")
+
+    return config
+
+
+def get_api_url(endpoint: str) -> str:
+    """Get the PagerDuty API URL for an endpoint.
+
+    In production, this routes through the credential proxy.
+    """
+    base_url = os.getenv("PAGERDUTY_BASE_URL")
+    if not base_url:
+        # Fall back to direct API (for local development only)
+        base_url = "https://api.pagerduty.com"
+
+    return f"{base_url.rstrip('/')}{endpoint}"
+
+
+def get_headers() -> dict[str, str]:
+    """Get headers for PagerDuty API requests.
+
+    The credential proxy will inject Authorization header.
+    """
+    config = get_config()
+
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/vnd.pagerduty+json;version=2",
+    }
+
+    # Proxy mode - use JWT for credential-resolver auth
+    sandbox_jwt = os.getenv("SANDBOX_JWT")
+    if sandbox_jwt:
+        headers["X-Sandbox-JWT"] = sandbox_jwt
+    else:
+        # Fallback for local dev
+        headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+        headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    # For local development, allow direct token usage
+    token = os.getenv("PAGERDUTY_API_KEY")
+    if token and not os.getenv("PAGERDUTY_BASE_URL"):
+        headers["Authorization"] = f"Token token={token}"
+
+    return headers
+
+
+def api_request(
+    method: str,
+    endpoint: str,
+    params: dict[str, Any] | None = None,
+    json_data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Make a request to the PagerDuty API.
+
+    Args:
+        method: HTTP method
+        endpoint: API endpoint
+        params: Query parameters
+        json_data: JSON body
+
+    Returns:
+        Parsed JSON response
+
+    Raises:
+        RuntimeError: If the request fails
+    """
+    url = get_api_url(endpoint)
+    headers = get_headers()
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.request(
+            method=method,
+            url=url,
+            headers=headers,
+            params=params,
+            json=json_data,
+        )
+
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"PagerDuty API error {response.status_code}: {response.text}"
+            )
+
+        return response.json()
+
+
+def get_incident(incident_id: str) -> dict[str, Any]:
+    """Get details of a specific incident.
+
+    Args:
+        incident_id: PagerDuty incident ID
+
+    Returns:
+        Incident object
+    """
+    result = api_request("GET", f"/incidents/{incident_id}")
+    return result.get("incident", {})
+
+
+def list_incidents(
+    status: str | None = None,
+    service_ids: list[str] | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    limit: int = 25,
+) -> list[dict[str, Any]]:
+    """List incidents with optional filters.
+
+    Args:
+        status: Filter by status (triggered, acknowledged, resolved)
+        service_ids: Filter by service IDs
+        since: Start date (ISO 8601)
+        until: End date (ISO 8601)
+        limit: Maximum results
+
+    Returns:
+        List of incident objects
+    """
+    params = {"limit": limit}
+    if status:
+        params["statuses[]"] = status
+    if service_ids:
+        params["service_ids[]"] = service_ids
+    if since:
+        params["since"] = since
+    if until:
+        params["until"] = until
+
+    result = api_request("GET", "/incidents", params=params)
+    return result.get("incidents", [])
+
+
+def get_incident_log_entries(
+    incident_id: str,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Get log entries (timeline) for an incident.
+
+    Args:
+        incident_id: PagerDuty incident ID
+        limit: Maximum entries
+
+    Returns:
+        List of log entry objects
+    """
+    result = api_request(
+        "GET",
+        f"/incidents/{incident_id}/log_entries",
+        params={"limit": limit},
+    )
+    return result.get("log_entries", [])
+
+
+def get_escalation_policy(policy_id: str) -> dict[str, Any]:
+    """Get an escalation policy.
+
+    Args:
+        policy_id: Escalation policy ID
+
+    Returns:
+        Escalation policy object
+    """
+    result = api_request("GET", f"/escalation_policies/{policy_id}")
+    return result.get("escalation_policy", {})
+
+
+def list_services(limit: int = 100) -> list[dict[str, Any]]:
+    """List all services.
+
+    Args:
+        limit: Maximum results
+
+    Returns:
+        List of service objects
+    """
+    result = api_request("GET", "/services", params={"limit": limit})
+    return result.get("services", [])
+
+
+def get_on_calls(
+    escalation_policy_ids: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Get current on-call users.
+
+    Args:
+        escalation_policy_ids: Filter by escalation policies
+
+    Returns:
+        List of on-call objects
+    """
+    params = {}
+    if escalation_policy_ids:
+        params["escalation_policy_ids[]"] = escalation_policy_ids
+
+    result = api_request("GET", "/oncalls", params=params)
+    return result.get("oncalls", [])
+
+
+def calculate_mttr(
+    service_id: str | None = None,
+    days: int = 30,
+) -> dict[str, Any]:
+    """Calculate Mean Time To Resolve for incidents.
+
+    Args:
+        service_id: Filter by service ID
+        days: Number of days to analyze
+
+    Returns:
+        MTTR statistics
+    """
+    since = (
+        (datetime.now(timezone.utc) - timedelta(days=days))
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    until = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    params = {
+        "since": since,
+        "until": until,
+        "statuses[]": "resolved",
+        "limit": 100,
+    }
+    if service_id:
+        params["service_ids[]"] = [service_id]
+
+    result = api_request("GET", "/incidents", params=params)
+    incidents = result.get("incidents", [])
+
+    if not incidents:
+        return {
+            "sample_size": 0,
+            "message": "No resolved incidents found in time range",
+        }
+
+    # Calculate resolution times
+    resolution_times = []
+    for inc in incidents:
+        created = inc.get("created_at")
+        resolved = inc.get("last_status_change_at")
+        if created and resolved:
+            try:
+                created_dt = datetime.fromisoformat(created.replace("Z", "+00:00"))
+                resolved_dt = datetime.fromisoformat(resolved.replace("Z", "+00:00"))
+                duration = (resolved_dt - created_dt).total_seconds() / 60  # Minutes
+                resolution_times.append(duration)
+            except (ValueError, TypeError):
+                pass
+
+    if not resolution_times:
+        return {
+            "sample_size": 0,
+            "message": "Could not calculate resolution times",
+        }
+
+    resolution_times.sort()
+    n = len(resolution_times)
+
+    return {
+        "sample_size": n,
+        "days_analyzed": days,
+        "service_id": service_id,
+        "mttr_minutes": {
+            "mean": sum(resolution_times) / n,
+            "median": resolution_times[n // 2],
+            "p95": resolution_times[int(n * 0.95)] if n >= 20 else None,
+            "min": min(resolution_times),
+            "max": max(resolution_times),
+        },
+    }
+
+
+def format_incident(incident: dict[str, Any]) -> str:
+    """Format an incident for display.
+
+    Args:
+        incident: Incident object from API
+
+    Returns:
+        Formatted string
+    """
+    inc_id = incident.get("id", "")
+    title = incident.get("title", "Untitled")
+    status = incident.get("status", "unknown")
+    urgency = incident.get("urgency", "unknown")
+    created = incident.get("created_at", "")
+    service = incident.get("service", {}).get("summary", "unknown")
+
+    status_icon = {
+        "triggered": "🔴",
+        "acknowledged": "🟡",
+        "resolved": "🟢",
+    }.get(status, "❓")
+
+    output = f"{status_icon} [{inc_id}] {title}\n"
+    output += f"   Status: {status} | Urgency: {urgency}\n"
+    output += f"   Service: {service}\n"
+    output += f"   Created: {created}"
+
+    return output

--- a/sre-agent/.claude/skills/alerting-opsgenie/SKILL.md
+++ b/sre-agent/.claude/skills/alerting-opsgenie/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: alerting-opsgenie
+description: Opsgenie alert management and on-call scheduling. Use for listing alerts, checking on-call, computing MTTA/MTTR, and alert fatigue analysis. Supports team and priority filtering.
+allowed-tools: Bash(python *)
+---
+
+# Opsgenie Integration
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `OPSGENIE_API_KEY` in environment variables - they won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `OPSGENIE_BASE_URL` - Proxy base URL (set automatically in production)
+- `OPSGENIE_API_URL` - Custom API URL (default: https://api.opsgenie.com)
+
+---
+
+## Available Scripts
+
+All scripts are in `.claude/skills/alerting-opsgenie/scripts/`
+
+### list_alerts.py - List Alerts
+```bash
+python .claude/skills/alerting-opsgenie/scripts/list_alerts.py [--status open] [--priority P1] [--query QUERY] [--max-results N]
+```
+
+### get_alert.py - Get Alert Details
+```bash
+python .claude/skills/alerting-opsgenie/scripts/get_alert.py --alert-id ALERT_ID
+```
+
+### get_alert_logs.py - Alert Timeline
+```bash
+python .claude/skills/alerting-opsgenie/scripts/get_alert_logs.py --alert-id ALERT_ID [--max-results 50]
+```
+
+### list_alerts_by_date_range.py - Historical Alerts with MTTA/MTTR
+```bash
+python .claude/skills/alerting-opsgenie/scripts/list_alerts_by_date_range.py --since "2024-01-01T00:00:00Z" --until "2024-01-31T23:59:59Z" [--query QUERY]
+```
+
+### list_services.py - List Services
+```bash
+python .claude/skills/alerting-opsgenie/scripts/list_services.py
+```
+
+### list_teams.py - List Teams
+```bash
+python .claude/skills/alerting-opsgenie/scripts/list_teams.py
+```
+
+### get_on_call.py - On-Call Schedule
+```bash
+python .claude/skills/alerting-opsgenie/scripts/get_on_call.py [--schedule-id ID] [--team-id ID]
+```
+
+### get_alert_analytics.py - Alert Fatigue Analysis
+```bash
+python .claude/skills/alerting-opsgenie/scripts/get_alert_analytics.py --since "2024-01-01T00:00:00Z" --until "2024-01-31T23:59:59Z" [--team-id ID]
+```
+
+### calculate_mttr.py - MTTR Statistics
+```bash
+python .claude/skills/alerting-opsgenie/scripts/calculate_mttr.py [--team-id ID] [--priority P1] [--days 30]
+```
+
+---
+
+## Investigation Workflow
+
+### On-Call & Alert Triage
+```
+1. Check who's on call:
+   get_on_call.py
+
+2. List open alerts:
+   list_alerts.py --status open
+
+3. Get alert details:
+   get_alert.py --alert-id <id>
+
+4. Review alert timeline:
+   get_alert_logs.py --alert-id <id>
+```
+
+### Alert Fatigue Analysis
+```
+1. Get alert analytics:
+   get_alert_analytics.py --since "2024-01-01T00:00:00Z" --until "2024-01-31T23:59:59Z"
+
+2. Review noisy alerts (high fire count, low ack rate)
+3. Review flapping alerts (quick auto-resolve)
+
+4. MTTR by priority:
+   calculate_mttr.py --priority P1 --days 30
+```

--- a/sre-agent/.claude/skills/alerting-opsgenie/scripts/calculate_mttr.py
+++ b/sre-agent/.claude/skills/alerting-opsgenie/scripts/calculate_mttr.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Calculate MTTR statistics for Opsgenie alerts.
+
+Usage:
+    python calculate_mttr.py [--team-id ID] [--priority P1] [--days 30]
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+from opsgenie_client import opsgenie_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Calculate MTTR")
+    parser.add_argument("--team-id", help="Optional team ID filter")
+    parser.add_argument("--priority", help="Optional priority filter (P1-P5)")
+    parser.add_argument(
+        "--days", type=int, default=30, help="Days to analyze (default: 30)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        since = (datetime.now(timezone.utc) - timedelta(days=args.days)).isoformat()
+        until = datetime.now(timezone.utc).isoformat()
+
+        query_parts = [
+            f"createdAt >= {since} AND createdAt <= {until}",
+            "status=closed",
+        ]
+        if args.team_id:
+            query_parts.append(f"responders:{args.team_id}")
+        if args.priority:
+            query_parts.append(f"priority={args.priority}")
+
+        params = {
+            "query": " AND ".join(query_parts),
+            "limit": 100,
+            "sort": "createdAt",
+            "order": "desc",
+        }
+        mttr_values = []
+        offset = 0
+
+        while len(mttr_values) < 500:
+            params["offset"] = offset
+            data = opsgenie_request("GET", "/v2/alerts", params=params)
+            alerts = data.get("data", [])
+            if not alerts:
+                break
+
+            for alert in alerts:
+                close_time = alert.get("report", {}).get("closeTime")
+                if close_time:
+                    mttr_values.append(close_time / 1000 / 60)
+
+            offset += len(alerts)
+            if len(alerts) < params["limit"]:
+                break
+
+        if not mttr_values:
+            result = {
+                "team_id": args.team_id,
+                "priority": args.priority,
+                "period_days": args.days,
+                "alert_count": 0,
+                "message": "No closed alerts in this period",
+            }
+        else:
+            mttr_values.sort()
+            count = len(mttr_values)
+            avg = sum(mttr_values) / count
+            result = {
+                "team_id": args.team_id,
+                "priority": args.priority,
+                "period_days": args.days,
+                "alert_count": count,
+                "mttr_minutes": round(avg, 2),
+                "mttr_hours": round(avg / 60, 2),
+                "median_minutes": round(mttr_values[count // 2], 2),
+                "p95_minutes": (
+                    round(mttr_values[int(count * 0.95)], 2)
+                    if count > 1
+                    else round(mttr_values[0], 2)
+                ),
+                "fastest_resolution_minutes": round(min(mttr_values), 2),
+                "slowest_resolution_minutes": round(max(mttr_values), 2),
+            }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"MTTR Statistics (last {args.days} days)")
+            if args.team_id:
+                print(f"Team: {args.team_id}")
+            if args.priority:
+                print(f"Priority: {args.priority}")
+            print(f"Alerts analyzed: {result.get('alert_count', 0)}")
+            if result.get("mttr_minutes"):
+                print(
+                    f"Average MTTR: {result['mttr_minutes']} min ({result['mttr_hours']} hrs)"
+                )
+                print(f"Median: {result['median_minutes']} min")
+                print(f"P95: {result['p95_minutes']} min")
+                print(f"Fastest: {result['fastest_resolution_minutes']} min")
+                print(f"Slowest: {result['slowest_resolution_minutes']} min")
+            else:
+                print(result.get("message", "No data"))
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/alerting-opsgenie/scripts/get_alert.py
+++ b/sre-agent/.claude/skills/alerting-opsgenie/scripts/get_alert.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Get details of a specific Opsgenie alert.
+
+Usage:
+    python get_alert.py --alert-id ALERT_ID
+"""
+
+import argparse
+import json
+import sys
+
+from opsgenie_client import opsgenie_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Opsgenie alert details")
+    parser.add_argument("--alert-id", required=True, help="Alert ID")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        data = opsgenie_request(
+            "GET", f"/v2/alerts/{args.alert_id}", params={"identifierType": "id"}
+        )
+        alert = data.get("data", {})
+
+        result = {
+            "id": alert["id"],
+            "tiny_id": alert.get("tinyId"),
+            "alias": alert.get("alias"),
+            "message": alert.get("message"),
+            "description": alert.get("description"),
+            "status": alert.get("status"),
+            "acknowledged": alert.get("acknowledged", False),
+            "priority": alert.get("priority"),
+            "source": alert.get("source"),
+            "created_at": alert.get("createdAt"),
+            "updated_at": alert.get("updatedAt"),
+            "acknowledged_at": alert.get("report", {}).get("ackTime"),
+            "closed_at": alert.get("report", {}).get("closeTime"),
+            "tags": alert.get("tags", []),
+            "teams": [t.get("name") for t in alert.get("teams", [])],
+            "responders": [
+                {"type": r.get("type"), "name": r.get("name") or r.get("id")}
+                for r in alert.get("responders", [])
+            ],
+            "owner": alert.get("owner"),
+            "count": alert.get("count", 1),
+            "details": alert.get("details", {}),
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Alert: [{result['priority']}] {result['message']}")
+            print(
+                f"Status: {result['status']} | Acknowledged: {result['acknowledged']}"
+            )
+            print(f"Source: {result.get('source', '?')}")
+            print(f"Created: {result.get('created_at', '?')}")
+            if result.get("description"):
+                print(f"Description: {result['description'][:200]}")
+            if result["responders"]:
+                print("Responders:")
+                for r in result["responders"]:
+                    print(f"  {r['type']}: {r['name']}")
+            if result["tags"]:
+                print(f"Tags: {', '.join(result['tags'])}")
+            if result["details"]:
+                print("Details:")
+                for k, v in result["details"].items():
+                    print(f"  {k}: {v}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/alerting-opsgenie/scripts/get_alert_analytics.py
+++ b/sre-agent/.claude/skills/alerting-opsgenie/scripts/get_alert_analytics.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Analyze Opsgenie alert patterns for fatigue reduction.
+
+Usage:
+    python get_alert_analytics.py --since "2024-01-01T00:00:00Z" --until "2024-01-31T23:59:59Z" [--team-id ID]
+"""
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from datetime import datetime
+
+from opsgenie_client import opsgenie_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get alert analytics")
+    parser.add_argument("--since", required=True, help="Start date (ISO format)")
+    parser.add_argument("--until", required=True, help="End date (ISO format)")
+    parser.add_argument("--team-id", help="Optional team ID filter")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        date_query = f"createdAt >= {args.since} AND createdAt <= {args.until}"
+        if args.team_id:
+            date_query += f" AND responders:{args.team_id}"
+
+        params = {
+            "query": date_query,
+            "limit": 100,
+            "sort": "createdAt",
+            "order": "desc",
+        }
+        all_alerts = []
+        offset = 0
+
+        while len(all_alerts) < 1000:
+            params["offset"] = offset
+            data = opsgenie_request("GET", "/v2/alerts", params=params)
+            alerts = data.get("data", [])
+            if not alerts:
+                break
+
+            for alert in alerts:
+                mtta = None
+                ack_time = alert.get("report", {}).get("ackTime")
+                if ack_time:
+                    mtta = ack_time / 1000 / 60
+                mttr = None
+                close_time = alert.get("report", {}).get("closeTime")
+                if close_time:
+                    mttr = close_time / 1000 / 60
+
+                all_alerts.append(
+                    {
+                        "message": alert.get("message", "")[:100],
+                        "acknowledged": alert.get("acknowledged", False),
+                        "priority": alert.get("priority"),
+                        "source": alert.get("source"),
+                        "created_at": alert["createdAt"],
+                        "count": alert.get("count", 1),
+                        "mtta_minutes": round(mtta, 2) if mtta else None,
+                        "mttr_minutes": round(mttr, 2) if mttr else None,
+                    }
+                )
+
+            offset += len(alerts)
+            if len(alerts) < params["limit"]:
+                break
+
+        alert_stats = defaultdict(
+            lambda: {
+                "fire_count": 0,
+                "acknowledged_count": 0,
+                "mtta_values": [],
+                "mttr_values": [],
+                "hours_distribution": defaultdict(int),
+                "priorities": defaultdict(int),
+                "sources": set(),
+            }
+        )
+
+        for alert in all_alerts:
+            msg = alert["message"]
+            stats = alert_stats[msg]
+            stats["fire_count"] += alert.get("count", 1)
+            stats["sources"].add(alert.get("source") or "Unknown")
+            stats["priorities"][alert["priority"]] += 1
+            if alert["acknowledged"]:
+                stats["acknowledged_count"] += 1
+            if alert["mtta_minutes"]:
+                stats["mtta_values"].append(alert["mtta_minutes"])
+            if alert["mttr_minutes"]:
+                stats["mttr_values"].append(alert["mttr_minutes"])
+            try:
+                created = datetime.fromisoformat(
+                    alert["created_at"].replace("Z", "+00:00")
+                )
+                stats["hours_distribution"][created.hour] += 1
+            except (ValueError, TypeError):
+                pass
+
+        analytics = []
+        for msg, stats in alert_stats.items():
+            fc = stats["fire_count"]
+            ac = stats["acknowledged_count"]
+            ack_rate = round(ac / fc * 100, 1) if fc > 0 else 0
+            avg_mtta = (
+                round(sum(stats["mtta_values"]) / len(stats["mtta_values"]), 2)
+                if stats["mtta_values"]
+                else None
+            )
+            avg_mttr = (
+                round(sum(stats["mttr_values"]) / len(stats["mttr_values"]), 2)
+                if stats["mttr_values"]
+                else None
+            )
+            is_noisy = fc > 10 and ack_rate < 50
+            is_flapping = fc > 20 and avg_mttr and avg_mttr < 10
+
+            hours_dist = dict(stats["hours_distribution"])
+            off_hours = sum(hours_dist.get(h, 0) for h in [0, 1, 2, 3, 4, 5, 22, 23])
+            off_hours_rate = round(off_hours / fc * 100, 1) if fc > 0 else 0
+
+            analytics.append(
+                {
+                    "alert_message": msg,
+                    "fire_count": fc,
+                    "acknowledgment_rate": ack_rate,
+                    "avg_mtta_minutes": avg_mtta,
+                    "avg_mttr_minutes": avg_mttr,
+                    "sources": list(stats["sources"]),
+                    "off_hours_rate": off_hours_rate,
+                    "classification": {
+                        "is_noisy": is_noisy,
+                        "is_flapping": is_flapping,
+                        "reason": (
+                            "High frequency, low ack rate"
+                            if is_noisy
+                            else ("Quick auto-resolve" if is_flapping else None)
+                        ),
+                    },
+                }
+            )
+
+        analytics.sort(key=lambda x: x["fire_count"], reverse=True)
+        noisy = sum(1 for a in analytics if a["classification"]["is_noisy"])
+        flapping = sum(1 for a in analytics if a["classification"]["is_flapping"])
+
+        result = {
+            "ok": True,
+            "period": {"since": args.since, "until": args.until},
+            "summary": {
+                "total_unique_alerts": len(analytics),
+                "total_alert_fires": len(all_alerts),
+                "noisy_alerts_count": noisy,
+                "flapping_alerts_count": flapping,
+            },
+            "alert_analytics": analytics[:50],
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Period: {args.since} to {args.until}")
+            print(f"Total fires: {len(all_alerts)} | Unique alerts: {len(analytics)}")
+            print(f"Noisy: {noisy} | Flapping: {flapping}")
+            print()
+            for a in analytics[:20]:
+                flags = []
+                if a["classification"]["is_noisy"]:
+                    flags.append("NOISY")
+                if a["classification"]["is_flapping"]:
+                    flags.append("FLAPPING")
+                tag = f" [{', '.join(flags)}]" if flags else ""
+                print(f"  {a['fire_count']}x {a['alert_message']}{tag}")
+                print(
+                    f"    Ack: {a['acknowledgment_rate']}% | Off-hours: {a['off_hours_rate']}%"
+                )
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/alerting-opsgenie/scripts/get_alert_logs.py
+++ b/sre-agent/.claude/skills/alerting-opsgenie/scripts/get_alert_logs.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Get log entries for an Opsgenie alert.
+
+Usage:
+    python get_alert_logs.py --alert-id ALERT_ID [--max-results 50]
+"""
+
+import argparse
+import json
+import sys
+
+from opsgenie_client import opsgenie_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get alert log entries")
+    parser.add_argument("--alert-id", required=True, help="Alert ID")
+    parser.add_argument("--max-results", type=int, default=50, help="Maximum results")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        data = opsgenie_request(
+            "GET",
+            f"/v2/alerts/{args.alert_id}/logs",
+            params={"limit": args.max_results},
+        )
+        logs = []
+        for log in data.get("data", []):
+            logs.append(
+                {
+                    "log": log.get("log"),
+                    "type": log.get("type"),
+                    "owner": log.get("owner"),
+                    "created_at": log.get("createdAt"),
+                }
+            )
+
+        if args.json:
+            print(json.dumps(logs, indent=2))
+        else:
+            print(f"Alert logs for {args.alert_id}: {len(logs)} entries")
+            print()
+            for l in logs:
+                print(f"  [{l.get('created_at', '?')}] {l.get('type', '?')}")
+                print(f"    {l.get('log', '')}")
+                if l.get("owner"):
+                    print(f"    By: {l['owner']}")
+                print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/alerting-opsgenie/scripts/get_on_call.py
+++ b/sre-agent/.claude/skills/alerting-opsgenie/scripts/get_on_call.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Get current on-call users from Opsgenie.
+
+Usage:
+    python get_on_call.py [--schedule-id ID] [--team-id ID]
+"""
+
+import argparse
+import json
+import sys
+
+from opsgenie_client import opsgenie_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get on-call users")
+    parser.add_argument("--schedule-id", help="Schedule ID")
+    parser.add_argument("--team-id", help="Team ID")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        result = []
+
+        if args.schedule_id:
+            data = opsgenie_request("GET", f"/v2/schedules/{args.schedule_id}/on-calls")
+            oncall_data = data.get("data", {})
+            for p in oncall_data.get("onCallParticipants", []):
+                result.append(
+                    {
+                        "schedule_id": args.schedule_id,
+                        "user": p.get("name"),
+                        "type": p.get("type"),
+                    }
+                )
+        elif args.team_id:
+            data = opsgenie_request("GET", f"/v2/teams/{args.team_id}/on-calls")
+            oncall_data = data.get("data", {})
+            for p in oncall_data.get("onCallParticipants", []):
+                result.append(
+                    {
+                        "team_id": args.team_id,
+                        "user": p.get("name"),
+                        "type": p.get("type"),
+                    }
+                )
+        else:
+            data = opsgenie_request("GET", "/v2/schedules")
+            schedules = data.get("data", [])
+            for schedule in schedules:
+                try:
+                    oncall_data = opsgenie_request(
+                        "GET", f"/v2/schedules/{schedule['id']}/on-calls"
+                    )
+                    for p in oncall_data.get("data", {}).get("onCallParticipants", []):
+                        result.append(
+                            {
+                                "schedule_id": schedule["id"],
+                                "schedule_name": schedule["name"],
+                                "user": p.get("name"),
+                                "type": p.get("type"),
+                            }
+                        )
+                except Exception:
+                    continue
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"On-call entries: {len(result)}")
+            for entry in result:
+                schedule = (
+                    entry.get("schedule_name")
+                    or entry.get("schedule_id")
+                    or entry.get("team_id", "")
+                )
+                print(
+                    f"  {schedule}: {entry.get('user', 'Unknown')} ({entry.get('type', '?')})"
+                )
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/alerting-opsgenie/scripts/list_alerts.py
+++ b/sre-agent/.claude/skills/alerting-opsgenie/scripts/list_alerts.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""List Opsgenie alerts with optional filters.
+
+Usage:
+    python list_alerts.py [--status open] [--priority P1] [--query QUERY] [--max-results 100]
+"""
+
+import argparse
+import json
+import sys
+
+from opsgenie_client import opsgenie_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Opsgenie alerts")
+    parser.add_argument("--status", help="Filter by status (open, acked, closed)")
+    parser.add_argument("--priority", help="Filter by priority (P1-P5)")
+    parser.add_argument("--query", help="Opsgenie search query")
+    parser.add_argument("--max-results", type=int, default=100, help="Maximum results")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        query_parts = []
+        if args.status:
+            query_parts.append(f"status={args.status}")
+        if args.priority:
+            query_parts.append(f"priority={args.priority}")
+        if args.query:
+            query_parts.append(args.query)
+
+        params = {"limit": min(args.max_results, 100)}
+        if query_parts:
+            params["query"] = " AND ".join(query_parts)
+
+        all_alerts = []
+        offset = 0
+
+        while len(all_alerts) < args.max_results:
+            params["offset"] = offset
+            data = opsgenie_request("GET", "/v2/alerts", params=params)
+            alerts = data.get("data", [])
+
+            if not alerts:
+                break
+
+            for alert in alerts:
+                all_alerts.append(
+                    {
+                        "id": alert["id"],
+                        "tiny_id": alert.get("tinyId"),
+                        "message": alert.get("message"),
+                        "status": alert.get("status"),
+                        "acknowledged": alert.get("acknowledged", False),
+                        "priority": alert.get("priority"),
+                        "source": alert.get("source"),
+                        "created_at": alert.get("createdAt"),
+                        "count": alert.get("count", 1),
+                        "tags": alert.get("tags", []),
+                        "teams": [t.get("name") for t in alert.get("teams", [])],
+                        "owner": alert.get("owner"),
+                    }
+                )
+
+            offset += len(alerts)
+            if len(alerts) < params["limit"]:
+                break
+
+        by_status = {}
+        by_priority = {}
+        for a in all_alerts:
+            by_status[a["status"]] = by_status.get(a["status"], 0) + 1
+            by_priority[a["priority"]] = by_priority.get(a["priority"], 0) + 1
+
+        result = {
+            "ok": True,
+            "total_count": len(all_alerts),
+            "summary": {"by_status": by_status, "by_priority": by_priority},
+            "alerts": all_alerts,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Found: {len(all_alerts)} alerts")
+            if by_status:
+                print(
+                    f"By status: {', '.join(f'{k}: {v}' for k, v in by_status.items())}"
+                )
+            if by_priority:
+                print(
+                    f"By priority: {', '.join(f'{k}: {v}' for k, v in by_priority.items())}"
+                )
+            print()
+            for a in all_alerts:
+                ack = " [ACK]" if a["acknowledged"] else ""
+                print(f"  [{a['priority']}] {a['message']}{ack}")
+                print(f"    Status: {a['status']} | Source: {a.get('source', '?')}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/alerting-opsgenie/scripts/list_alerts_by_date_range.py
+++ b/sre-agent/.claude/skills/alerting-opsgenie/scripts/list_alerts_by_date_range.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""List Opsgenie alerts within a date range with MTTA/MTTR computation.
+
+Usage:
+    python list_alerts_by_date_range.py --since "2024-01-01T00:00:00Z" --until "2024-01-31T23:59:59Z"
+"""
+
+import argparse
+import json
+import sys
+
+from opsgenie_client import opsgenie_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List alerts by date range")
+    parser.add_argument("--since", required=True, help="Start date (ISO format)")
+    parser.add_argument("--until", required=True, help="End date (ISO format)")
+    parser.add_argument("--query", help="Optional Opsgenie search query")
+    parser.add_argument("--max-results", type=int, default=500, help="Maximum results")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        date_query = f"createdAt >= {args.since} AND createdAt <= {args.until}"
+        if args.query:
+            date_query = f"({date_query}) AND ({args.query})"
+
+        params = {
+            "query": date_query,
+            "limit": 100,
+            "sort": "createdAt",
+            "order": "desc",
+        }
+
+        all_alerts = []
+        offset = 0
+
+        while len(all_alerts) < args.max_results:
+            params["offset"] = offset
+            data = opsgenie_request("GET", "/v2/alerts", params=params)
+            alerts = data.get("data", [])
+
+            if not alerts:
+                break
+
+            for alert in alerts:
+                mtta_minutes = None
+                ack_time = alert.get("report", {}).get("ackTime")
+                if ack_time:
+                    mtta_minutes = ack_time / 1000 / 60
+
+                mttr_minutes = None
+                close_time = alert.get("report", {}).get("closeTime")
+                if close_time:
+                    mttr_minutes = close_time / 1000 / 60
+
+                all_alerts.append(
+                    {
+                        "id": alert["id"],
+                        "tiny_id": alert.get("tinyId"),
+                        "message": alert.get("message"),
+                        "status": alert.get("status"),
+                        "acknowledged": alert.get("acknowledged", False),
+                        "priority": alert.get("priority"),
+                        "source": alert.get("source"),
+                        "created_at": alert["createdAt"],
+                        "mtta_minutes": (
+                            round(mtta_minutes, 2) if mtta_minutes else None
+                        ),
+                        "mttr_minutes": (
+                            round(mttr_minutes, 2) if mttr_minutes else None
+                        ),
+                        "count": alert.get("count", 1),
+                        "tags": alert.get("tags", []),
+                        "teams": [t.get("name") for t in alert.get("teams", [])],
+                    }
+                )
+
+            offset += len(alerts)
+            if len(alerts) < params["limit"]:
+                break
+
+        total = len(all_alerts)
+        ack_count = sum(1 for a in all_alerts if a["acknowledged"])
+        mtta_values = [a["mtta_minutes"] for a in all_alerts if a["mtta_minutes"]]
+        mttr_values = [a["mttr_minutes"] for a in all_alerts if a["mttr_minutes"]]
+
+        by_message = {}
+        for a in all_alerts:
+            msg = a["message"][:100]
+            by_message[msg] = by_message.get(msg, 0) + 1
+        top_alerts = sorted(by_message.items(), key=lambda x: x[1], reverse=True)[:20]
+
+        by_priority = {}
+        for a in all_alerts:
+            by_priority[a["priority"]] = by_priority.get(a["priority"], 0) + 1
+
+        result = {
+            "ok": True,
+            "period": {"since": args.since, "until": args.until},
+            "total_alerts": total,
+            "summary": {
+                "acknowledged_count": ack_count,
+                "acknowledged_rate": (
+                    round(ack_count / total * 100, 1) if total > 0 else 0
+                ),
+                "avg_mtta_minutes": (
+                    round(sum(mtta_values) / len(mtta_values), 2)
+                    if mtta_values
+                    else None
+                ),
+                "avg_mttr_minutes": (
+                    round(sum(mttr_values) / len(mttr_values), 2)
+                    if mttr_values
+                    else None
+                ),
+            },
+            "by_priority": by_priority,
+            "top_alerts": top_alerts,
+            "alerts": all_alerts,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Period: {args.since} to {args.until}")
+            print(f"Total alerts: {total}")
+            print(f"Ack rate: {result['summary']['acknowledged_rate']}%")
+            if result["summary"]["avg_mtta_minutes"]:
+                print(f"Avg MTTA: {result['summary']['avg_mtta_minutes']} min")
+            if result["summary"]["avg_mttr_minutes"]:
+                print(f"Avg MTTR: {result['summary']['avg_mttr_minutes']} min")
+            print(
+                f"By priority: {', '.join(f'{k}: {v}' for k, v in by_priority.items())}"
+            )
+            if top_alerts:
+                print("\nTop alerts by frequency:")
+                for msg, count in top_alerts[:10]:
+                    print(f"  {count}x {msg}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/alerting-opsgenie/scripts/list_services.py
+++ b/sre-agent/.claude/skills/alerting-opsgenie/scripts/list_services.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""List all Opsgenie services.
+
+Usage:
+    python list_services.py [--json]
+"""
+
+import argparse
+import json
+import sys
+
+from opsgenie_client import opsgenie_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Opsgenie services")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        all_services = []
+        offset = 0
+
+        while True:
+            data = opsgenie_request(
+                "GET", "/v1/services", params={"limit": 100, "offset": offset}
+            )
+            services = data.get("data", [])
+
+            if not services:
+                break
+
+            for svc in services:
+                all_services.append(
+                    {
+                        "id": svc["id"],
+                        "name": svc["name"],
+                        "description": svc.get("description"),
+                        "team_id": svc.get("teamId"),
+                    }
+                )
+
+            offset += 100
+            if len(services) < 100:
+                break
+
+        if args.json:
+            print(json.dumps(all_services, indent=2))
+        else:
+            print(f"Services: {len(all_services)}")
+            for svc in all_services:
+                print(f"  [{svc['id']}] {svc['name']}")
+                if svc.get("description"):
+                    print(f"    {svc['description']}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/alerting-opsgenie/scripts/list_teams.py
+++ b/sre-agent/.claude/skills/alerting-opsgenie/scripts/list_teams.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""List all Opsgenie teams.
+
+Usage:
+    python list_teams.py [--json]
+"""
+
+import argparse
+import json
+import sys
+
+from opsgenie_client import opsgenie_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Opsgenie teams")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        data = opsgenie_request("GET", "/v2/teams")
+        teams = []
+        for team in data.get("data", []):
+            teams.append(
+                {
+                    "id": team["id"],
+                    "name": team["name"],
+                    "description": team.get("description"),
+                }
+            )
+
+        if args.json:
+            print(json.dumps(teams, indent=2))
+        else:
+            print(f"Teams: {len(teams)}")
+            for t in teams:
+                print(f"  [{t['id']}] {t['name']}")
+                if t.get("description"):
+                    print(f"    {t['description']}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/alerting-opsgenie/scripts/opsgenie_client.py
+++ b/sre-agent/.claude/skills/alerting-opsgenie/scripts/opsgenie_client.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Shared Opsgenie API client with proxy support.
+
+Credentials are injected transparently by the proxy layer.
+"""
+
+import os
+
+import httpx
+
+
+def get_base_url() -> str:
+    """Get Opsgenie API base URL."""
+    proxy_url = os.getenv("OPSGENIE_BASE_URL")
+    if proxy_url:
+        return proxy_url.rstrip("/")
+    return os.getenv("OPSGENIE_API_URL", "https://api.opsgenie.com").rstrip("/")
+
+
+def get_headers() -> dict[str, str]:
+    """Get API headers."""
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    api_key = os.getenv("OPSGENIE_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"GenieKey {api_key}"
+    else:
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            headers["X-Tenant-Id"] = os.getenv("OPENSRE_TENANT_ID", "local")
+            headers["X-Team-Id"] = os.getenv("OPENSRE_TEAM_ID", "local")
+
+    return headers
+
+
+def opsgenie_request(
+    method: str,
+    path: str,
+    params: dict | None = None,
+    json_body: dict | None = None,
+) -> dict | list | None:
+    """Make a request to Opsgenie API."""
+    base_url = get_base_url()
+    url = f"{base_url}/{path.lstrip('/')}"
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.request(
+            method,
+            url,
+            headers=get_headers(),
+            params=params,
+            json=json_body,
+        )
+        response.raise_for_status()
+        if response.status_code == 204:
+            return None
+        return response.json()

--- a/sre-agent/.claude/skills/analytics-amplitude/SKILL.md
+++ b/sre-agent/.claude/skills/analytics-amplitude/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: analytics-amplitude
+description: Amplitude product analytics. Use when querying user events, funnels, retention, or product usage data. Provides event segmentation, user activity lookup, and annotation queries.
+allowed-tools: Bash(python *)
+---
+
+# Amplitude Analytics
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `AMPLITUDE_API_KEY` or `AMPLITUDE_SECRET_KEY` in environment variables — they won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `AMPLITUDE_REGION` — Region: `US` (default) or `EU`
+
+---
+
+## Available Scripts
+
+All scripts are in `.claude/skills/analytics-amplitude/scripts/`
+
+### query_events.py — Event Segmentation
+
+Query event counts, uniques, averages over time. This is the primary analytics query.
+
+```bash
+# Basic: count unique users who triggered an event
+python .claude/skills/analytics-amplitude/scripts/query_events.py \
+  --event "Button Clicked" --start 2026-02-10 --end 2026-02-17
+
+# Group by property
+python .claude/skills/analytics-amplitude/scripts/query_events.py \
+  --event "Page Viewed" --start 2026-02-10 --end 2026-02-17 \
+  --group-by "platform"
+
+# Daily interval with totals metric
+python .claude/skills/analytics-amplitude/scripts/query_events.py \
+  --event "Error Occurred" --start 2026-02-10 --end 2026-02-17 \
+  --interval daily --metric totals
+
+# With filters
+python .claude/skills/analytics-amplitude/scripts/query_events.py \
+  --event "Purchase Completed" --start 2026-02-10 --end 2026-02-17 \
+  --filters '[{"subprop_type": "event", "subprop_key": "platform", "subprop_op": "is", "subprop_value": ["iOS"]}]'
+```
+
+**Arguments:**
+- `--event` (required): Event name exactly as tracked
+- `--start` / `--end` (required): Date range (YYYYMMDD or YYYY-MM-DD)
+- `--interval`: `realtime`, `daily`, `weekly`, `monthly` (default: realtime). Note: hourly is not available on all Amplitude plans.
+- `--metric`: `uniques`, `totals`, `avg`, `pct_dau` (default: uniques)
+- `--group-by`: Event property to segment by
+- `--filters`: JSON array of property filters
+- `--raw`: Output full JSON response
+
+### get_user_activity.py — User Activity Stream
+
+Look up a specific user's event stream. Useful for debugging user-reported issues.
+
+```bash
+# By user ID
+python .claude/skills/analytics-amplitude/scripts/get_user_activity.py --user "12345"
+
+# By email
+python .claude/skills/analytics-amplitude/scripts/get_user_activity.py --user "user@example.com"
+
+# With pagination
+python .claude/skills/analytics-amplitude/scripts/get_user_activity.py --user "12345" --offset 100 --limit 50
+```
+
+**Arguments:**
+- `--user` (required): Amplitude user ID or email
+- `--offset`: Pagination offset (default: 0)
+- `--limit`: Max events (default: 100)
+- `--raw`: Output full JSON response
+
+### get_chart_annotations.py — Annotations
+
+List chart annotations (deploy markers, releases, feature flags).
+
+```bash
+python .claude/skills/analytics-amplitude/scripts/get_chart_annotations.py
+```
+
+---
+
+## Investigation Workflow
+
+```
+1. What happened?
+   └─→ query_events.py --event "Error Occurred" --interval daily
+       (see error trend over time)
+
+2. Who was affected?
+   └─→ query_events.py --event "Error Occurred" --group-by "user_id"
+       (find impacted users)
+
+3. What did the user see?
+   └─→ get_user_activity.py --user "<user_id>"
+       (trace the user's full event stream)
+
+4. Was there a deploy?
+   └─→ get_chart_annotations.py
+       (check if a deploy correlates with the error spike)
+```
+
+---
+
+## Tips
+
+- Event names are **case-sensitive** and must match exactly as tracked in Amplitude
+- Date format: `YYYYMMDD` or `YYYY-MM-DD` (both work)
+- The `--raw` flag on any script gives you the full API response for deeper analysis
+- For time-series analysis, use `--interval daily` or `--interval hourly`
+- `uniques` counts distinct users; `totals` counts total event firings

--- a/sre-agent/.claude/skills/analytics-amplitude/scripts/amplitude_client.py
+++ b/sre-agent/.claude/skills/analytics-amplitude/scripts/amplitude_client.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Shared Amplitude API client with proxy support.
+
+This module provides the Amplitude API client that works through the credential proxy.
+Credentials are injected transparently by the proxy layer.
+
+Amplitude Regions:
+- US: amplitude.com/api/2/ (default)
+- EU: analytics.eu.amplitude.com/api/2/
+"""
+
+import base64
+import os
+import sys
+from typing import Any
+
+import httpx
+
+# Region to base URL mapping
+REGION_URLS = {
+    "US": "https://amplitude.com/api/2",
+    "EU": "https://analytics.eu.amplitude.com/api/2",
+}
+
+
+def get_config() -> dict[str, str | None]:
+    """Get Amplitude configuration from environment.
+
+    Environment variables:
+        OPENSRE_TENANT_ID - Tenant ID for credential lookup
+        OPENSRE_TEAM_ID - Team ID for credential lookup
+        AMPLITUDE_REGION - Region: US (default) or EU
+    """
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+        "region": os.getenv("AMPLITUDE_REGION", "US"),
+    }
+
+
+def get_api_url(endpoint: str) -> str:
+    """Build the Amplitude API URL.
+
+    Supports two modes:
+    1. Proxy mode (production): Uses AMPLITUDE_BASE_URL
+    2. Direct mode (testing): Uses AMPLITUDE_REGION to build URL
+
+    Args:
+        endpoint: API path (e.g., "/events/segmentation")
+
+    Returns:
+        Full API URL
+    """
+    # Proxy mode (production)
+    base_url = os.getenv("AMPLITUDE_BASE_URL")
+    if base_url:
+        return f"{base_url.rstrip('/')}{endpoint}"
+
+    # Direct mode (testing) - requires AMPLITUDE_API_KEY
+    if os.getenv("AMPLITUDE_API_KEY"):
+        region = os.getenv("AMPLITUDE_REGION", "US").upper()
+        base = REGION_URLS.get(region, REGION_URLS["US"])
+        return f"{base}{endpoint}"
+
+    raise RuntimeError(
+        "Either AMPLITUDE_BASE_URL (proxy mode) or AMPLITUDE_API_KEY (direct mode) must be set."
+    )
+
+
+def get_headers() -> dict[str, str]:
+    """Get Amplitude API headers.
+
+    In proxy mode: includes tenant context for credential lookup.
+    In direct mode: includes HTTP Basic auth (api_key:secret_key).
+    """
+    config = get_config()
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    # Direct mode - add Basic auth
+    api_key = os.getenv("AMPLITUDE_API_KEY")
+    secret_key = os.getenv("AMPLITUDE_SECRET_KEY")
+    if api_key and secret_key:
+        encoded = base64.b64encode(f"{api_key}:{secret_key}".encode()).decode()
+        headers["Authorization"] = f"Basic {encoded}"
+    else:
+        # Proxy mode - use JWT for credential-resolver auth
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if not sandbox_jwt:
+            jwt_path = "/tmp/sandbox-jwt"
+            if os.path.exists(jwt_path):
+                with open(jwt_path) as f:
+                    sandbox_jwt = f.read().strip()
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            # Fallback for local dev
+            headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+            headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    return headers
+
+
+def amplitude_request(
+    method: str,
+    endpoint: str,
+    params: dict[str, Any] | None = None,
+    json_body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Make an Amplitude API request.
+
+    Args:
+        method: HTTP method (GET, POST)
+        endpoint: API path (e.g., "/events/segmentation")
+        params: Query parameters
+        json_body: JSON body for POST requests
+
+    Returns:
+        Parsed JSON response
+
+    Raises:
+        httpx.HTTPStatusError: On API errors
+    """
+    url = get_api_url(endpoint)
+    headers = get_headers()
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.request(
+            method, url, headers=headers, params=params, json=json_body
+        )
+
+        if response.status_code != 200:
+            print(
+                f"ERROR: Amplitude API returned {response.status_code}", file=sys.stderr
+            )
+            response.raise_for_status()
+
+        return response.json()
+
+
+def format_event_data(data: dict[str, Any]) -> str:
+    """Format event segmentation data for display."""
+    series = data.get("data", {}).get("series", [])
+    labels = data.get("data", {}).get("seriesLabels", [])
+    x_values = data.get("data", {}).get("xValues", [])
+
+    if not series:
+        return "No data returned."
+
+    lines = []
+    for i, label in enumerate(labels):
+        label_str = (
+            str(label)
+            if not isinstance(label, list)
+            else " > ".join(str(l) for l in label)
+        )
+        if i < len(series) and series[i]:
+            total = sum(v for v in series[i] if v is not None)
+            lines.append(f"  {label_str}: {total:,.0f} total")
+
+    if x_values:
+        lines.insert(0, f"Time range: {x_values[0]} to {x_values[-1]}")
+
+    return "\n".join(lines)

--- a/sre-agent/.claude/skills/analytics-amplitude/scripts/get_chart_annotations.py
+++ b/sre-agent/.claude/skills/analytics-amplitude/scripts/get_chart_annotations.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Get Amplitude chart annotations (deploy markers, release notes, etc.).
+
+Usage:
+    python get_chart_annotations.py
+    python get_chart_annotations.py --raw
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from amplitude_client import amplitude_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Amplitude chart annotations")
+    parser.add_argument("--raw", action="store_true", help="Output raw JSON response")
+    args = parser.parse_args()
+
+    data = amplitude_request("GET", "/annotations")
+
+    if args.raw:
+        print(json.dumps(data, indent=2))
+        return
+
+    annotations = data.get("data", [])
+
+    print(f"Annotations: {len(annotations)}")
+    print("---")
+
+    if not annotations:
+        print("No annotations found.")
+        return
+
+    for ann in annotations:
+        date = ann.get("date", "")
+        label = ann.get("label", "")
+        details = ann.get("details", "")
+
+        line = f"  [{date}] {label}"
+        if details:
+            line += f" — {details}"
+        print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/analytics-amplitude/scripts/get_user_activity.py
+++ b/sre-agent/.claude/skills/analytics-amplitude/scripts/get_user_activity.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Get Amplitude user activity stream.
+
+Usage:
+    python get_user_activity.py --user "user@example.com"
+    python get_user_activity.py --user "12345" --offset 0 --limit 50
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from amplitude_client import amplitude_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Amplitude user activity")
+    parser.add_argument("--user", required=True, help="Amplitude user ID or email")
+    parser.add_argument(
+        "--offset", type=int, default=0, help="Pagination offset (default: 0)"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=100, help="Max events to return (default: 100)"
+    )
+    parser.add_argument("--raw", action="store_true", help="Output raw JSON response")
+    args = parser.parse_args()
+
+    params = {
+        "user": args.user,
+        "offset": args.offset,
+        "limit": args.limit,
+    }
+
+    data = amplitude_request("GET", "/useractivity", params=params)
+
+    if args.raw:
+        print(json.dumps(data, indent=2))
+        return
+
+    events = data.get("userData", {}).get("events", [])
+    user_id = data.get("userData", {}).get("user_id", args.user)
+
+    print(f"User: {user_id}")
+    print(f"Events: {len(events)} (offset={args.offset}, limit={args.limit})")
+    print("---")
+
+    if not events:
+        print("No events found for this user.")
+        return
+
+    for event in events:
+        event_type = event.get("event_type", "unknown")
+        event_time = event.get("event_time", "")
+        platform = event.get("platform", "")
+        country = event.get("country", "")
+        city = event.get("city", "")
+
+        line = f"  [{event_time}] {event_type}"
+        details = []
+        if platform:
+            details.append(f"platform={platform}")
+        if country:
+            details.append(f"country={country}")
+        if city:
+            details.append(f"city={city}")
+        if details:
+            line += f" ({', '.join(details)})"
+
+        event_props = event.get("event_properties", {})
+        if event_props:
+            props_str = json.dumps(event_props, default=str)
+            if len(props_str) > 200:
+                props_str = props_str[:200] + "..."
+            line += f"\n    props: {props_str}"
+
+        print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/analytics-amplitude/scripts/query_events.py
+++ b/sre-agent/.claude/skills/analytics-amplitude/scripts/query_events.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Query Amplitude event segmentation data.
+
+Usage:
+    python query_events.py --event "Button Clicked" --start 2026-02-10 --end 2026-02-17
+    python query_events.py --event "Page Viewed" --start 2026-02-10 --end 2026-02-17 --group-by "platform"
+    python query_events.py --event "Error Occurred" --start 2026-02-10 --end 2026-02-17 --interval daily
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from amplitude_client import amplitude_request, format_event_data
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Query Amplitude event segmentation")
+    parser.add_argument(
+        "--event", required=True, help="Event name (e.g., 'Button Clicked')"
+    )
+    parser.add_argument(
+        "--start", required=True, help="Start date (YYYYMMDD or YYYY-MM-DD)"
+    )
+    parser.add_argument(
+        "--end", required=True, help="End date (YYYYMMDD or YYYY-MM-DD)"
+    )
+    parser.add_argument(
+        "--interval",
+        default="-300000",
+        help="Interval: -300000 (realtime), 1 (daily), 7 (weekly), 30 (monthly), or use 'daily'/'weekly'/'realtime'",
+    )
+    parser.add_argument(
+        "--group-by", help="Group by event property (e.g., 'platform', 'country')"
+    )
+    parser.add_argument(
+        "--metric",
+        default="uniques",
+        help="Metric: uniques, totals, avg, pct_dau (default: uniques)",
+    )
+    parser.add_argument(
+        "--filters",
+        help='JSON array of filters, e.g., \'[{"subprop_type": "event", "subprop_key": "platform", "subprop_op": "is", "subprop_value": ["iOS"]}]\'',
+    )
+    parser.add_argument("--raw", action="store_true", help="Output raw JSON response")
+    args = parser.parse_args()
+
+    # Normalize dates to YYYYMMDD
+    start = args.start.replace("-", "")
+    end = args.end.replace("-", "")
+
+    # Normalize interval (Amplitude V2 API values)
+    interval_map = {"realtime": "-300000", "daily": "1", "weekly": "7", "monthly": "30"}
+    interval = interval_map.get(args.interval, args.interval)
+
+    # Build event spec
+    event = {"event_type": args.event}
+    if args.filters:
+        event["filters"] = json.loads(args.filters)
+    if args.group_by:
+        event["group_by"] = [{"type": "event", "value": args.group_by}]
+
+    params = {
+        "e": json.dumps(event, separators=(",", ":")),
+        "start": start,
+        "end": end,
+        "i": interval,
+        "m": args.metric,
+    }
+
+    data = amplitude_request("GET", "/events/segmentation", params=params)
+
+    if args.raw:
+        print(json.dumps(data, indent=2))
+    else:
+        event_name = args.event
+        metric = args.metric
+        print(f"Event: {event_name} ({metric})")
+        print(f"Period: {start} to {end}")
+        if args.group_by:
+            print(f"Grouped by: {args.group_by}")
+        print("---")
+        print(format_event_data(data))
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-bigquery/SKILL.md
+++ b/sre-agent/.claude/skills/database-bigquery/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: database-bigquery
+description: Google BigQuery data warehouse queries and schema inspection. Use when running SQL queries, listing datasets/tables, or inspecting table schemas in BigQuery.
+allowed-tools: Bash(python *)
+---
+
+# BigQuery Data Warehouse
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `BIGQUERY_SERVICE_ACCOUNT_KEY` in environment variables - it won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `BIGQUERY_PROJECT_ID` - GCP project ID
+- `BIGQUERY_DATASET` - Default dataset
+
+---
+
+## MANDATORY: Schema-First Investigation
+
+**List datasets and tables before writing queries.**
+
+```
+LIST DATASETS → LIST TABLES → GET TABLE SCHEMA → QUERY
+```
+
+## Available Scripts
+
+All scripts are in `.claude/skills/database-bigquery/scripts/`
+
+### list_datasets.py - List Datasets (START HERE)
+```bash
+python .claude/skills/database-bigquery/scripts/list_datasets.py
+```
+
+### list_tables.py - List Tables in Dataset
+```bash
+python .claude/skills/database-bigquery/scripts/list_tables.py --dataset DATASET_ID
+```
+
+### get_table_schema.py - Table Schema Details
+```bash
+python .claude/skills/database-bigquery/scripts/get_table_schema.py --dataset DATASET_ID --table TABLE_ID
+```
+
+### query.py - Run SQL Queries
+```bash
+python .claude/skills/database-bigquery/scripts/query.py --query "SELECT * FROM dataset.table LIMIT 10" [--dataset DEFAULT_DATASET] [--max-results 1000]
+```
+
+---
+
+## BigQuery SQL Reference
+
+```sql
+-- Standard SQL (default)
+SELECT * FROM `project.dataset.table` LIMIT 10
+
+-- Aggregate with time
+SELECT DATE(timestamp), COUNT(*) as events
+FROM `dataset.events`
+WHERE timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)
+GROUP BY 1 ORDER BY 1 DESC
+
+-- Partitioned table query (cost-efficient)
+SELECT * FROM `dataset.events`
+WHERE _PARTITIONTIME >= TIMESTAMP('2026-01-01')
+```
+
+---
+
+## Investigation Workflow
+
+### Data Analysis
+```
+1. list_datasets.py (find available datasets)
+2. list_tables.py --dataset <dataset> (find tables)
+3. get_table_schema.py --dataset <dataset> --table <table>
+4. query.py --query "SELECT ..."
+```

--- a/sre-agent/.claude/skills/database-bigquery/scripts/bq_client.py
+++ b/sre-agent/.claude/skills/database-bigquery/scripts/bq_client.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Shared BigQuery client with credential support.
+
+Credentials are injected transparently by the proxy layer.
+"""
+
+import json
+import os
+
+
+def get_config() -> dict[str, str | None]:
+    """Get BigQuery configuration from environment."""
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+        "project_id": os.getenv("BIGQUERY_PROJECT_ID", ""),
+        "dataset": os.getenv("BIGQUERY_DATASET"),
+    }
+
+
+def get_project_id() -> str:
+    """Get the BigQuery project ID."""
+    project_id = os.getenv("BIGQUERY_PROJECT_ID", "")
+    if not project_id:
+        raise RuntimeError("BIGQUERY_PROJECT_ID must be set")
+    return project_id
+
+
+def get_client():
+    """Get a BigQuery client."""
+    from google.cloud import bigquery
+
+    sa_key = os.getenv("BIGQUERY_SERVICE_ACCOUNT_KEY")
+    if sa_key:
+        from google.oauth2 import service_account
+
+        credentials_dict = json.loads(sa_key)
+        credentials = service_account.Credentials.from_service_account_info(
+            credentials_dict
+        )
+        return bigquery.Client(credentials=credentials, project=get_project_id())
+
+    return bigquery.Client(project=get_project_id())
+
+
+def format_output(data: dict) -> str:
+    """Format output as JSON string."""
+    return json.dumps(data, indent=2, default=str)

--- a/sre-agent/.claude/skills/database-bigquery/scripts/get_table_schema.py
+++ b/sre-agent/.claude/skills/database-bigquery/scripts/get_table_schema.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Get schema for a BigQuery table."""
+
+import argparse
+import sys
+
+from bq_client import format_output, get_client, get_config
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get BigQuery table schema")
+    parser.add_argument("--dataset", required=True, help="Dataset ID")
+    parser.add_argument("--table", required=True, help="Table ID")
+    args = parser.parse_args()
+
+    try:
+        client = get_client()
+        config = get_config()
+
+        table_ref = f"{config['project_id']}.{args.dataset}.{args.table}"
+        table_obj = client.get_table(table_ref)
+
+        schema = []
+        for field in table_obj.schema:
+            schema.append(
+                {
+                    "name": field.name,
+                    "type": field.field_type,
+                    "mode": field.mode,
+                    "description": field.description or "",
+                }
+            )
+
+        print(
+            format_output(
+                {
+                    "dataset": args.dataset,
+                    "table": args.table,
+                    "num_rows": table_obj.num_rows,
+                    "num_bytes": table_obj.num_bytes,
+                    "schema": schema,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(
+            format_output(
+                {"error": str(e), "dataset": args.dataset, "table": args.table}
+            )
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-bigquery/scripts/list_datasets.py
+++ b/sre-agent/.claude/skills/database-bigquery/scripts/list_datasets.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""List BigQuery datasets."""
+
+import sys
+
+from bq_client import format_output, get_client
+
+
+def main():
+    try:
+        client = get_client()
+
+        datasets = []
+        for dataset in client.list_datasets():
+            datasets.append(
+                {
+                    "dataset_id": dataset.dataset_id,
+                    "full_name": dataset.full_dataset_id,
+                    "location": dataset.location,
+                }
+            )
+
+        print(
+            format_output(
+                {
+                    "dataset_count": len(datasets),
+                    "datasets": datasets,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-bigquery/scripts/list_tables.py
+++ b/sre-agent/.claude/skills/database-bigquery/scripts/list_tables.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""List tables in a BigQuery dataset."""
+
+import argparse
+import sys
+
+from bq_client import format_output, get_client, get_config
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List BigQuery tables")
+    parser.add_argument("--dataset", required=True, help="Dataset ID")
+    args = parser.parse_args()
+
+    try:
+        client = get_client()
+        config = get_config()
+
+        dataset_ref = f"{config['project_id']}.{args.dataset}"
+        tables = []
+
+        for table in client.list_tables(dataset_ref):
+            table_ref = client.get_table(f"{dataset_ref}.{table.table_id}")
+            tables.append(
+                {
+                    "table_id": table.table_id,
+                    "full_name": f"{dataset_ref}.{table.table_id}",
+                    "table_type": table.table_type,
+                    "num_rows": table_ref.num_rows,
+                    "num_bytes": table_ref.num_bytes,
+                    "created": str(table_ref.created),
+                    "modified": str(table_ref.modified),
+                }
+            )
+
+        print(
+            format_output(
+                {
+                    "dataset": args.dataset,
+                    "table_count": len(tables),
+                    "tables": tables,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e), "dataset": args.dataset}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-bigquery/scripts/query.py
+++ b/sre-agent/.claude/skills/database-bigquery/scripts/query.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Execute a SQL query on BigQuery."""
+
+import argparse
+import sys
+
+from bq_client import format_output, get_client, get_config
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Execute BigQuery query")
+    parser.add_argument("--query", required=True, help="SQL query to execute")
+    parser.add_argument("--dataset", help="Default dataset")
+    parser.add_argument(
+        "--max-results", type=int, default=1000, help="Max rows (default: 1000)"
+    )
+    args = parser.parse_args()
+
+    try:
+        from google.cloud import bigquery
+
+        client = get_client()
+        config = get_config()
+
+        default_dataset = args.dataset or config.get("dataset")
+
+        job_config = None
+        if default_dataset:
+            job_config = bigquery.QueryJobConfig(
+                default_dataset=f"{config['project_id']}.{default_dataset}"
+            )
+
+        query_job = client.query(args.query, job_config=job_config)
+        results = query_job.result(max_results=args.max_results)
+
+        rows = []
+        for row in results:
+            rows.append(dict(row))
+
+        print(
+            format_output(
+                {
+                    "row_count": len(rows),
+                    "total_rows": results.total_rows,
+                    "schema": [
+                        {"name": field.name, "type": field.field_type}
+                        for field in results.schema
+                    ],
+                    "rows": rows,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-mysql/SKILL.md
+++ b/sre-agent/.claude/skills/database-mysql/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: database-mysql
+description: MySQL/MariaDB database inspection and queries. Use when investigating table schemas, running queries, checking processlist, replication status, InnoDB engine status, or lock contention.
+allowed-tools: Bash(python *)
+---
+
+# MySQL Database
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `MYSQL_PASSWORD` in environment variables - it won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `MYSQL_HOST` - Database host
+- `MYSQL_PORT` - Database port (default: 3306)
+- `MYSQL_DATABASE` - Database name
+
+---
+
+## MANDATORY: Schema-First Investigation
+
+**Understand the schema before running queries.**
+
+```
+LIST TABLES → DESCRIBE TABLE → EXECUTE QUERY → CHECK HEALTH
+```
+
+## Available Scripts
+
+All scripts are in `.claude/skills/database-mysql/scripts/`
+
+### list_tables.py - List Tables (START HERE)
+```bash
+python .claude/skills/database-mysql/scripts/list_tables.py [--database DB]
+```
+
+### describe_table.py - Table Schema Details
+```bash
+python .claude/skills/database-mysql/scripts/describe_table.py --table TABLE_NAME [--database DB]
+```
+
+### execute_query.py - Run SQL Queries
+```bash
+python .claude/skills/database-mysql/scripts/execute_query.py --query "SELECT * FROM users LIMIT 10" [--limit 100]
+```
+
+### show_processlist.py - Active Connections
+```bash
+python .claude/skills/database-mysql/scripts/show_processlist.py [--full]
+```
+
+### show_replica_status.py - Replication Health
+```bash
+python .claude/skills/database-mysql/scripts/show_replica_status.py
+```
+
+### show_engine_status.py - InnoDB Engine Status
+```bash
+python .claude/skills/database-mysql/scripts/show_engine_status.py [--engine innodb]
+```
+
+### get_table_locks.py - Lock Contention
+```bash
+python .claude/skills/database-mysql/scripts/get_table_locks.py
+```
+
+---
+
+## Investigation Workflow
+
+### Slow Query Investigation
+```
+1. show_processlist.py --full (find active/long queries)
+2. show_engine_status.py (check InnoDB lock waits, deadlocks)
+3. get_table_locks.py (find lock contention)
+```
+
+### Replication Lag
+```
+1. show_replica_status.py (check Seconds_Behind_Master)
+2. show_processlist.py (check for blocking queries)
+```

--- a/sre-agent/.claude/skills/database-mysql/scripts/describe_table.py
+++ b/sre-agent/.claude/skills/database-mysql/scripts/describe_table.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Get column details for a MySQL table."""
+
+import argparse
+import sys
+
+from mysql_client import format_output, get_config, get_connection
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Describe MySQL table")
+    parser.add_argument("--table", required=True, help="Table name")
+    parser.add_argument("--database", help="Database name")
+    args = parser.parse_args()
+
+    config = get_config()
+    database = args.database or config["database"]
+
+    try:
+        conn = get_connection()
+        cursor = conn.cursor(dictionary=True)
+
+        # Get columns
+        cursor.execute(
+            """
+            SELECT COLUMN_NAME as name, DATA_TYPE as data_type, COLUMN_TYPE as full_type,
+                   CHARACTER_MAXIMUM_LENGTH as max_length, IS_NULLABLE as nullable,
+                   COLUMN_DEFAULT as default_value, COLUMN_KEY as key_type,
+                   EXTRA as extra, COLUMN_COMMENT as comment
+            FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
+            ORDER BY ORDINAL_POSITION
+        """,
+            (database, args.table),
+        )
+        columns_raw = cursor.fetchall()
+
+        # Get indexes
+        cursor.execute(
+            """
+            SELECT INDEX_NAME as index_name, COLUMN_NAME as column_name,
+                   NON_UNIQUE as non_unique, INDEX_TYPE as index_type
+            FROM information_schema.STATISTICS
+            WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
+            ORDER BY INDEX_NAME, SEQ_IN_INDEX
+        """,
+            (database, args.table),
+        )
+
+        indexes = {}
+        for row in cursor.fetchall():
+            idx_name = row["index_name"]
+            if idx_name not in indexes:
+                indexes[idx_name] = {
+                    "name": idx_name,
+                    "unique": not row["non_unique"],
+                    "type": row["index_type"],
+                    "columns": [],
+                }
+            indexes[idx_name]["columns"].append(row["column_name"])
+
+        # Get foreign keys
+        cursor.execute(
+            """
+            SELECT COLUMN_NAME, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME, CONSTRAINT_NAME
+            FROM information_schema.KEY_COLUMN_USAGE
+            WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s AND REFERENCED_TABLE_NAME IS NOT NULL
+        """,
+            (database, args.table),
+        )
+
+        foreign_keys = {
+            row["COLUMN_NAME"]: {
+                "constraint": row["CONSTRAINT_NAME"],
+                "ref_table": row["REFERENCED_TABLE_NAME"],
+                "ref_column": row["REFERENCED_COLUMN_NAME"],
+            }
+            for row in cursor.fetchall()
+        }
+
+        # Get row count
+        cursor.execute(f"SELECT COUNT(*) as cnt FROM `{database}`.`{args.table}`")
+        row_count = cursor.fetchone()["cnt"]
+
+        columns = []
+        for col in columns_raw:
+            columns.append(
+                {
+                    "name": col["name"],
+                    "type": col["data_type"],
+                    "full_type": col["full_type"],
+                    "nullable": col["nullable"] == "YES",
+                    "default": col["default_value"],
+                    "primary_key": col["key_type"] == "PRI",
+                    "auto_increment": "auto_increment" in (col["extra"] or "").lower(),
+                    "foreign_key": foreign_keys.get(col["name"]),
+                    "comment": col["comment"] if col["comment"] else None,
+                }
+            )
+
+        cursor.close()
+        conn.close()
+
+        print(
+            format_output(
+                {
+                    "database": database,
+                    "table": args.table,
+                    "row_count": row_count,
+                    "column_count": len(columns),
+                    "columns": columns,
+                    "indexes": list(indexes.values()),
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e), "table": args.table}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-mysql/scripts/execute_query.py
+++ b/sre-agent/.claude/skills/database-mysql/scripts/execute_query.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Execute a read-only SQL query against MySQL.
+
+Security: Only SELECT, SHOW, EXPLAIN, and DESCRIBE statements are allowed.
+DML/DDL (INSERT, UPDATE, DELETE, DROP, etc.) is blocked to prevent data modification.
+"""
+
+import argparse
+import re
+import sys
+
+from mysql_client import format_output, get_connection
+
+# Allowed read-only statement types (case-insensitive, anchored to start of query)
+_READONLY_PATTERN = re.compile(
+    r"^\s*(SELECT|SHOW|EXPLAIN|DESCRIBE|DESC|WITH)\b", re.IGNORECASE
+)
+
+
+def _validate_readonly(query: str) -> None:
+    """Reject non-read-only statements."""
+    if not _READONLY_PATTERN.match(query):
+        raise ValueError(
+            "Only read-only queries are allowed (SELECT, SHOW, EXPLAIN, DESCRIBE, WITH). "
+            "DML/DDL statements are blocked for safety."
+        )
+    # Block semicolons that could enable multi-statement injection
+    # (allow trailing semicolon only)
+    stripped = query.rstrip().rstrip(";").rstrip()
+    if ";" in stripped:
+        raise ValueError(
+            "Multi-statement queries are not allowed. Submit one query at a time."
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Execute MySQL query (read-only)")
+    parser.add_argument("--query", required=True, help="SQL query to execute")
+    parser.add_argument(
+        "--limit", type=int, default=100, help="Max rows to return (default: 100)"
+    )
+    args = parser.parse_args()
+
+    try:
+        _validate_readonly(args.query)
+
+        conn = get_connection()
+        cursor = conn.cursor(dictionary=True)
+
+        query = args.query
+        query_lower = query.lower().strip()
+        if query_lower.startswith("select") and "limit" not in query_lower:
+            query = f"{query.rstrip(';')} LIMIT {args.limit}"
+
+        cursor.execute(query)
+
+        if cursor.description:
+            columns = [desc[0] for desc in cursor.description]
+            rows = cursor.fetchall()
+
+            results = []
+            for row in rows:
+                row_dict = {}
+                for col in columns:
+                    val = row[col]
+                    if hasattr(val, "isoformat"):
+                        val = val.isoformat()
+                    elif isinstance(val, bytes):
+                        val = val.decode("utf-8", errors="replace")
+                    elif isinstance(val, set):
+                        val = list(val)
+                    row_dict[col] = val
+                results.append(row_dict)
+
+            cursor.close()
+            conn.close()
+
+            print(
+                format_output(
+                    {
+                        "row_count": len(results),
+                        "columns": columns,
+                        "rows": results,
+                    }
+                )
+            )
+        else:
+            cursor.close()
+            conn.close()
+
+            print(format_output({"row_count": 0, "columns": [], "rows": []}))
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-mysql/scripts/get_table_locks.py
+++ b/sre-agent/.claude/skills/database-mysql/scripts/get_table_locks.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Get MySQL table locks and lock waits."""
+
+import sys
+
+from mysql_client import format_output, get_connection
+
+
+def main():
+    try:
+        conn = get_connection()
+        cursor = conn.cursor(dictionary=True)
+
+        # Check if performance_schema is available
+        cursor.execute("SELECT @@performance_schema as ps_enabled")
+        ps_enabled = cursor.fetchone()["ps_enabled"]
+
+        if not ps_enabled:
+            cursor.close()
+            conn.close()
+            print(
+                format_output(
+                    {
+                        "message": "performance_schema is not enabled",
+                        "locks": [],
+                    }
+                )
+            )
+            return
+
+        # Get current locks
+        locks = []
+        try:
+            cursor.execute("""
+                SELECT OBJECT_SCHEMA as `database`, OBJECT_NAME as `table`,
+                       LOCK_TYPE as lock_type, LOCK_MODE as lock_mode,
+                       LOCK_STATUS as status, OWNER_THREAD_ID as thread_id
+                FROM performance_schema.metadata_locks
+                WHERE OBJECT_TYPE = 'TABLE'
+                ORDER BY OBJECT_SCHEMA, OBJECT_NAME
+            """)
+            locks = cursor.fetchall()
+        except Exception:
+            pass
+
+        # Get lock waits
+        waits = []
+        try:
+            cursor.execute("""
+                SELECT r.trx_id AS waiting_trx_id, r.trx_mysql_thread_id AS waiting_thread,
+                       r.trx_query AS waiting_query,
+                       b.trx_id AS blocking_trx_id, b.trx_mysql_thread_id AS blocking_thread,
+                       b.trx_query AS blocking_query
+                FROM information_schema.innodb_lock_waits w
+                JOIN information_schema.innodb_trx b ON b.trx_id = w.blocking_trx_id
+                JOIN information_schema.innodb_trx r ON r.trx_id = w.requesting_trx_id
+            """)
+            waits = cursor.fetchall()
+        except Exception:
+            try:
+                cursor.execute("""
+                    SELECT REQUESTING_ENGINE_TRANSACTION_ID AS waiting_trx_id,
+                           REQUESTING_THREAD_ID AS waiting_thread,
+                           BLOCKING_ENGINE_TRANSACTION_ID AS blocking_trx_id,
+                           BLOCKING_THREAD_ID AS blocking_thread
+                    FROM performance_schema.data_lock_waits LIMIT 100
+                """)
+                waits = cursor.fetchall()
+            except Exception:
+                pass
+
+        cursor.close()
+        conn.close()
+
+        print(
+            format_output(
+                {
+                    "lock_count": len(locks),
+                    "wait_count": len(waits),
+                    "locks": locks,
+                    "lock_waits": waits,
+                    "has_contention": len(waits) > 0,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-mysql/scripts/list_tables.py
+++ b/sre-agent/.claude/skills/database-mysql/scripts/list_tables.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""List all tables in a MySQL database."""
+
+import argparse
+import sys
+
+from mysql_client import format_output, get_config, get_connection
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List MySQL tables")
+    parser.add_argument(
+        "--database", help="Database name (uses default if not specified)"
+    )
+    args = parser.parse_args()
+
+    config = get_config()
+    database = args.database or config["database"]
+
+    try:
+        conn = get_connection()
+        cursor = conn.cursor(dictionary=True)
+
+        cursor.execute(
+            """
+            SELECT
+                TABLE_NAME as table_name, ENGINE as engine,
+                TABLE_ROWS as estimated_rows,
+                DATA_LENGTH as data_bytes, INDEX_LENGTH as index_bytes,
+                (DATA_LENGTH + INDEX_LENGTH) as total_bytes,
+                CREATE_TIME as created_at, UPDATE_TIME as updated_at
+            FROM information_schema.TABLES
+            WHERE TABLE_SCHEMA = %s AND TABLE_TYPE = 'BASE TABLE'
+            ORDER BY TABLE_NAME
+        """,
+            (database,),
+        )
+
+        tables = []
+        for row in cursor.fetchall():
+            tables.append(
+                {
+                    "table_name": row["table_name"],
+                    "engine": row["engine"],
+                    "estimated_rows": row["estimated_rows"],
+                    "data_mb": round((row["data_bytes"] or 0) / (1024 * 1024), 2),
+                    "index_mb": round((row["index_bytes"] or 0) / (1024 * 1024), 2),
+                    "total_mb": round((row["total_bytes"] or 0) / (1024 * 1024), 2),
+                    "created_at": (
+                        row["created_at"].isoformat() if row["created_at"] else None
+                    ),
+                    "updated_at": (
+                        row["updated_at"].isoformat() if row["updated_at"] else None
+                    ),
+                }
+            )
+
+        cursor.close()
+        conn.close()
+
+        print(
+            format_output(
+                {
+                    "database": database,
+                    "table_count": len(tables),
+                    "tables": tables,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-mysql/scripts/mysql_client.py
+++ b/sre-agent/.claude/skills/database-mysql/scripts/mysql_client.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Shared MySQL client with credential support.
+
+Credentials are injected transparently by the proxy layer.
+"""
+
+import json
+import os
+
+
+def get_config() -> dict[str, str | None]:
+    """Get MySQL configuration from environment."""
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+        "host": os.getenv("MYSQL_HOST", ""),
+        "port": os.getenv("MYSQL_PORT", "3306"),
+        "database": os.getenv("MYSQL_DATABASE", ""),
+        "user": os.getenv("MYSQL_USER"),
+        "password": os.getenv("MYSQL_PASSWORD"),
+        "ssl_mode": os.getenv("MYSQL_SSL_MODE", "PREFERRED"),
+        "charset": os.getenv("MYSQL_CHARSET", "utf8mb4"),
+    }
+
+
+def get_connection():
+    """Get a MySQL connection."""
+    import mysql.connector
+
+    config = get_config()
+
+    conn_kwargs = {
+        "host": config["host"],
+        "port": int(config.get("port") or 3306),
+        "database": config["database"],
+        "user": config.get("user"),
+        "password": config.get("password"),
+        "charset": config.get("charset") or "utf8mb4",
+        "use_unicode": True,
+        "autocommit": True,
+    }
+
+    ssl_mode = config.get("ssl_mode", "PREFERRED")
+    if ssl_mode and ssl_mode.upper() not in ("DISABLED", "NONE"):
+        conn_kwargs["ssl_disabled"] = False
+    else:
+        conn_kwargs["ssl_disabled"] = True
+
+    return mysql.connector.connect(**conn_kwargs)
+
+
+def format_output(data: dict) -> str:
+    """Format output as JSON string."""
+    return json.dumps(data, indent=2, default=str)

--- a/sre-agent/.claude/skills/database-mysql/scripts/show_engine_status.py
+++ b/sre-agent/.claude/skills/database-mysql/scripts/show_engine_status.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Show MySQL engine status (primarily InnoDB)."""
+
+import argparse
+import sys
+
+from mysql_client import format_output, get_connection
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Show MySQL engine status")
+    parser.add_argument(
+        "--engine", default="innodb", help="Storage engine (default: innodb)"
+    )
+    args = parser.parse_args()
+
+    try:
+        conn = get_connection()
+        cursor = conn.cursor(dictionary=True)
+
+        cursor.execute(f"SHOW ENGINE {args.engine.upper()} STATUS")
+        status = cursor.fetchone()
+
+        cursor.close()
+        conn.close()
+
+        if not status:
+            print(
+                format_output(
+                    {
+                        "engine": args.engine,
+                        "message": f"No status available for {args.engine}",
+                    }
+                )
+            )
+            return
+
+        raw_status = status.get("Status", "")
+
+        result = {
+            "engine": args.engine,
+            "raw_status": raw_status[:5000] if len(raw_status) > 5000 else raw_status,
+        }
+
+        if "LATEST DETECTED DEADLOCK" in raw_status:
+            start = raw_status.find("LATEST DETECTED DEADLOCK")
+            end = raw_status.find("---", start + 100)
+            result["deadlock_info"] = (
+                raw_status[start:end]
+                if end > start
+                else raw_status[start : start + 2000]
+            )
+            result["has_recent_deadlock"] = True
+        else:
+            result["has_recent_deadlock"] = False
+
+        result["has_lock_waits"] = "LOCK WAIT" in raw_status
+
+        print(format_output(result))
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-mysql/scripts/show_processlist.py
+++ b/sre-agent/.claude/skills/database-mysql/scripts/show_processlist.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Show current MySQL processes/connections."""
+
+import argparse
+import sys
+
+from mysql_client import format_output, get_connection
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Show MySQL processlist")
+    parser.add_argument("--full", action="store_true", help="Show full query text")
+    args = parser.parse_args()
+
+    try:
+        conn = get_connection()
+        cursor = conn.cursor(dictionary=True)
+
+        if args.full:
+            cursor.execute("SHOW FULL PROCESSLIST")
+        else:
+            cursor.execute("SHOW PROCESSLIST")
+
+        processes = []
+        for proc in cursor.fetchall():
+            processes.append(
+                {
+                    "id": proc["Id"],
+                    "user": proc["User"],
+                    "host": proc["Host"],
+                    "database": proc["db"],
+                    "command": proc["Command"],
+                    "time_seconds": proc["Time"],
+                    "state": proc["State"],
+                    "info": proc["Info"],
+                }
+            )
+
+        active_queries = [p for p in processes if p["command"] == "Query" and p["info"]]
+        sleeping = [p for p in processes if p["command"] == "Sleep"]
+        long_running = [
+            p for p in processes if p["time_seconds"] and p["time_seconds"] > 60
+        ]
+
+        cursor.close()
+        conn.close()
+
+        print(
+            format_output(
+                {
+                    "total_connections": len(processes),
+                    "active_queries": len(active_queries),
+                    "sleeping_connections": len(sleeping),
+                    "long_running_queries": len(long_running),
+                    "processes": processes,
+                    "long_running": long_running,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-mysql/scripts/show_replica_status.py
+++ b/sre-agent/.claude/skills/database-mysql/scripts/show_replica_status.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Show MySQL replication status."""
+
+import sys
+
+from mysql_client import format_output, get_connection
+
+
+def main():
+    try:
+        conn = get_connection()
+        cursor = conn.cursor(dictionary=True)
+
+        # Try MySQL 8.0+ syntax first
+        try:
+            cursor.execute("SHOW REPLICA STATUS")
+        except Exception:
+            cursor.execute("SHOW SLAVE STATUS")
+
+        status = cursor.fetchone()
+        cursor.close()
+        conn.close()
+
+        if not status:
+            print(
+                format_output(
+                    {
+                        "is_replica": False,
+                        "message": "This server is not configured as a replica",
+                    }
+                )
+            )
+            return
+
+        result = {
+            "is_replica": True,
+            "master_host": status.get("Master_Host") or status.get("Source_Host"),
+            "master_port": status.get("Master_Port") or status.get("Source_Port"),
+            "io_running": status.get("Slave_IO_Running")
+            or status.get("Replica_IO_Running"),
+            "sql_running": status.get("Slave_SQL_Running")
+            or status.get("Replica_SQL_Running"),
+            "seconds_behind_master": status.get("Seconds_Behind_Master")
+            or status.get("Seconds_Behind_Source"),
+            "master_log_file": status.get("Master_Log_File")
+            or status.get("Source_Log_File"),
+            "relay_log_file": status.get("Relay_Log_File"),
+            "last_io_error": status.get("Last_IO_Error")
+            or status.get("Last_IO_Error_Message"),
+            "last_sql_error": status.get("Last_SQL_Error")
+            or status.get("Last_SQL_Error_Message"),
+            "gtid_mode": status.get("Retrieved_Gtid_Set") is not None,
+            "retrieved_gtid_set": status.get("Retrieved_Gtid_Set"),
+            "executed_gtid_set": status.get("Executed_Gtid_Set"),
+        }
+
+        io_ok = result["io_running"] in ("Yes", True)
+        sql_ok = result["sql_running"] in ("Yes", True)
+        lag = result["seconds_behind_master"]
+
+        if io_ok and sql_ok and (lag is None or lag < 30):
+            result["health"] = "healthy"
+        elif io_ok and sql_ok and lag < 300:
+            result["health"] = "lagging"
+        elif io_ok and sql_ok:
+            result["health"] = "severely_lagging"
+        else:
+            result["health"] = "broken"
+
+        print(format_output(result))
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-postgresql/SKILL.md
+++ b/sre-agent/.claude/skills/database-postgresql/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: database-postgresql
+description: PostgreSQL database inspection and queries. Use when investigating table schemas, running queries, checking locks, replication status, or long-running queries.
+allowed-tools: Bash(python *)
+---
+
+# PostgreSQL Database
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `POSTGRES_PASSWORD` in environment variables - it won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `POSTGRES_HOST` - Database host
+- `POSTGRES_PORT` - Database port (default: 5432)
+- `POSTGRES_DATABASE` - Database name
+- `POSTGRES_SCHEMA` - Default schema (default: public)
+
+---
+
+## MANDATORY: Schema-First Investigation
+
+**Understand the schema before running queries.**
+
+```
+LIST TABLES → DESCRIBE TABLE → EXECUTE QUERY → CHECK HEALTH
+```
+
+## Available Scripts
+
+All scripts are in `.claude/skills/database-postgresql/scripts/`
+
+### list_tables.py - List Tables (START HERE)
+```bash
+python .claude/skills/database-postgresql/scripts/list_tables.py [--schema public]
+```
+
+### describe_table.py - Table Schema Details
+```bash
+python .claude/skills/database-postgresql/scripts/describe_table.py --table TABLE_NAME [--schema public]
+```
+
+### execute_query.py - Run SQL Queries
+```bash
+python .claude/skills/database-postgresql/scripts/execute_query.py --query "SELECT * FROM users WHERE created_at > now() - interval '1 hour'" [--limit 100]
+```
+
+### list_indexes.py - Index Information
+```bash
+python .claude/skills/database-postgresql/scripts/list_indexes.py [--table TABLE_NAME] [--schema public]
+```
+
+### get_table_sizes.py - Table Size Analysis
+```bash
+python .claude/skills/database-postgresql/scripts/get_table_sizes.py [--table TABLE_NAME] [--schema public]
+```
+
+### get_locks.py - Current Locks & Blocking Queries
+```bash
+python .claude/skills/database-postgresql/scripts/get_locks.py
+```
+
+### get_replication_status.py - Replication Health
+```bash
+python .claude/skills/database-postgresql/scripts/get_replication_status.py
+```
+
+### get_long_running_queries.py - Long-Running Queries
+```bash
+python .claude/skills/database-postgresql/scripts/get_long_running_queries.py [--min-duration 60]
+```
+
+---
+
+## Investigation Workflow
+
+### Lock Contention
+```
+1. get_locks.py (find blocking relationships)
+2. get_long_running_queries.py --min-duration 30
+3. execute_query.py --query "SELECT * FROM pg_stat_activity WHERE state = 'active'"
+```
+
+### Replication Lag
+```
+1. get_replication_status.py (check lag_bytes/lag_seconds)
+2. get_long_running_queries.py (queries blocking replication)
+```
+
+### Table Growth Investigation
+```
+1. get_table_sizes.py (find largest tables)
+2. list_indexes.py --table <table> (check index health)
+3. describe_table.py --table <table>
+```

--- a/sre-agent/.claude/skills/database-postgresql/scripts/describe_table.py
+++ b/sre-agent/.claude/skills/database-postgresql/scripts/describe_table.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Get column details for a PostgreSQL table."""
+
+import argparse
+import sys
+
+from pg_client import format_output, get_connection, get_default_schema
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Describe PostgreSQL table")
+    parser.add_argument("--table", required=True, help="Table name")
+    parser.add_argument("--schema", help="Schema name")
+    args = parser.parse_args()
+
+    schema = args.schema or get_default_schema()
+
+    try:
+        conn = get_connection()
+        cursor = conn.cursor()
+
+        # Get columns
+        cursor.execute(
+            """
+            SELECT column_name, data_type, character_maximum_length, is_nullable, column_default
+            FROM information_schema.columns
+            WHERE table_schema = %s AND table_name = %s
+            ORDER BY ordinal_position
+        """,
+            (schema, args.table),
+        )
+        columns_raw = cursor.fetchall()
+
+        # Get primary keys
+        cursor.execute(
+            """
+            SELECT a.attname
+            FROM pg_index i
+            JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+            WHERE i.indrelid = %s::regclass AND i.indisprimary
+        """,
+            (f"{schema}.{args.table}",),
+        )
+        primary_keys = {row[0] for row in cursor.fetchall()}
+
+        # Get foreign keys
+        cursor.execute(
+            """
+            SELECT kcu.column_name, ccu.table_name, ccu.column_name
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.key_column_usage kcu
+                ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
+            JOIN information_schema.constraint_column_usage ccu
+                ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema
+            WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema = %s AND tc.table_name = %s
+        """,
+            (schema, args.table),
+        )
+        foreign_keys = {
+            row[0]: {"foreign_table": row[1], "foreign_column": row[2]}
+            for row in cursor.fetchall()
+        }
+
+        # Get row count
+        cursor.execute(f'SELECT COUNT(*) FROM "{schema}"."{args.table}"')
+        row_count = cursor.fetchone()[0]
+
+        columns = []
+        for col in columns_raw:
+            columns.append(
+                {
+                    "name": col[0],
+                    "type": col[1],
+                    "max_length": col[2],
+                    "nullable": col[3] == "YES",
+                    "default": col[4],
+                    "primary_key": col[0] in primary_keys,
+                    "foreign_key": foreign_keys.get(col[0]),
+                }
+            )
+
+        cursor.close()
+        conn.close()
+
+        print(
+            format_output(
+                {
+                    "schema": schema,
+                    "table": args.table,
+                    "row_count": row_count,
+                    "column_count": len(columns),
+                    "columns": columns,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e), "table": args.table}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-postgresql/scripts/execute_query.py
+++ b/sre-agent/.claude/skills/database-postgresql/scripts/execute_query.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Execute a read-only SQL query against PostgreSQL.
+
+Security: Only SELECT, SHOW, EXPLAIN, and DESCRIBE statements are allowed.
+DML/DDL (INSERT, UPDATE, DELETE, DROP, etc.) is blocked to prevent data modification.
+"""
+
+import argparse
+import re
+import sys
+
+from pg_client import format_output, get_connection
+
+# Allowed read-only statement types (case-insensitive, anchored to start of query)
+_READONLY_PATTERN = re.compile(
+    r"^\s*(SELECT|SHOW|EXPLAIN|DESCRIBE|WITH)\b", re.IGNORECASE
+)
+
+
+def _validate_readonly(query: str) -> None:
+    """Reject non-read-only statements."""
+    if not _READONLY_PATTERN.match(query):
+        raise ValueError(
+            "Only read-only queries are allowed (SELECT, SHOW, EXPLAIN, DESCRIBE, WITH). "
+            "DML/DDL statements are blocked for safety."
+        )
+    # Block semicolons that could enable multi-statement injection
+    # (allow trailing semicolon only)
+    stripped = query.rstrip().rstrip(";").rstrip()
+    if ";" in stripped:
+        raise ValueError(
+            "Multi-statement queries are not allowed. Submit one query at a time."
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Execute PostgreSQL query (read-only)")
+    parser.add_argument("--query", required=True, help="SQL query to execute")
+    parser.add_argument(
+        "--limit", type=int, default=100, help="Max rows to return (default: 100)"
+    )
+    args = parser.parse_args()
+
+    try:
+        _validate_readonly(args.query)
+
+        from psycopg2.extras import RealDictCursor
+
+        conn = get_connection()
+        # Use a read-only transaction for defense-in-depth
+        conn.set_session(readonly=True, autocommit=False)
+        cursor = conn.cursor(cursor_factory=RealDictCursor)
+
+        query = args.query
+        if "limit" not in query.lower():
+            query = f"{query.rstrip(';')} LIMIT {args.limit}"
+
+        cursor.execute(query)
+
+        if cursor.description:
+            columns = [desc[0] for desc in cursor.description]
+            rows = cursor.fetchall()
+
+            results = []
+            for row in rows:
+                row_dict = {}
+                for col in columns:
+                    val = row[col]
+                    if hasattr(val, "isoformat"):
+                        val = val.isoformat()
+                    elif isinstance(val, bytes):
+                        val = val.decode("utf-8", errors="replace")
+                    row_dict[col] = val
+                results.append(row_dict)
+
+            cursor.close()
+            conn.close()
+
+            print(
+                format_output(
+                    {
+                        "row_count": len(results),
+                        "columns": columns,
+                        "rows": results,
+                    }
+                )
+            )
+        else:
+            cursor.close()
+            conn.close()
+
+            print(format_output({"row_count": 0, "columns": [], "rows": []}))
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-postgresql/scripts/get_locks.py
+++ b/sre-agent/.claude/skills/database-postgresql/scripts/get_locks.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Get current locks and blocking queries in PostgreSQL."""
+
+import sys
+
+from pg_client import format_output, get_connection
+
+
+def main():
+    try:
+        conn = get_connection()
+        cursor = conn.cursor()
+
+        # Get current locks
+        cursor.execute("""
+            SELECT
+                l.locktype, l.relation::regclass AS table_name, l.mode, l.granted,
+                l.pid, a.usename, a.query, a.state,
+                age(now(), a.query_start) AS duration,
+                a.wait_event_type, a.wait_event
+            FROM pg_locks l
+            JOIN pg_stat_activity a ON l.pid = a.pid
+            WHERE l.relation IS NOT NULL
+            ORDER BY a.query_start
+        """)
+
+        locks = []
+        for row in cursor.fetchall():
+            locks.append(
+                {
+                    "lock_type": row[0],
+                    "table_name": str(row[1]) if row[1] else None,
+                    "mode": row[2],
+                    "granted": row[3],
+                    "pid": row[4],
+                    "user": row[5],
+                    "query": row[6][:200] if row[6] else None,
+                    "state": row[7],
+                    "duration": str(row[8]) if row[8] else None,
+                    "wait_event_type": row[9],
+                    "wait_event": row[10],
+                }
+            )
+
+        # Get blocking queries
+        cursor.execute("""
+            SELECT
+                blocked_locks.pid AS blocked_pid,
+                blocked_activity.usename AS blocked_user,
+                blocked_activity.query AS blocked_query,
+                blocking_locks.pid AS blocking_pid,
+                blocking_activity.usename AS blocking_user,
+                blocking_activity.query AS blocking_query,
+                age(now(), blocked_activity.query_start) AS blocked_duration
+            FROM pg_catalog.pg_locks blocked_locks
+            JOIN pg_catalog.pg_stat_activity blocked_activity ON blocked_activity.pid = blocked_locks.pid
+            JOIN pg_catalog.pg_locks blocking_locks
+                ON blocking_locks.locktype = blocked_locks.locktype
+                AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
+                AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
+                AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
+                AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
+                AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
+                AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+                AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
+                AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
+                AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
+                AND blocking_locks.pid != blocked_locks.pid
+            JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+            WHERE NOT blocked_locks.granted
+        """)
+
+        blocking = []
+        for row in cursor.fetchall():
+            blocking.append(
+                {
+                    "blocked_pid": row[0],
+                    "blocked_user": row[1],
+                    "blocked_query": row[2][:200] if row[2] else None,
+                    "blocking_pid": row[3],
+                    "blocking_user": row[4],
+                    "blocking_query": row[5][:200] if row[5] else None,
+                    "blocked_duration": str(row[6]) if row[6] else None,
+                }
+            )
+
+        cursor.close()
+        conn.close()
+
+        waiting_locks = [l for l in locks if not l["granted"]]
+
+        print(
+            format_output(
+                {
+                    "total_locks": len(locks),
+                    "waiting_locks": len(waiting_locks),
+                    "blocking_relationships": len(blocking),
+                    "has_contention": len(blocking) > 0,
+                    "locks": locks,
+                    "blocking": blocking,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-postgresql/scripts/get_long_running_queries.py
+++ b/sre-agent/.claude/skills/database-postgresql/scripts/get_long_running_queries.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Get long-running queries in PostgreSQL."""
+
+import argparse
+import sys
+
+from pg_client import format_output, get_connection
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get long-running PostgreSQL queries")
+    parser.add_argument(
+        "--min-duration",
+        type=int,
+        default=60,
+        help="Min duration in seconds (default: 60)",
+    )
+    args = parser.parse_args()
+
+    try:
+        conn = get_connection()
+        cursor = conn.cursor()
+
+        cursor.execute(
+            """
+            SELECT
+                pid, usename, datname, state, query, query_start,
+                EXTRACT(EPOCH FROM (now() - query_start)) AS duration_seconds,
+                wait_event_type, wait_event, client_addr, application_name
+            FROM pg_stat_activity
+            WHERE state != 'idle'
+                AND query NOT LIKE '%%pg_stat_activity%%'
+                AND EXTRACT(EPOCH FROM (now() - query_start)) > %s
+            ORDER BY query_start
+        """,
+            (args.min_duration,),
+        )
+
+        queries = []
+        for row in cursor.fetchall():
+            queries.append(
+                {
+                    "pid": row[0],
+                    "user": row[1],
+                    "database": row[2],
+                    "state": row[3],
+                    "query": row[4][:500] if row[4] else None,
+                    "query_start": row[5].isoformat() if row[5] else None,
+                    "duration_seconds": round(row[6], 1) if row[6] else None,
+                    "wait_event_type": row[7],
+                    "wait_event": row[8],
+                    "client_addr": str(row[9]) if row[9] else None,
+                    "application_name": row[10],
+                }
+            )
+
+        cursor.close()
+        conn.close()
+
+        print(
+            format_output(
+                {
+                    "min_duration_seconds": args.min_duration,
+                    "query_count": len(queries),
+                    "queries": queries,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-postgresql/scripts/get_replication_status.py
+++ b/sre-agent/.claude/skills/database-postgresql/scripts/get_replication_status.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Get PostgreSQL replication status."""
+
+import sys
+
+from pg_client import format_output, get_connection
+
+
+def main():
+    try:
+        conn = get_connection()
+        cursor = conn.cursor()
+
+        cursor.execute("SELECT pg_is_in_recovery()")
+        is_standby = cursor.fetchone()[0]
+
+        result = {"is_standby": is_standby}
+
+        if is_standby:
+            cursor.execute("""
+                SELECT
+                    pg_last_wal_receive_lsn(),
+                    pg_last_wal_replay_lsn(),
+                    pg_last_xact_replay_timestamp(),
+                    EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))
+            """)
+            standby = cursor.fetchone()
+
+            lag = float(standby[3]) if standby[3] else None
+            result["standby_status"] = {
+                "receive_lsn": str(standby[0]) if standby[0] else None,
+                "replay_lsn": str(standby[1]) if standby[1] else None,
+                "last_replay_time": standby[2].isoformat() if standby[2] else None,
+                "lag_seconds": lag,
+            }
+
+            if lag is None:
+                result["health"] = "unknown"
+            elif lag < 10:
+                result["health"] = "healthy"
+            elif lag < 60:
+                result["health"] = "lagging"
+            elif lag < 300:
+                result["health"] = "severely_lagging"
+            else:
+                result["health"] = "critical"
+        else:
+            cursor.execute("""
+                SELECT client_addr, state, sent_lsn, write_lsn, flush_lsn, replay_lsn,
+                       pg_wal_lsn_diff(sent_lsn, replay_lsn) AS lag_bytes,
+                       sync_state, application_name
+                FROM pg_stat_replication
+            """)
+
+            replicas = []
+            for row in cursor.fetchall():
+                replicas.append(
+                    {
+                        "client_addr": str(row[0]) if row[0] else None,
+                        "state": row[1],
+                        "sent_lsn": str(row[2]) if row[2] else None,
+                        "replay_lsn": str(row[5]) if row[5] else None,
+                        "lag_bytes": row[6],
+                        "sync_state": row[7],
+                        "application_name": row[8],
+                    }
+                )
+
+            result["replicas"] = replicas
+            result["replica_count"] = len(replicas)
+
+            # Replication slots
+            cursor.execute("""
+                SELECT slot_name, slot_type, active,
+                       pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) AS lag_bytes
+                FROM pg_replication_slots
+            """)
+
+            slots = []
+            for row in cursor.fetchall():
+                slots.append(
+                    {
+                        "slot_name": row[0],
+                        "slot_type": row[1],
+                        "active": row[2],
+                        "lag_bytes": row[3],
+                    }
+                )
+
+            result["replication_slots"] = slots
+
+            max_lag = max([r["lag_bytes"] or 0 for r in replicas], default=0)
+            if len(replicas) == 0:
+                result["health"] = "no_replicas"
+            elif max_lag < 1024 * 1024:
+                result["health"] = "healthy"
+            elif max_lag < 100 * 1024 * 1024:
+                result["health"] = "lagging"
+            else:
+                result["health"] = "severely_lagging"
+
+        cursor.close()
+        conn.close()
+
+        print(format_output(result))
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-postgresql/scripts/get_table_sizes.py
+++ b/sre-agent/.claude/skills/database-postgresql/scripts/get_table_sizes.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Get detailed size information for PostgreSQL tables."""
+
+import argparse
+import sys
+
+from pg_client import format_output, get_connection, get_default_schema
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get PostgreSQL table sizes")
+    parser.add_argument("--table", help="Optional table name filter")
+    parser.add_argument("--schema", help="Schema name")
+    args = parser.parse_args()
+
+    schema = args.schema or get_default_schema()
+
+    try:
+        conn = get_connection()
+        cursor = conn.cursor()
+
+        query = """
+            SELECT
+                t.relname AS table_name,
+                pg_table_size(t.oid) AS table_bytes,
+                pg_indexes_size(t.oid) AS indexes_bytes,
+                pg_total_relation_size(t.oid) AS total_bytes,
+                pg_size_pretty(pg_table_size(t.oid)) AS table_size,
+                pg_size_pretty(pg_indexes_size(t.oid)) AS indexes_size,
+                pg_size_pretty(pg_total_relation_size(t.oid)) AS total_size,
+                c.reltuples::bigint AS estimated_rows
+            FROM pg_class t
+            JOIN pg_namespace n ON n.oid = t.relnamespace
+            LEFT JOIN pg_class c ON c.oid = t.oid
+            WHERE n.nspname = %s AND t.relkind = 'r'
+        """
+        params = [schema]
+
+        if args.table:
+            query += " AND t.relname = %s"
+            params.append(args.table)
+
+        query += " ORDER BY pg_total_relation_size(t.oid) DESC"
+
+        cursor.execute(query, params)
+        rows = cursor.fetchall()
+
+        tables = []
+        total_bytes = 0
+        for row in rows:
+            tables.append(
+                {
+                    "table_name": row[0],
+                    "table_bytes": row[1],
+                    "indexes_bytes": row[2],
+                    "total_bytes": row[3],
+                    "table_size": row[4],
+                    "indexes_size": row[5],
+                    "total_size": row[6],
+                    "estimated_rows": row[7],
+                }
+            )
+            total_bytes += row[3] or 0
+
+        cursor.close()
+        conn.close()
+
+        print(
+            format_output(
+                {
+                    "schema": schema,
+                    "table_count": len(tables),
+                    "total_bytes": total_bytes,
+                    "total_size_pretty": f"{total_bytes / (1024*1024*1024):.2f} GB",
+                    "tables": tables,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-postgresql/scripts/list_indexes.py
+++ b/sre-agent/.claude/skills/database-postgresql/scripts/list_indexes.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""List indexes in a PostgreSQL database."""
+
+import argparse
+import sys
+
+from pg_client import format_output, get_connection, get_default_schema
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List PostgreSQL indexes")
+    parser.add_argument("--table", help="Optional table name filter")
+    parser.add_argument("--schema", help="Schema name")
+    args = parser.parse_args()
+
+    schema = args.schema or get_default_schema()
+
+    try:
+        conn = get_connection()
+        cursor = conn.cursor()
+
+        query = """
+            SELECT
+                i.relname AS index_name,
+                t.relname AS table_name,
+                a.attname AS column_name,
+                am.amname AS index_type,
+                ix.indisunique AS is_unique,
+                ix.indisprimary AS is_primary,
+                pg_relation_size(i.oid) AS index_size_bytes,
+                pg_size_pretty(pg_relation_size(i.oid)) AS index_size
+            FROM pg_index ix
+            JOIN pg_class t ON t.oid = ix.indrelid
+            JOIN pg_class i ON i.oid = ix.indexrelid
+            JOIN pg_namespace n ON n.oid = t.relnamespace
+            JOIN pg_am am ON am.oid = i.relam
+            LEFT JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
+            WHERE n.nspname = %s
+        """
+        params = [schema]
+
+        if args.table:
+            query += " AND t.relname = %s"
+            params.append(args.table)
+
+        query += " ORDER BY t.relname, i.relname, a.attnum"
+
+        cursor.execute(query, params)
+        rows = cursor.fetchall()
+
+        indexes = {}
+        for row in rows:
+            idx_name = row[0]
+            if idx_name not in indexes:
+                indexes[idx_name] = {
+                    "index_name": row[0],
+                    "table_name": row[1],
+                    "columns": [],
+                    "index_type": row[3],
+                    "is_unique": row[4],
+                    "is_primary": row[5],
+                    "size_bytes": row[6],
+                    "size": row[7],
+                }
+            if row[2]:
+                indexes[idx_name]["columns"].append(row[2])
+
+        cursor.close()
+        conn.close()
+
+        result = list(indexes.values())
+
+        print(
+            format_output(
+                {
+                    "schema": schema,
+                    "table": args.table,
+                    "index_count": len(result),
+                    "indexes": result,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-postgresql/scripts/list_tables.py
+++ b/sre-agent/.claude/skills/database-postgresql/scripts/list_tables.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""List all tables in a PostgreSQL database schema."""
+
+import argparse
+import sys
+
+from pg_client import format_output, get_connection, get_default_schema
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List PostgreSQL tables")
+    parser.add_argument(
+        "--schema", help=f"Schema name (default: {get_default_schema()})"
+    )
+    args = parser.parse_args()
+
+    schema = args.schema or get_default_schema()
+
+    try:
+        conn = get_connection()
+        cursor = conn.cursor()
+
+        cursor.execute(
+            """
+            SELECT
+                table_name,
+                pg_total_relation_size(quote_ident(table_schema) || '.' || quote_ident(table_name)) as size_bytes
+            FROM information_schema.tables
+            WHERE table_schema = %s AND table_type = 'BASE TABLE'
+            ORDER BY table_name
+        """,
+            (schema,),
+        )
+
+        tables = []
+        for row in cursor.fetchall():
+            tables.append(
+                {
+                    "table_name": row[0],
+                    "size_bytes": row[1],
+                    "size_mb": round(row[1] / (1024 * 1024), 2) if row[1] else 0,
+                }
+            )
+
+        cursor.close()
+        conn.close()
+
+        print(
+            format_output(
+                {
+                    "schema": schema,
+                    "table_count": len(tables),
+                    "tables": tables,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-postgresql/scripts/pg_client.py
+++ b/sre-agent/.claude/skills/database-postgresql/scripts/pg_client.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Shared PostgreSQL client with credential support.
+
+Credentials are injected transparently by the proxy layer.
+"""
+
+import json
+import os
+
+
+def get_config() -> dict[str, str | None]:
+    """Get PostgreSQL configuration from environment."""
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+        "host": os.getenv("POSTGRES_HOST", ""),
+        "port": os.getenv("POSTGRES_PORT", "5432"),
+        "database": os.getenv("POSTGRES_DATABASE", ""),
+        "user": os.getenv("POSTGRES_USER"),
+        "password": os.getenv("POSTGRES_PASSWORD"),
+        "schema": os.getenv("POSTGRES_SCHEMA", "public"),
+        "ssl_mode": os.getenv("POSTGRES_SSL_MODE", "prefer"),
+    }
+
+
+def get_connection():
+    """Get a PostgreSQL connection."""
+    import psycopg2
+
+    config = get_config()
+
+    conn_kwargs = {
+        "host": config["host"],
+        "port": int(config.get("port") or 5432),
+        "database": config["database"],
+        "user": config.get("user"),
+        "password": config.get("password"),
+    }
+
+    ssl_mode = config.get("ssl_mode")
+    if ssl_mode and ssl_mode != "disable":
+        conn_kwargs["sslmode"] = ssl_mode
+
+    return psycopg2.connect(**conn_kwargs)
+
+
+def get_default_schema() -> str:
+    """Get the default schema name."""
+    return os.getenv("POSTGRES_SCHEMA", "public")
+
+
+def format_output(data: dict) -> str:
+    """Format output as JSON string."""
+    return json.dumps(data, indent=2, default=str)

--- a/sre-agent/.claude/skills/database-snowflake/SKILL.md
+++ b/sre-agent/.claude/skills/database-snowflake/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: database-snowflake
+description: Snowflake data warehouse queries and schema inspection. Use when running SQL queries against Snowflake, listing tables, or inspecting schemas.
+allowed-tools: Bash(python *)
+---
+
+# Snowflake Data Warehouse
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `SNOWFLAKE_PASSWORD` in environment variables - it won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `SNOWFLAKE_ACCOUNT` - Snowflake account identifier
+- `SNOWFLAKE_WAREHOUSE` - Compute warehouse
+- `SNOWFLAKE_DATABASE` - Default database
+- `SNOWFLAKE_SCHEMA` - Default schema
+
+---
+
+## MANDATORY: Schema-First Investigation
+
+**Always get the schema before writing queries.**
+
+```
+GET SCHEMA / LIST TABLES → DESCRIBE TABLE → EXECUTE QUERY
+```
+
+## Available Scripts
+
+All scripts are in `.claude/skills/database-snowflake/scripts/`
+
+### get_schema.py - Get Database Schema (START HERE)
+```bash
+python .claude/skills/database-snowflake/scripts/get_schema.py
+```
+
+### list_tables.py - List Tables
+```bash
+python .claude/skills/database-snowflake/scripts/list_tables.py [--database DB] [--schema SCHEMA]
+```
+
+### describe_table.py - Table Column Details
+```bash
+python .claude/skills/database-snowflake/scripts/describe_table.py --table TABLE_NAME [--database DB] [--schema SCHEMA]
+```
+
+### execute_query.py - Run SQL Queries
+```bash
+python .claude/skills/database-snowflake/scripts/execute_query.py --query "SELECT * FROM fact_incident ORDER BY started_at DESC LIMIT 10" [--limit 100]
+```
+
+---
+
+## Investigation Workflow
+
+### Incident Data Analysis
+```
+1. get_schema.py (understand available tables)
+2. execute_query.py --query "SELECT * FROM fact_incident WHERE sev = 'SEV-1' ORDER BY started_at DESC LIMIT 10"
+3. execute_query.py --query "SELECT c.customer_name, ic.estimated_arr_at_risk_usd FROM fact_incident_customer_impact ic JOIN dim_customer c ON ic.customer_id = c.customer_id WHERE ic.incident_id = '<id>'"
+```

--- a/sre-agent/.claude/skills/database-snowflake/scripts/describe_table.py
+++ b/sre-agent/.claude/skills/database-snowflake/scripts/describe_table.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Get column details for a Snowflake table."""
+
+import argparse
+import sys
+
+from snowflake_client import format_output, get_connection
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Describe Snowflake table")
+    parser.add_argument("--table", required=True, help="Table name")
+    parser.add_argument("--database", help="Database name")
+    parser.add_argument("--schema", help="Schema name")
+    args = parser.parse_args()
+
+    try:
+        conn = get_connection()
+        cursor = conn.cursor()
+
+        full_table_name = args.table
+        if args.database and args.schema:
+            full_table_name = f"{args.database}.{args.schema}.{args.table}"
+        elif args.schema:
+            full_table_name = f"{args.schema}.{args.table}"
+
+        cursor.execute(f"DESCRIBE TABLE {full_table_name}")
+        columns = cursor.fetchall()
+
+        result = []
+        for col in columns:
+            result.append(
+                {
+                    "name": col[0],
+                    "type": col[1],
+                    "kind": col[2],
+                    "null": col[3] == "Y",
+                    "default": col[4],
+                    "primary_key": col[5] == "Y",
+                    "unique_key": col[6] == "Y",
+                }
+            )
+
+        cursor.close()
+        conn.close()
+
+        print(
+            format_output(
+                {
+                    "table": args.table,
+                    "column_count": len(result),
+                    "columns": result,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e), "table": args.table}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-snowflake/scripts/execute_query.py
+++ b/sre-agent/.claude/skills/database-snowflake/scripts/execute_query.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Execute a SQL query against Snowflake."""
+
+import argparse
+import sys
+
+from snowflake_client import format_output, get_connection
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Execute Snowflake query")
+    parser.add_argument("--query", required=True, help="SQL query to execute")
+    parser.add_argument(
+        "--limit", type=int, default=100, help="Max rows to return (default: 100)"
+    )
+    args = parser.parse_args()
+
+    try:
+        conn = get_connection()
+        cursor = conn.cursor()
+
+        query = args.query
+        if "limit" not in query.lower():
+            query = f"{query.rstrip(';')} LIMIT {args.limit}"
+
+        cursor.execute(query)
+
+        columns = [desc[0] for desc in cursor.description]
+        rows = cursor.fetchall()
+
+        results = []
+        for row in rows:
+            row_dict = {}
+            for i, col in enumerate(columns):
+                val = row[i]
+                if hasattr(val, "isoformat"):
+                    val = val.isoformat()
+                elif isinstance(val, bytes):
+                    val = val.decode("utf-8", errors="replace")
+                row_dict[col] = val
+            results.append(row_dict)
+
+        cursor.close()
+        conn.close()
+
+        print(
+            format_output(
+                {
+                    "row_count": len(results),
+                    "columns": columns,
+                    "rows": results,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-snowflake/scripts/get_schema.py
+++ b/sre-agent/.claude/skills/database-snowflake/scripts/get_schema.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Get the known database schema for incident enrichment tables."""
+
+import json
+
+
+def main():
+    schema = {
+        "database": "INCIDENT_ENRICHMENT_DB",
+        "schema": "INCIDENT_ENRICHMENT_DEMO",
+        "tables": {
+            "fact_incident": {
+                "description": "Main incident table with all incidents",
+                "columns": [
+                    "INCIDENT_ID (string, PK)",
+                    "CREATED_AT (timestamp)",
+                    "STARTED_AT (timestamp)",
+                    "MITIGATED_AT (timestamp)",
+                    "RESOLVED_AT (timestamp)",
+                    "STATUS (string: resolved, open, investigating)",
+                    "SEV (string: SEV-1, SEV-2, SEV-3, SEV-4)",
+                    "PRIMARY_SERVICE_ID (string, FK)",
+                    "ENV (string: prod, staging)",
+                    "REGION (string)",
+                    "TITLE (string)",
+                    "SUMMARY (string)",
+                    "ROOT_CAUSE_TYPE (string: deployment, external_dependency, etc)",
+                    "DEPLOYMENT_ID (string, FK)",
+                    "CONFIDENCE (float)",
+                ],
+            },
+            "fact_incident_customer_impact": {
+                "description": "Customer impact per incident",
+                "columns": [
+                    "IMPACT_ID (string, PK)",
+                    "INCIDENT_ID (string, FK)",
+                    "CUSTOMER_ID (string, FK)",
+                    "IMPACT_TYPE (string)",
+                    "IMPACTED_REQUESTS (int)",
+                    "ERROR_RATE (float)",
+                    "LATENCY_P95_MS (int)",
+                    "ESTIMATED_ARR_AT_RISK_USD (float)",
+                    "RECORDED_AT (timestamp)",
+                ],
+            },
+            "dim_customer": {
+                "description": "Customer dimension table",
+                "columns": [
+                    "CUSTOMER_ID (string, PK)",
+                    "CUSTOMER_NAME (string)",
+                    "TIER (string: enterprise, pro, free)",
+                    "ARR_USD (float)",
+                    "INDUSTRY (string)",
+                    "CUSTOMER_REGION (string)",
+                    "SLA (string)",
+                    "ONBOARD_DATE (date)",
+                ],
+            },
+            "fact_deployment": {
+                "description": "Deployment records",
+                "columns": [
+                    "DEPLOYMENT_ID (string, PK)",
+                    "SERVICE_ID (string, FK)",
+                    "ENV (string)",
+                    "REGION (string)",
+                    "STARTED_AT (string)",
+                    "FINISHED_AT (string)",
+                    "STATUS (string)",
+                    "COMMIT_SHA (string)",
+                    "PR_NUMBER (int)",
+                    "AUTHOR (string)",
+                    "CHANGE_TYPE (string)",
+                    "RISK_LEVEL (string)",
+                ],
+            },
+            "dim_service": {
+                "description": "Service dimension table",
+                "columns": [
+                    "SERVICE_ID (string, PK)",
+                    "SERVICE_NAME (string)",
+                    "TEAM (string)",
+                    "TIER (string)",
+                ],
+            },
+        },
+        "usage_tips": [
+            "Use fact_incident for incident queries",
+            "Join fact_incident_customer_impact with dim_customer to get ARR at risk",
+            "TITLE and SUMMARY contain incident descriptions",
+        ],
+    }
+
+    print(json.dumps(schema, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-snowflake/scripts/list_tables.py
+++ b/sre-agent/.claude/skills/database-snowflake/scripts/list_tables.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""List tables in a Snowflake database/schema."""
+
+import argparse
+import sys
+
+from snowflake_client import format_output, get_connection
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Snowflake tables")
+    parser.add_argument("--database", help="Database name")
+    parser.add_argument("--schema", help="Schema name")
+    args = parser.parse_args()
+
+    try:
+        conn = get_connection()
+        cursor = conn.cursor()
+
+        query = "SHOW TABLES"
+        if args.database:
+            query += f" IN DATABASE {args.database}"
+        if args.schema:
+            query += f" IN SCHEMA {args.schema}"
+
+        cursor.execute(query)
+        tables = cursor.fetchall()
+
+        result = []
+        for table in tables:
+            result.append(
+                {
+                    "name": table[1],
+                    "database": table[2],
+                    "schema": table[3],
+                    "owner": table[4],
+                    "rows": table[5],
+                    "bytes": table[6],
+                    "created": str(table[0]),
+                }
+            )
+
+        cursor.close()
+        conn.close()
+
+        print(
+            format_output(
+                {
+                    "table_count": len(result),
+                    "tables": result,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/database-snowflake/scripts/snowflake_client.py
+++ b/sre-agent/.claude/skills/database-snowflake/scripts/snowflake_client.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Shared Snowflake client with credential support.
+
+Credentials are injected transparently by the proxy layer.
+"""
+
+import json
+import os
+
+
+def get_config() -> dict[str, str | None]:
+    """Get Snowflake configuration from environment."""
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+        "account": os.getenv("SNOWFLAKE_ACCOUNT", ""),
+        "username": os.getenv("SNOWFLAKE_USERNAME"),
+        "password": os.getenv("SNOWFLAKE_PASSWORD"),
+        "warehouse": os.getenv("SNOWFLAKE_WAREHOUSE"),
+        "database": os.getenv("SNOWFLAKE_DATABASE"),
+        "schema": os.getenv("SNOWFLAKE_SCHEMA"),
+    }
+
+
+def get_connection():
+    """Get a Snowflake connection."""
+    import snowflake.connector
+
+    config = get_config()
+
+    return snowflake.connector.connect(
+        account=config["account"],
+        user=config.get("username") or config.get("user"),
+        password=config["password"],
+        warehouse=config.get("warehouse") or "COMPUTE_WH",
+        database=config.get("database"),
+        schema=config.get("schema"),
+    )
+
+
+def format_output(data: dict) -> str:
+    """Format output as JSON string."""
+    return json.dumps(data, indent=2, default=str)

--- a/sre-agent/.claude/skills/docs-google/SKILL.md
+++ b/sre-agent/.claude/skills/docs-google/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: docs-google
+description: Google Docs and Drive integration. Use for reading documents, searching Drive, creating docs, writing content with markdown formatting, and sharing documents.
+allowed-tools: Bash(python *)
+---
+
+# Google Docs & Drive Integration
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Just run the scripts directly.
+
+**Note**: In direct mode, requires `google-api-python-client` and `google-auth` packages.
+
+## Available Scripts
+
+All scripts are in `.claude/skills/docs-google/scripts/`
+
+### read_document.py
+```bash
+python .claude/skills/docs-google/scripts/read_document.py --document-id DOC_ID
+```
+
+### search_drive.py
+```bash
+python .claude/skills/docs-google/scripts/search_drive.py --query "incident report" [--mime-type "application/vnd.google-apps.document"] [--max-results 10]
+```
+
+### list_folder.py
+```bash
+python .claude/skills/docs-google/scripts/list_folder.py --folder-id FOLDER_ID
+```
+
+### create_document.py
+```bash
+python .claude/skills/docs-google/scripts/create_document.py --title "Postmortem Report" [--folder-id FOLDER_ID]
+```
+
+### write_content.py
+```bash
+python .claude/skills/docs-google/scripts/write_content.py --document-id DOC_ID --content "# Heading\n\nParagraph..." [--replace]
+```
+
+### share_document.py
+```bash
+python .claude/skills/docs-google/scripts/share_document.py --document-id DOC_ID --email user@example.com [--role writer]
+python .claude/skills/docs-google/scripts/share_document.py --document-id DOC_ID --anyone [--role reader]
+```

--- a/sre-agent/.claude/skills/docs-google/scripts/create_document.py
+++ b/sre-agent/.claude/skills/docs-google/scripts/create_document.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Create a new Google Doc."""
+
+import argparse
+import json
+import sys
+
+from google_client import (
+    _is_proxy_mode,
+    docs_request,
+    drive_request,
+    get_docs_service,
+    get_drive_service,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create Google Doc")
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--folder-id", help="Optional folder to create in")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        if _is_proxy_mode():
+            doc = docs_request("POST", "/documents", json_body={"title": args.title})
+            doc_id = doc["documentId"]
+            if args.folder_id:
+                f = drive_request(
+                    "GET", f"/files/{doc_id}", params={"fields": "parents"}
+                )
+                prev = ",".join(f.get("parents", []))
+                drive_request(
+                    "PATCH",
+                    f"/files/{doc_id}",
+                    params={
+                        "addParents": args.folder_id,
+                        "removeParents": prev,
+                        "fields": "id,parents",
+                    },
+                )
+        else:
+            docs = get_docs_service()
+            doc = docs.documents().create(body={"title": args.title}).execute()
+            doc_id = doc["documentId"]
+            if args.folder_id:
+                drive = get_drive_service()
+                f = drive.files().get(fileId=doc_id, fields="parents").execute()
+                prev = ",".join(f.get("parents", []))
+                drive.files().update(
+                    fileId=doc_id,
+                    addParents=args.folder_id,
+                    removeParents=prev,
+                    fields="id,parents",
+                ).execute()
+
+        result = {
+            "document_id": doc_id,
+            "title": args.title,
+            "url": f"https://docs.google.com/document/d/{doc_id}/edit",
+            "success": True,
+        }
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Created: {args.title}\nURL: {result['url']}")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/docs-google/scripts/google_client.py
+++ b/sre-agent/.claude/skills/docs-google/scripts/google_client.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Shared Google Docs/Drive client with proxy and direct mode support."""
+
+import json as json_mod
+import os
+
+import httpx
+
+
+def _get_proxy_headers():
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    sandbox_jwt = os.getenv("SANDBOX_JWT")
+    if sandbox_jwt:
+        headers["X-Sandbox-JWT"] = sandbox_jwt
+    else:
+        headers["X-Tenant-Id"] = os.getenv("OPENSRE_TENANT_ID", "local")
+        headers["X-Team-Id"] = os.getenv("OPENSRE_TEAM_ID", "local")
+    return headers
+
+
+def _is_proxy_mode():
+    return bool(os.getenv("GOOGLE_DOCS_BASE_URL") or os.getenv("GOOGLE_DRIVE_BASE_URL"))
+
+
+def _get_credentials(readonly=False):
+    """Get Google API credentials for direct mode."""
+    from google.oauth2 import service_account
+
+    creds_json = os.getenv("GOOGLE_SERVICE_ACCOUNT_KEY")
+    creds_file = os.getenv("GOOGLE_CREDENTIALS_FILE")
+    scopes_suffix = ".readonly" if readonly else ""
+    scopes = [
+        f"https://www.googleapis.com/auth/documents{scopes_suffix}",
+        f"https://www.googleapis.com/auth/drive{'.readonly' if readonly else '.file'}",
+    ]
+    if creds_json:
+        return service_account.Credentials.from_service_account_info(
+            json_mod.loads(creds_json), scopes=scopes
+        )
+    elif creds_file:
+        return service_account.Credentials.from_service_account_file(
+            creds_file, scopes=scopes
+        )
+    raise RuntimeError(
+        "Neither GOOGLE_SERVICE_ACCOUNT_KEY nor GOOGLE_CREDENTIALS_FILE is set"
+    )
+
+
+def get_docs_service(readonly=False):
+    """Get Google Docs API service (direct mode)."""
+    from googleapiclient.discovery import build
+
+    return build("docs", "v1", credentials=_get_credentials(readonly))
+
+
+def get_drive_service(readonly=False):
+    """Get Google Drive API service (direct mode)."""
+    from googleapiclient.discovery import build
+
+    return build("drive", "v3", credentials=_get_credentials(readonly))
+
+
+def docs_request(method, path, params=None, json_body=None):
+    """Make a Docs API request via proxy."""
+    base = os.getenv("GOOGLE_DOCS_BASE_URL", "").rstrip("/")
+    url = f"{base}/{path.lstrip('/')}"
+    with httpx.Client(timeout=30.0) as client:
+        resp = client.request(
+            method, url, headers=_get_proxy_headers(), params=params, json=json_body
+        )
+        resp.raise_for_status()
+        return resp.json() if resp.status_code != 204 else None
+
+
+def drive_request(method, path, params=None, json_body=None):
+    """Make a Drive API request via proxy."""
+    base = os.getenv("GOOGLE_DRIVE_BASE_URL", "").rstrip("/")
+    url = f"{base}/{path.lstrip('/')}"
+    with httpx.Client(timeout=30.0) as client:
+        resp = client.request(
+            method, url, headers=_get_proxy_headers(), params=params, json=json_body
+        )
+        resp.raise_for_status()
+        return resp.json() if resp.status_code != 204 else None

--- a/sre-agent/.claude/skills/docs-google/scripts/list_folder.py
+++ b/sre-agent/.claude/skills/docs-google/scripts/list_folder.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""List contents of a Google Drive folder."""
+
+import argparse
+import json
+import sys
+
+from google_client import _is_proxy_mode, drive_request, get_drive_service
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Drive folder")
+    parser.add_argument("--folder-id", required=True)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        q = f"'{args.folder_id}' in parents"
+        if _is_proxy_mode():
+            data = drive_request(
+                "GET",
+                "/files",
+                params={"q": q, "fields": "files(id,name,mimeType,webViewLink)"},
+            )
+        else:
+            service = get_drive_service(readonly=True)
+            data = (
+                service.files()
+                .list(q=q, fields="files(id,name,mimeType,webViewLink)")
+                .execute()
+            )
+
+        files = [
+            {
+                "id": f["id"],
+                "name": f["name"],
+                "type": f["mimeType"],
+                "url": f.get("webViewLink"),
+            }
+            for f in data.get("files", [])
+        ]
+
+        if args.json:
+            print(json.dumps(files, indent=2))
+        else:
+            print(f"Folder contents: {len(files)} items")
+            for f in files:
+                print(f"  {f['name']} ({f['type'][:30]})")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/docs-google/scripts/read_document.py
+++ b/sre-agent/.claude/skills/docs-google/scripts/read_document.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Read content from a Google Doc."""
+
+import argparse
+import json
+import sys
+
+from google_client import _is_proxy_mode, docs_request, get_docs_service
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Read Google Doc")
+    parser.add_argument("--document-id", required=True)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        if _is_proxy_mode():
+            doc = docs_request("GET", f"/documents/{args.document_id}")
+        else:
+            service = get_docs_service(readonly=True)
+            doc = service.documents().get(documentId=args.document_id).execute()
+
+        parts = []
+        for el in doc.get("body", {}).get("content", []):
+            if "paragraph" in el:
+                for text_run in el["paragraph"].get("elements", []):
+                    if "textRun" in text_run:
+                        parts.append(text_run["textRun"]["content"])
+        text = "".join(parts)
+
+        result = {
+            "title": doc.get("title"),
+            "document_id": args.document_id,
+            "content": text,
+            "url": f"https://docs.google.com/document/d/{args.document_id}",
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Title: {result['title']}")
+            print(f"URL: {result['url']}")
+            print(f"Length: {len(text)} chars\n")
+            print(text[:2000])
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/docs-google/scripts/search_drive.py
+++ b/sre-agent/.claude/skills/docs-google/scripts/search_drive.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Search Google Drive for files."""
+
+import argparse
+import json
+import sys
+
+from google_client import _is_proxy_mode, drive_request, get_drive_service
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search Google Drive")
+    parser.add_argument("--query", required=True)
+    parser.add_argument("--mime-type", help="MIME type filter")
+    parser.add_argument("--max-results", type=int, default=10)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        q = f"name contains '{args.query}'"
+        if args.mime_type:
+            q += f" and mimeType = '{args.mime_type}'"
+
+        if _is_proxy_mode():
+            data = drive_request(
+                "GET",
+                "/files",
+                params={
+                    "q": q,
+                    "pageSize": args.max_results,
+                    "fields": "files(id,name,mimeType,webViewLink,modifiedTime)",
+                },
+            )
+        else:
+            service = get_drive_service(readonly=True)
+            data = (
+                service.files()
+                .list(
+                    q=q,
+                    pageSize=args.max_results,
+                    fields="files(id,name,mimeType,webViewLink,modifiedTime)",
+                )
+                .execute()
+            )
+
+        files = [
+            {
+                "id": f["id"],
+                "name": f["name"],
+                "type": f["mimeType"],
+                "url": f.get("webViewLink"),
+                "modified": f.get("modifiedTime"),
+            }
+            for f in data.get("files", [])
+        ]
+
+        if args.json:
+            print(json.dumps(files, indent=2))
+        else:
+            print(f"Found: {len(files)} files")
+            for f in files:
+                print(f"  {f['name']} ({f['type'][:30]})\n    {f.get('url', '')}")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/docs-google/scripts/share_document.py
+++ b/sre-agent/.claude/skills/docs-google/scripts/share_document.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Share a Google Doc."""
+
+import argparse
+import json
+import sys
+
+from google_client import _is_proxy_mode, drive_request, get_drive_service
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Share Google Doc")
+    parser.add_argument("--document-id", required=True)
+    parser.add_argument("--email", help="Email to share with")
+    parser.add_argument("--role", default="reader", help="reader, writer, or commenter")
+    parser.add_argument(
+        "--anyone", action="store_true", help="Share with anyone with link"
+    )
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    if not args.email and not args.anyone:
+        print("Error: Provide --email or --anyone", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        if args.anyone:
+            perm = {"type": "anyone", "role": args.role}
+        else:
+            perm = {"type": "user", "role": args.role, "emailAddress": args.email}
+
+        if _is_proxy_mode():
+            drive_request(
+                "POST", f"/files/{args.document_id}/permissions", json_body=perm
+            )
+        else:
+            service = get_drive_service()
+            service.permissions().create(
+                fileId=args.document_id, body=perm, fields="id"
+            ).execute()
+
+        shared_with = "anyone" if args.anyone else args.email
+        result = {
+            "document_id": args.document_id,
+            "shared_with": shared_with,
+            "role": args.role,
+            "success": True,
+        }
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Shared {args.document_id} with {shared_with} as {args.role}")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/docs-google/scripts/write_content.py
+++ b/sre-agent/.claude/skills/docs-google/scripts/write_content.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Write content to a Google Doc with markdown header formatting."""
+
+import argparse
+import json
+import sys
+
+from google_client import _is_proxy_mode, docs_request, get_docs_service
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Write to Google Doc")
+    parser.add_argument("--document-id", required=True)
+    parser.add_argument("--content", required=True)
+    parser.add_argument(
+        "--replace", action="store_true", help="Replace (default: append)"
+    )
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        if _is_proxy_mode():
+            doc = docs_request("GET", f"/documents/{args.document_id}")
+        else:
+            service = get_docs_service()
+            doc = service.documents().get(documentId=args.document_id).execute()
+
+        requests = []
+        if args.replace:
+            end_index = doc["body"]["content"][-1]["endIndex"] - 1
+            if end_index > 1:
+                requests.append(
+                    {
+                        "deleteContentRange": {
+                            "range": {"startIndex": 1, "endIndex": end_index}
+                        }
+                    }
+                )
+
+        requests.append(
+            {"insertText": {"location": {"index": 1}, "text": args.content}}
+        )
+
+        lines = args.content.split("\n")
+        idx = 1
+        for line in lines:
+            line_len = len(line) + 1
+            style = None
+            if line.startswith("### "):
+                style = "HEADING_3"
+            elif line.startswith("## "):
+                style = "HEADING_2"
+            elif line.startswith("# "):
+                style = "HEADING_1"
+            if style:
+                requests.append(
+                    {
+                        "updateParagraphStyle": {
+                            "range": {
+                                "startIndex": idx,
+                                "endIndex": idx + line_len - 1,
+                            },
+                            "paragraphStyle": {"namedStyleType": style},
+                            "fields": "namedStyleType",
+                        }
+                    }
+                )
+            idx += line_len
+
+        if _is_proxy_mode():
+            docs_request(
+                "POST",
+                f"/documents/{args.document_id}:batchUpdate",
+                json_body={"requests": requests},
+            )
+        else:
+            service.documents().batchUpdate(
+                documentId=args.document_id, body={"requests": requests}
+            ).execute()
+
+        result = {
+            "document_id": args.document_id,
+            "success": True,
+            "characters_written": len(args.content),
+        }
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Wrote {len(args.content)} chars to {args.document_id}")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/docs-notion/SKILL.md
+++ b/sre-agent/.claude/skills/docs-notion/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: docs-notion
+description: Notion page and database management. Use for searching, creating, and writing to Notion pages. Supports creating pages in databases or under parent pages.
+allowed-tools: Bash(python *)
+---
+
+# Notion Integration
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Just run the scripts directly.
+
+## Available Scripts
+
+All scripts are in `.claude/skills/docs-notion/scripts/`
+
+### search.py - Search Pages
+```bash
+python .claude/skills/docs-notion/scripts/search.py --query "incident runbook" [--max-results 10]
+```
+
+### create_page.py - Create Page
+```bash
+python .claude/skills/docs-notion/scripts/create_page.py --title "Incident Report" --parent-page-id PAGE_ID [--content "Report content..."]
+python .claude/skills/docs-notion/scripts/create_page.py --title "New Entry" --parent-database-id DB_ID
+```
+
+### write_content.py - Write to Page
+```bash
+python .claude/skills/docs-notion/scripts/write_content.py --page-id PAGE_ID --content "New content..." [--replace]
+```

--- a/sre-agent/.claude/skills/docs-notion/scripts/create_page.py
+++ b/sre-agent/.claude/skills/docs-notion/scripts/create_page.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Create a new Notion page."""
+
+import argparse
+import json
+import sys
+
+from notion_client import notion_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create Notion page")
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--parent-page-id", help="Parent page ID")
+    parser.add_argument("--parent-database-id", help="Parent database ID")
+    parser.add_argument("--content", help="Page content text")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    if not args.parent_page_id and not args.parent_database_id:
+        print(
+            "Error: Must provide --parent-page-id or --parent-database-id",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        parent = (
+            {"database_id": args.parent_database_id}
+            if args.parent_database_id
+            else {"page_id": args.parent_page_id}
+        )
+        properties = {"title": {"title": [{"text": {"content": args.title}}]}}
+        children = []
+        if args.content:
+            for para in args.content.split("\n\n"):
+                if para.strip():
+                    children.append(
+                        {
+                            "object": "block",
+                            "type": "paragraph",
+                            "paragraph": {
+                                "rich_text": [
+                                    {"type": "text", "text": {"content": para.strip()}}
+                                ]
+                            },
+                        }
+                    )
+
+        body = {"parent": parent, "properties": properties}
+        if children:
+            body["children"] = children
+        page = notion_request("POST", "/pages", json_body=body)
+
+        result = {
+            "id": page["id"],
+            "url": page.get("url"),
+            "title": args.title,
+            "success": True,
+        }
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Created: {args.title}")
+            print(f"ID: {page['id']}")
+            if page.get("url"):
+                print(f"URL: {page['url']}")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/docs-notion/scripts/notion_client.py
+++ b/sre-agent/.claude/skills/docs-notion/scripts/notion_client.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Shared Notion API client with proxy support. Uses httpx (not notion-client package)."""
+
+import os
+
+import httpx
+
+NOTION_VERSION = "2022-06-28"
+
+
+def get_base_url() -> str:
+    proxy_url = os.getenv("NOTION_BASE_URL")
+    if proxy_url:
+        return proxy_url.rstrip("/")
+    return "https://api.notion.com/v1"
+
+
+def get_headers() -> dict[str, str]:
+    headers = {"Content-Type": "application/json", "Notion-Version": NOTION_VERSION}
+    api_key = os.getenv("NOTION_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    else:
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            headers["X-Tenant-Id"] = os.getenv("OPENSRE_TENANT_ID", "local")
+            headers["X-Team-Id"] = os.getenv("OPENSRE_TEAM_ID", "local")
+    return headers
+
+
+def notion_request(method, path, params=None, json_body=None):
+    url = f"{get_base_url()}/{path.lstrip('/')}"
+    with httpx.Client(timeout=30.0) as client:
+        response = client.request(
+            method, url, headers=get_headers(), params=params, json=json_body
+        )
+        response.raise_for_status()
+        return None if response.status_code == 204 else response.json()

--- a/sre-agent/.claude/skills/docs-notion/scripts/search.py
+++ b/sre-agent/.claude/skills/docs-notion/scripts/search.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Search Notion pages."""
+
+import argparse
+import json
+import sys
+
+from notion_client import notion_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search Notion pages")
+    parser.add_argument("--query", required=True)
+    parser.add_argument("--max-results", type=int, default=10)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        data = notion_request(
+            "POST",
+            "/search",
+            json_body={"query": args.query, "page_size": args.max_results},
+        )
+        results = []
+        for item in data.get("results", []):
+            if item["object"] == "page":
+                title = ""
+                if "properties" in item and "title" in item["properties"]:
+                    title_prop = item["properties"]["title"]
+                    if "title" in title_prop and title_prop["title"]:
+                        title = title_prop["title"][0]["text"]["content"]
+                results.append(
+                    {
+                        "id": item["id"],
+                        "title": title,
+                        "url": item.get("url"),
+                        "last_edited": item.get("last_edited_time"),
+                    }
+                )
+
+        if args.json:
+            print(json.dumps(results, indent=2))
+        else:
+            print(f"Found: {len(results)} pages")
+            for r in results:
+                print(f"  {r['title'] or '(untitled)'}")
+                print(f"    ID: {r['id']} | Edited: {r.get('last_edited', '?')}")
+                if r.get("url"):
+                    print(f"    {r['url']}")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/docs-notion/scripts/write_content.py
+++ b/sre-agent/.claude/skills/docs-notion/scripts/write_content.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Write or append content to a Notion page."""
+
+import argparse
+import json
+import sys
+
+from notion_client import notion_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Write to Notion page")
+    parser.add_argument("--page-id", required=True)
+    parser.add_argument("--content", required=True)
+    parser.add_argument(
+        "--replace", action="store_true", help="Replace content (default: append)"
+    )
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        children = []
+        for para in args.content.split("\n\n"):
+            if para.strip():
+                children.append(
+                    {
+                        "object": "block",
+                        "type": "paragraph",
+                        "paragraph": {
+                            "rich_text": [
+                                {"type": "text", "text": {"content": para.strip()}}
+                            ]
+                        },
+                    }
+                )
+
+        if args.replace:
+            blocks = notion_request("GET", f"/blocks/{args.page_id}/children")
+            for block in blocks.get("results", []):
+                try:
+                    notion_request("DELETE", f"/blocks/{block['id']}")
+                except Exception:
+                    pass
+
+        notion_request(
+            "PATCH",
+            f"/blocks/{args.page_id}/children",
+            json_body={"children": children},
+        )
+
+        result = {
+            "page_id": args.page_id,
+            "success": True,
+            "blocks_added": len(children),
+        }
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            action = "Replaced" if args.replace else "Appended"
+            print(f"{action} {len(children)} blocks to page {args.page_id}")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-blameless/SKILL.md
+++ b/sre-agent/.claude/skills/incident-blameless/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: incident-blameless
+description: Blameless incident management and retrospectives. Use for listing incidents, analyzing MTTR, reviewing post-incident retrospectives with contributing factors, action items, and lessons learned.
+allowed-tools: Bash(python *)
+---
+
+# Blameless Integration
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `BLAMELESS_API_KEY` in environment variables. Just run the scripts directly.
+
+Configuration environment variables you CAN check (non-secret):
+- `BLAMELESS_BASE_URL` - Proxy base URL (set automatically in production)
+- `BLAMELESS_INSTANCE_URL` - Custom instance URL (default: https://api.blameless.io)
+
+---
+
+## Available Scripts
+
+All scripts are in `.claude/skills/incident-blameless/scripts/`
+
+### list_incidents.py - List Incidents
+```bash
+python .claude/skills/incident-blameless/scripts/list_incidents.py [--status resolved] [--severity SEV1] [--max-results N]
+```
+
+### get_incident.py - Get Incident Details
+```bash
+python .claude/skills/incident-blameless/scripts/get_incident.py --incident-id ID
+```
+
+### get_incident_timeline.py - Timeline Events
+```bash
+python .claude/skills/incident-blameless/scripts/get_incident_timeline.py --incident-id ID [--max-results 50]
+```
+
+### list_incidents_by_date_range.py - Historical with MTTR
+```bash
+python .claude/skills/incident-blameless/scripts/list_incidents_by_date_range.py --since "2024-01-01T00:00:00Z" --until "2024-01-31T23:59:59Z"
+```
+
+### list_severities.py - Severity Levels
+```bash
+python .claude/skills/incident-blameless/scripts/list_severities.py
+```
+
+### get_retrospective.py - Post-Incident Retrospective
+```bash
+python .claude/skills/incident-blameless/scripts/get_retrospective.py --incident-id ID
+```
+Returns contributing factors, action items, root cause, lessons learned.
+
+### get_alert_analytics.py - Incident Pattern Analysis
+```bash
+python .claude/skills/incident-blameless/scripts/get_alert_analytics.py --since "2024-01-01T00:00:00Z" --until "2024-01-31T23:59:59Z"
+```
+
+### calculate_mttr.py - MTTR Statistics
+```bash
+python .claude/skills/incident-blameless/scripts/calculate_mttr.py [--severity SEV1] [--days 30]
+```

--- a/sre-agent/.claude/skills/incident-blameless/scripts/blameless_client.py
+++ b/sre-agent/.claude/skills/incident-blameless/scripts/blameless_client.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Shared Blameless API client with proxy support."""
+
+import os
+
+import httpx
+
+
+def get_base_url() -> str:
+    proxy_url = os.getenv("BLAMELESS_BASE_URL")
+    if proxy_url:
+        return proxy_url.rstrip("/")
+    instance = os.getenv("BLAMELESS_INSTANCE_URL", "https://api.blameless.io").rstrip(
+        "/"
+    )
+    return f"{instance}/api/v1"
+
+
+def get_headers() -> dict[str, str]:
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    api_key = os.getenv("BLAMELESS_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    else:
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            headers["X-Tenant-Id"] = os.getenv("OPENSRE_TENANT_ID", "local")
+            headers["X-Team-Id"] = os.getenv("OPENSRE_TEAM_ID", "local")
+    return headers
+
+
+def blameless_request(method, path, params=None, json_body=None):
+    base_url = get_base_url()
+    url = f"{base_url}/{path.lstrip('/')}"
+    with httpx.Client(timeout=30.0) as client:
+        response = client.request(
+            method, url, headers=get_headers(), params=params, json=json_body
+        )
+        response.raise_for_status()
+        if response.status_code == 204:
+            return None
+        return response.json()

--- a/sre-agent/.claude/skills/incident-blameless/scripts/calculate_mttr.py
+++ b/sre-agent/.claude/skills/incident-blameless/scripts/calculate_mttr.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Calculate MTTR statistics for Blameless incidents."""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+from blameless_client import blameless_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Calculate MTTR")
+    parser.add_argument("--severity", help="Severity filter (SEV0-SEV4)")
+    parser.add_argument("--days", type=int, default=30)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        since = (datetime.now(timezone.utc) - timedelta(days=args.days)).isoformat()
+        until = datetime.now(timezone.utc).isoformat()
+        params = {"limit": 100, "created_after": since, "created_before": until}
+        if args.severity:
+            params["severity"] = args.severity
+
+        mttr_values, page = [], 1
+        while True:
+            params["page"] = page
+            data = blameless_request("GET", "/incidents", params=params)
+            incidents = data.get("incidents", data.get("data", []))
+            if not incidents:
+                break
+            for inc in incidents:
+                c, r = inc.get("created_at", ""), inc.get("resolved_at")
+                if c and r:
+                    try:
+                        mttr = (
+                            datetime.fromisoformat(r.replace("Z", "+00:00"))
+                            - datetime.fromisoformat(c.replace("Z", "+00:00"))
+                        ).total_seconds() / 60
+                        mttr_values.append(mttr)
+                    except (ValueError, KeyError, TypeError):
+                        pass
+            page += 1
+            if len(incidents) < params["limit"]:
+                break
+
+        mttr_values.sort()
+        if not mttr_values:
+            result = {
+                "severity": args.severity,
+                "period_days": args.days,
+                "incident_count": 0,
+                "message": "No resolved incidents",
+            }
+        else:
+            count = len(mttr_values)
+            avg = sum(mttr_values) / count
+            result = {
+                "severity": args.severity,
+                "period_days": args.days,
+                "incident_count": count,
+                "mttr_minutes": round(avg, 2),
+                "mttr_hours": round(avg / 60, 2),
+                "median_minutes": round(mttr_values[count // 2], 2),
+                "p95_minutes": (
+                    round(mttr_values[int(count * 0.95)], 2)
+                    if count > 1
+                    else round(mttr_values[0], 2)
+                ),
+                "fastest_resolution_minutes": round(min(mttr_values), 2),
+                "slowest_resolution_minutes": round(max(mttr_values), 2),
+            }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"MTTR Statistics (last {args.days} days)")
+            if args.severity:
+                print(f"Severity: {args.severity}")
+            print(f"Incidents: {result.get('incident_count', 0)}")
+            if result.get("mttr_minutes"):
+                print(
+                    f"Avg: {result['mttr_minutes']} min | Median: {result['median_minutes']} min | P95: {result['p95_minutes']} min"
+                )
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-blameless/scripts/get_alert_analytics.py
+++ b/sre-agent/.claude/skills/incident-blameless/scripts/get_alert_analytics.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Analyze Blameless incident patterns for fatigue reduction."""
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from datetime import datetime
+
+from blameless_client import blameless_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get alert analytics")
+    parser.add_argument("--since", required=True)
+    parser.add_argument("--until", required=True)
+    parser.add_argument("--severity", help="Severity filter")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        params = {
+            "limit": 100,
+            "created_after": args.since,
+            "created_before": args.until,
+        }
+        if args.severity:
+            params["severity"] = args.severity
+
+        all_incidents, page = [], 1
+        while len(all_incidents) < 1000:
+            params["page"] = page
+            data = blameless_request("GET", "/incidents", params=params)
+            incidents = data.get("incidents", data.get("data", []))
+            if not incidents:
+                break
+            for inc in incidents:
+                mttr = None
+                c, r = inc.get("created_at", ""), inc.get("resolved_at")
+                if c and r:
+                    try:
+                        mttr = round(
+                            (
+                                datetime.fromisoformat(r.replace("Z", "+00:00"))
+                                - datetime.fromisoformat(c.replace("Z", "+00:00"))
+                            ).total_seconds()
+                            / 60,
+                            2,
+                        )
+                    except (ValueError, KeyError, TypeError):
+                        pass
+                all_incidents.append(
+                    {
+                        "title": (inc.get("title") or "Unknown")[:100],
+                        "status": inc.get("status"),
+                        "severity": inc.get("severity"),
+                        "created_at": c,
+                        "mttr_minutes": mttr,
+                    }
+                )
+            page += 1
+            if len(incidents) < params["limit"]:
+                break
+
+        title_stats = defaultdict(
+            lambda: {
+                "fire_count": 0,
+                "resolved_count": 0,
+                "mttr_values": [],
+                "hours": defaultdict(int),
+                "severities": defaultdict(int),
+            }
+        )
+        for inc in all_incidents:
+            s = title_stats[inc["title"]]
+            s["fire_count"] += 1
+            s["severities"][inc.get("severity") or "Unknown"] += 1
+            if inc["status"] in ("resolved", "closed"):
+                s["resolved_count"] += 1
+            if inc["mttr_minutes"]:
+                s["mttr_values"].append(inc["mttr_minutes"])
+            if inc["created_at"]:
+                try:
+                    s["hours"][
+                        datetime.fromisoformat(
+                            inc["created_at"].replace("Z", "+00:00")
+                        ).hour
+                    ] += 1
+                except (ValueError, KeyError, TypeError):
+                    pass
+
+        analytics = []
+        for title, s in title_stats.items():
+            fc = s["fire_count"]
+            avg_mttr = (
+                round(sum(s["mttr_values"]) / len(s["mttr_values"]), 2)
+                if s["mttr_values"]
+                else None
+            )
+            is_noisy = fc > 10
+            is_flapping = fc > 20 and avg_mttr and avg_mttr < 10
+            off_hours = sum(s["hours"].get(h, 0) for h in [0, 1, 2, 3, 4, 5, 22, 23])
+            analytics.append(
+                {
+                    "incident_title": title,
+                    "fire_count": fc,
+                    "resolved_count": s["resolved_count"],
+                    "avg_mttr_minutes": avg_mttr,
+                    "off_hours_rate": round(off_hours / fc * 100, 1) if fc > 0 else 0,
+                    "classification": {
+                        "is_noisy": is_noisy,
+                        "is_flapping": is_flapping,
+                        "reason": (
+                            "High frequency"
+                            if is_noisy
+                            else ("Quick auto-resolve" if is_flapping else None)
+                        ),
+                    },
+                }
+            )
+        analytics.sort(key=lambda x: x["fire_count"], reverse=True)
+
+        result = {
+            "ok": True,
+            "period": {"since": args.since, "until": args.until},
+            "summary": {
+                "total_unique": len(analytics),
+                "total_count": len(all_incidents),
+                "noisy": sum(1 for a in analytics if a["classification"]["is_noisy"]),
+                "flapping": sum(
+                    1 for a in analytics if a["classification"]["is_flapping"]
+                ),
+            },
+            "alert_analytics": analytics[:50],
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Period: {args.since} to {args.until}")
+            print(f"Unique: {len(analytics)} | Total: {len(all_incidents)}")
+            for a in analytics[:20]:
+                tag = (
+                    " [NOISY]"
+                    if a["classification"]["is_noisy"]
+                    else (" [FLAPPING]" if a["classification"]["is_flapping"] else "")
+                )
+                print(f"  {a['fire_count']}x {a['incident_title']}{tag}")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-blameless/scripts/get_incident.py
+++ b/sre-agent/.claude/skills/incident-blameless/scripts/get_incident.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Get details of a specific Blameless incident."""
+
+import argparse
+import json
+import sys
+
+from blameless_client import blameless_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Blameless incident details")
+    parser.add_argument("--incident-id", required=True)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        data = blameless_request("GET", f"/incidents/{args.incident_id}")
+        inc = data.get("incident", data)
+        roles = [
+            {
+                "role": r.get("role") or r.get("name"),
+                "assignee": (
+                    r.get("user", {}).get("name")
+                    if isinstance(r.get("user"), dict)
+                    else r.get("assignee")
+                ),
+            }
+            for r in inc.get("roles", [])
+        ]
+
+        result = {
+            "id": inc.get("id"),
+            "title": inc.get("title") or inc.get("name"),
+            "description": inc.get("description"),
+            "status": inc.get("status"),
+            "severity": inc.get("severity"),
+            "created_at": inc.get("created_at"),
+            "resolved_at": inc.get("resolved_at"),
+            "commander": (
+                inc.get("commander", {}).get("name")
+                if isinstance(inc.get("commander"), dict)
+                else inc.get("commander")
+            ),
+            "communication_lead": (
+                inc.get("communication_lead", {}).get("name")
+                if isinstance(inc.get("communication_lead"), dict)
+                else inc.get("communication_lead")
+            ),
+            "roles": roles,
+            "slack_channel": inc.get("slack_channel") or inc.get("slack_channel_name"),
+            "postmortem_url": inc.get("postmortem_url") or inc.get("retrospective_url"),
+            "url": inc.get("url") or inc.get("permalink"),
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Incident: {result['title']}")
+            print(f"Status: {result['status']} | Severity: {result['severity']}")
+            print(f"Commander: {result.get('commander', 'N/A')}")
+            if roles:
+                print("Roles:")
+                for r in roles:
+                    print(f"  {r['role']}: {r['assignee']}")
+            if result.get("postmortem_url"):
+                print(f"Postmortem: {result['postmortem_url']}")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-blameless/scripts/get_incident_timeline.py
+++ b/sre-agent/.claude/skills/incident-blameless/scripts/get_incident_timeline.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Get timeline entries for a Blameless incident."""
+
+import argparse
+import json
+import sys
+
+from blameless_client import blameless_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get incident timeline")
+    parser.add_argument("--incident-id", required=True)
+    parser.add_argument("--max-results", type=int, default=50)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        data = blameless_request(
+            "GET",
+            f"/incidents/{args.incident_id}/events",
+            params={"limit": args.max_results},
+        )
+        events = data.get("events", data.get("data", []))
+        result = [
+            {
+                "id": e.get("id"),
+                "type": e.get("type") or e.get("event_type"),
+                "description": e.get("description")
+                or e.get("message")
+                or e.get("summary"),
+                "created_at": e.get("created_at") or e.get("timestamp"),
+                "user": (
+                    e.get("user", {}).get("name")
+                    if isinstance(e.get("user"), dict)
+                    else e.get("user")
+                ),
+            }
+            for e in events
+        ]
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Timeline for incident {args.incident_id}: {len(result)} events")
+            for e in result:
+                print(
+                    f"  [{e.get('created_at', '?')}] {e.get('type', '?')} - {e.get('description', '')[:100]}"
+                )
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-blameless/scripts/get_retrospective.py
+++ b/sre-agent/.claude/skills/incident-blameless/scripts/get_retrospective.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Get the retrospective for a Blameless incident.
+
+Returns contributing factors, action items, root cause, and lessons learned.
+"""
+
+import argparse
+import json
+import sys
+
+from blameless_client import blameless_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get incident retrospective")
+    parser.add_argument("--incident-id", required=True)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        data = blameless_request("GET", f"/incidents/{args.incident_id}/retrospective")
+        retro = data.get("retrospective", data)
+
+        contributing_factors = [
+            {
+                "id": f.get("id"),
+                "description": f.get("description"),
+                "category": f.get("category"),
+            }
+            for f in retro.get("contributing_factors", [])
+        ]
+        action_items = [
+            {
+                "id": a.get("id"),
+                "title": a.get("title") or a.get("description"),
+                "status": a.get("status"),
+                "priority": a.get("priority"),
+                "due_date": a.get("due_date"),
+                "assignee": (
+                    a.get("assignee", {}).get("name")
+                    if isinstance(a.get("assignee"), dict)
+                    else a.get("assignee")
+                ),
+            }
+            for a in retro.get("action_items", [])
+        ]
+
+        result = {
+            "incident_id": args.incident_id,
+            "summary": retro.get("summary") or retro.get("description"),
+            "impact": retro.get("impact"),
+            "root_cause": retro.get("root_cause"),
+            "contributing_factors": contributing_factors,
+            "action_items": action_items,
+            "lessons_learned": retro.get("lessons_learned", []),
+            "status": retro.get("status"),
+            "url": retro.get("url") or retro.get("permalink"),
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Retrospective for incident {args.incident_id}")
+            if result.get("summary"):
+                print(f"Summary: {result['summary']}")
+            if result.get("root_cause"):
+                print(f"Root Cause: {result['root_cause']}")
+            if result.get("impact"):
+                print(f"Impact: {result['impact']}")
+            if contributing_factors:
+                print(f"\nContributing Factors ({len(contributing_factors)}):")
+                for f in contributing_factors:
+                    print(f"  [{f.get('category', '?')}] {f['description']}")
+            if action_items:
+                print(f"\nAction Items ({len(action_items)}):")
+                for a in action_items:
+                    print(
+                        f"  [{a.get('status', '?')}] {a['title']} (assignee: {a.get('assignee', '?')})"
+                    )
+            if result.get("lessons_learned"):
+                print("\nLessons Learned:")
+                for l in result["lessons_learned"]:
+                    print(f"  - {l}")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-blameless/scripts/list_incidents.py
+++ b/sre-agent/.claude/skills/incident-blameless/scripts/list_incidents.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""List Blameless incidents with optional filters."""
+
+import argparse
+import json
+import sys
+
+from blameless_client import blameless_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Blameless incidents")
+    parser.add_argument(
+        "--status", help="Filter: investigating, identified, monitoring, resolved"
+    )
+    parser.add_argument("--severity", help="Filter: SEV0-SEV4")
+    parser.add_argument("--incident-type", help="Filter by incident type")
+    parser.add_argument("--max-results", type=int, default=100)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        params = {"limit": min(args.max_results, 100)}
+        if args.status:
+            params["status"] = args.status
+        if args.severity:
+            params["severity"] = args.severity
+        if args.incident_type:
+            params["type"] = args.incident_type
+
+        all_incidents, page = [], 1
+        while len(all_incidents) < args.max_results:
+            params["page"] = page
+            data = blameless_request("GET", "/incidents", params=params)
+            incidents = data.get("incidents", data.get("data", []))
+            if not incidents:
+                break
+            for inc in incidents:
+                all_incidents.append(
+                    {
+                        "id": inc.get("id"),
+                        "title": inc.get("title") or inc.get("name"),
+                        "status": inc.get("status"),
+                        "severity": inc.get("severity"),
+                        "created_at": inc.get("created_at"),
+                        "resolved_at": inc.get("resolved_at"),
+                        "commander": (
+                            inc.get("commander", {}).get("name")
+                            if isinstance(inc.get("commander"), dict)
+                            else inc.get("commander")
+                        ),
+                        "url": inc.get("url") or inc.get("permalink"),
+                    }
+                )
+            page += 1
+            if len(incidents) < params["limit"]:
+                break
+
+        by_status, by_severity = {}, {}
+        for i in all_incidents:
+            by_status[i["status"] or "unknown"] = (
+                by_status.get(i["status"] or "unknown", 0) + 1
+            )
+            by_severity[i["severity"] or "unknown"] = (
+                by_severity.get(i["severity"] or "unknown", 0) + 1
+            )
+
+        result = {
+            "ok": True,
+            "total_count": len(all_incidents),
+            "summary": {"by_status": by_status, "by_severity": by_severity},
+            "incidents": all_incidents,
+        }
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Found: {len(all_incidents)} incidents")
+            for i in all_incidents:
+                print(
+                    f"  [{i.get('severity', '?')}] {i.get('title', '')} - {i.get('status', '?')}"
+                )
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-blameless/scripts/list_incidents_by_date_range.py
+++ b/sre-agent/.claude/skills/incident-blameless/scripts/list_incidents_by_date_range.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""List Blameless incidents within a date range with MTTR computation."""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+
+from blameless_client import blameless_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List incidents by date range")
+    parser.add_argument("--since", required=True, help="Start date (ISO)")
+    parser.add_argument("--until", required=True, help="End date (ISO)")
+    parser.add_argument("--severity", help="Severity filter (SEV0-SEV4)")
+    parser.add_argument("--max-results", type=int, default=500)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        params = {
+            "limit": 100,
+            "created_after": args.since,
+            "created_before": args.until,
+        }
+        if args.severity:
+            params["severity"] = args.severity
+
+        all_incidents, page = [], 1
+        while len(all_incidents) < args.max_results:
+            params["page"] = page
+            data = blameless_request("GET", "/incidents", params=params)
+            incidents = data.get("incidents", data.get("data", []))
+            if not incidents:
+                break
+            for inc in incidents:
+                mttr = None
+                created, resolved = inc.get("created_at", ""), inc.get("resolved_at")
+                if created and resolved:
+                    try:
+                        c = datetime.fromisoformat(created.replace("Z", "+00:00"))
+                        r = datetime.fromisoformat(resolved.replace("Z", "+00:00"))
+                        mttr = round((r - c).total_seconds() / 60, 2)
+                    except (ValueError, TypeError):
+                        pass
+                all_incidents.append(
+                    {
+                        "id": inc.get("id"),
+                        "title": inc.get("title") or inc.get("name"),
+                        "status": inc.get("status"),
+                        "severity": inc.get("severity"),
+                        "created_at": created,
+                        "resolved_at": resolved,
+                        "mttr_minutes": mttr,
+                        "commander": (
+                            inc.get("commander", {}).get("name")
+                            if isinstance(inc.get("commander"), dict)
+                            else inc.get("commander")
+                        ),
+                    }
+                )
+            page += 1
+            if len(incidents) < params["limit"]:
+                break
+
+        mttr_values = sorted(
+            [i["mttr_minutes"] for i in all_incidents if i["mttr_minutes"]]
+        )
+        by_severity = {}
+        for i in all_incidents:
+            s = i["severity"] or "Unknown"
+            by_severity[s] = by_severity.get(s, 0) + 1
+
+        result = {
+            "ok": True,
+            "period": {"since": args.since, "until": args.until},
+            "total_incidents": len(all_incidents),
+            "summary": {
+                "resolved_count": len(mttr_values),
+                "avg_mttr_minutes": (
+                    round(sum(mttr_values) / len(mttr_values), 2)
+                    if mttr_values
+                    else None
+                ),
+                "median_mttr_minutes": (
+                    round(mttr_values[len(mttr_values) // 2], 2)
+                    if mttr_values
+                    else None
+                ),
+            },
+            "by_severity": by_severity,
+            "incidents": all_incidents,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Period: {args.since} to {args.until}")
+            print(f"Total: {len(all_incidents)} | Resolved: {len(mttr_values)}")
+            if mttr_values:
+                print(
+                    f"Avg MTTR: {result['summary']['avg_mttr_minutes']} min | Median: {result['summary']['median_mttr_minutes']} min"
+                )
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-blameless/scripts/list_severities.py
+++ b/sre-agent/.claude/skills/incident-blameless/scripts/list_severities.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""List all Blameless severity levels."""
+
+import argparse
+import json
+import sys
+
+from blameless_client import blameless_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List severities")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        data = blameless_request("GET", "/severities")
+        severities = [
+            {
+                "id": s.get("id"),
+                "name": s.get("name"),
+                "description": s.get("description"),
+                "rank": s.get("rank") or s.get("order"),
+            }
+            for s in data.get("severities", data.get("data", []))
+        ]
+
+        if args.json:
+            print(json.dumps(severities, indent=2))
+        else:
+            print(f"Severities: {len(severities)}")
+            for s in severities:
+                print(f"  [{s['id']}] {s['name']} (rank: {s.get('rank', '?')})")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-comms/SKILL.md
+++ b/sre-agent/.claude/skills/incident-comms/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: incident-comms
+description: Slack integration for incident communication. Use when searching for context in incident channels, posting status updates, or finding discussions about issues.
+allowed-tools: Bash(python *)
+---
+
+# Incident Communications
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `SLACK_BOT_TOKEN` in environment variables — it won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+## Bot Token Permissions
+
+You authenticate as a **bot** (not a user). This means:
+
+| Can do | Cannot do |
+|--------|-----------|
+| List channels (`conversations.list`) | **Search messages** (`search.messages` — requires user token) |
+| Read channel history (if bot is a member) | Read channels the bot hasn't been added to |
+| Read thread replies | Access DMs between other users |
+| Post messages and thread replies | |
+| Look up user profiles | |
+
+**If search is requested**: Do NOT attempt `search_messages.py` — it will fail with a `missing_scope` error. Instead, use the channel-scanning workflow below.
+
+---
+
+## Available Scripts
+
+All scripts are in `.claude/skills/incident-comms/scripts/`
+
+### list_channels.py — List Channels
+```bash
+python .claude/skills/incident-comms/scripts/list_channels.py [--types TYPE] [--limit N] [--filter NAME]
+
+# Examples:
+python .claude/skills/incident-comms/scripts/list_channels.py
+python .claude/skills/incident-comms/scripts/list_channels.py --filter incident
+python .claude/skills/incident-comms/scripts/list_channels.py --types public_channel --limit 500
+```
+
+### get_channel_history.py — Read Channel Messages
+```bash
+python .claude/skills/incident-comms/scripts/get_channel_history.py --channel CHANNEL_ID [--limit N]
+
+# Examples:
+python .claude/skills/incident-comms/scripts/get_channel_history.py --channel C123ABC456
+python .claude/skills/incident-comms/scripts/get_channel_history.py --channel C123ABC456 --limit 100
+```
+
+### get_thread_replies.py — Read Thread Replies
+```bash
+python .claude/skills/incident-comms/scripts/get_thread_replies.py --channel CHANNEL_ID --thread THREAD_TS [--limit N]
+
+# Examples:
+python .claude/skills/incident-comms/scripts/get_thread_replies.py --channel C123ABC456 --thread 1705320123.456789
+```
+
+### post_message.py — Post Status Updates
+```bash
+python .claude/skills/incident-comms/scripts/post_message.py --channel CHANNEL_ID --text MESSAGE [--thread THREAD_TS]
+
+# Examples:
+python .claude/skills/incident-comms/scripts/post_message.py --channel C123ABC456 --text "Investigation update: found root cause"
+python .claude/skills/incident-comms/scripts/post_message.py --channel C123ABC456 --text "Rollback completed" --thread 1705320123.456789
+```
+
+---
+
+## Workflows
+
+### Finding Recent Activity (Bot-Compatible Search Alternative)
+
+Since `search.messages` requires a user token, use this workflow instead:
+
+```bash
+# Step 1: Find relevant channels
+python .claude/skills/incident-comms/scripts/list_channels.py --filter incident
+
+# Step 2: Read recent history from channels the bot is in (★ in list)
+python .claude/skills/incident-comms/scripts/get_channel_history.py --channel C_INCIDENTS --limit 50
+
+# Step 3: Dive into interesting threads
+python .claude/skills/incident-comms/scripts/get_thread_replies.py --channel C_INCIDENTS --thread 1705320123.456789
+```
+
+Scan multiple channels to build context. Focus on channels with names like `#incidents`, `#alerts`, `#engineering`, `#support`.
+
+### Gather Context for New Incident
+
+```bash
+# Find incident-related channels
+python .claude/skills/incident-comms/scripts/list_channels.py --filter incident
+
+# Check the incident channel for recent activity
+python .claude/skills/incident-comms/scripts/get_channel_history.py --channel C_INCIDENTS --limit 50
+
+# Read a specific thread
+python .claude/skills/incident-comms/scripts/get_thread_replies.py --channel C_INCIDENTS --thread 1705320123.456789
+```
+
+### Post Investigation Summary
+
+```bash
+python .claude/skills/incident-comms/scripts/post_message.py --channel C_INCIDENTS --thread 1705320123.456789 --text ":clipboard: *Investigation Summary*
+
+*Timeline:*
+• 14:00 - Alerts started firing
+• 14:05 - Investigation began
+• 14:15 - Root cause identified
+• 14:20 - Fix deployed
+
+*Root Cause:*
+Connection pool exhaustion due to unclosed connections.
+
+*Resolution:*
+Rolled back to v2.3.4, deployed fix in v2.3.5."
+```
+
+---
+
+## Quick Reference
+
+| Goal | Command |
+|------|---------|
+| List channels | `list_channels.py` |
+| Filter channels by name | `list_channels.py --filter incident` |
+| Channel history | `get_channel_history.py --channel C123ABC` |
+| Thread replies | `get_thread_replies.py --channel C123ABC --thread TS` |
+| Post update | `post_message.py --channel C123ABC --text "Update"` |
+| Reply to thread | `post_message.py --channel C123ABC --text "..." --thread TS` |
+
+---
+
+## Status Update Templates
+
+**Investigation Started:**
+```
+:mag: *Investigation Started*
+
+Investigating: [Brief description of symptoms]
+Initial findings: [What you've found so far]
+Current hypothesis: [What you think might be wrong]
+
+Will update in 15 minutes.
+```
+
+**Root Cause Identified:**
+```
+:bulb: *Root Cause Identified*
+
+Cause: [Clear explanation]
+Impact: [What was affected]
+Mitigation: [What we're doing to fix it]
+
+ETA for resolution: [Time estimate]
+```
+
+**Resolved:**
+```
+:white_check_mark: *Incident Resolved*
+
+Root cause: [Brief summary]
+Resolution: [What fixed it]
+Duration: [How long the incident lasted]
+
+Follow-up: [Next steps, postmortem timing]
+```
+
+---
+
+## Best Practices
+
+### Reading Channels
+- **List first**: Use `list_channels.py` to find channel IDs — don't guess
+- **Check membership**: Only channels marked ★ can be read (bot must be a member)
+- **Scan multiple**: Check `#incidents`, `#alerts`, `#engineering`, `#support`, etc.
+
+### Posting Updates
+- **Use threads**: Keep updates in the incident thread, not the main channel
+- **Be concise**: Busy responders scan updates quickly
+- **Include next steps**: Always say what's happening next
+
+### Anti-Patterns
+1. Do NOT use `search_messages.py` — it requires a user token and will fail
+2. Do NOT post before reading — check what's already been discussed
+3. Do NOT guess channel IDs — use `list_channels.py` to find them

--- a/sre-agent/.claude/skills/incident-comms/scripts/__init__.py
+++ b/sre-agent/.claude/skills/incident-comms/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Slack incident communication scripts

--- a/sre-agent/.claude/skills/incident-comms/scripts/get_channel_history.py
+++ b/sre-agent/.claude/skills/incident-comms/scripts/get_channel_history.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Get message history from a Slack channel.
+
+Usage:
+    python get_channel_history.py --channel CHANNEL_ID [--limit N]
+
+Examples:
+    python get_channel_history.py --channel C123ABC456
+    python get_channel_history.py --channel C123ABC456 --limit 50
+"""
+
+import argparse
+import json
+import sys
+
+from slack_client import format_message, get_channel_history
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Get message history from a Slack channel"
+    )
+    parser.add_argument(
+        "--channel",
+        required=True,
+        help="Channel ID (e.g., C123ABC456)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Maximum messages to return (default: 50)",
+    )
+    parser.add_argument(
+        "--oldest",
+        help="Start timestamp (Unix)",
+    )
+    parser.add_argument(
+        "--latest",
+        help="End timestamp (Unix)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    try:
+        result = get_channel_history(
+            channel_id=args.channel,
+            limit=args.limit,
+            oldest=args.oldest,
+            latest=args.latest,
+        )
+
+        messages = result.get("messages", [])
+        has_more = result.get("has_more", False)
+
+        if args.json:
+            output = {
+                "channel_id": args.channel,
+                "message_count": len(messages),
+                "has_more": has_more,
+                "messages": [
+                    {
+                        "timestamp": m.get("ts"),
+                        "user": m.get("user"),
+                        "text": m.get("text", "")[:1000],
+                        "thread_ts": m.get("thread_ts"),
+                        "reply_count": m.get("reply_count", 0),
+                    }
+                    for m in messages
+                ],
+            }
+            print(json.dumps(output, indent=2))
+        else:
+            print("=" * 60)
+            print(f"CHANNEL HISTORY: {args.channel}")
+            print("=" * 60)
+            print(f"Messages: {len(messages)}")
+            print(f"Has more: {has_more}")
+            print()
+
+            if not messages:
+                print("No messages found in channel.")
+            else:
+                # Messages are in reverse chronological order
+                for msg in reversed(messages):
+                    print(format_message(msg))
+                    if msg.get("thread_ts") and msg.get("reply_count"):
+                        print(
+                            f"  └── Thread with {msg['reply_count']} replies (ts: {msg['thread_ts']})"
+                        )
+                    print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-comms/scripts/get_thread_replies.py
+++ b/sre-agent/.claude/skills/incident-comms/scripts/get_thread_replies.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Get replies in a Slack thread.
+
+Usage:
+    python get_thread_replies.py --channel CHANNEL_ID --thread THREAD_TS [--limit N]
+
+Examples:
+    python get_thread_replies.py --channel C123ABC456 --thread 1705320123.456789
+    python get_thread_replies.py --channel C123ABC456 --thread 1705320123.456789 --limit 50
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from slack_client import format_message, get_thread_replies
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get replies in a Slack thread")
+    parser.add_argument(
+        "--channel", required=True, help="Channel ID (e.g., C123ABC456)"
+    )
+    parser.add_argument(
+        "--thread",
+        required=True,
+        help="Thread parent timestamp (e.g., 1705320123.456789)",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=100, help="Max replies to return (default: 100)"
+    )
+    args = parser.parse_args()
+
+    try:
+        result = get_thread_replies(args.channel, args.thread, limit=args.limit)
+        messages = result.get("messages", [])
+
+        if not messages:
+            print("No messages found in this thread.")
+            return
+
+        print(f"THREAD REPLIES ({len(messages)} messages)")
+        print("=" * 70)
+        for msg in messages:
+            print(format_message(msg))
+            print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-comms/scripts/list_channels.py
+++ b/sre-agent/.claude/skills/incident-comms/scripts/list_channels.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""List Slack channels the bot has access to.
+
+Usage:
+    python list_channels.py [--types public_channel,private_channel] [--limit N]
+
+Examples:
+    python list_channels.py
+    python list_channels.py --types public_channel
+    python list_channels.py --limit 500
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from slack_client import api_request
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="List Slack channels the bot can access"
+    )
+    parser.add_argument(
+        "--types",
+        default="public_channel,private_channel",
+        help="Channel types (default: public_channel,private_channel)",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=200, help="Max channels to return (default: 200)"
+    )
+    parser.add_argument(
+        "--filter",
+        help="Filter channels by name substring (case-insensitive)",
+    )
+    args = parser.parse_args()
+
+    try:
+        channels = []
+        cursor = None
+
+        while len(channels) < args.limit:
+            params = {
+                "types": args.types,
+                "limit": min(200, args.limit - len(channels)),
+                "exclude_archived": "true",
+            }
+            if cursor:
+                params["cursor"] = cursor
+
+            result = api_request("GET", "/conversations.list", params=params)
+            batch = result.get("channels", [])
+            channels.extend(batch)
+
+            cursor = result.get("response_metadata", {}).get("next_cursor")
+            if not cursor or not batch:
+                break
+
+        # Apply name filter if specified
+        if args.filter:
+            filter_lower = args.filter.lower()
+            channels = [
+                c for c in channels if filter_lower in c.get("name", "").lower()
+            ]
+
+        if not channels:
+            print("No channels found.")
+            return
+
+        print(f"CHANNELS ({len(channels)} total)")
+        print("=" * 70)
+        for ch in channels:
+            name = ch.get("name", "unknown")
+            ch_id = ch.get("id", "")
+            purpose = (ch.get("purpose", {}).get("value", "") or "")[:60]
+            member_count = ch.get("num_members", "?")
+            is_member = "★" if ch.get("is_member") else " "
+
+            print(f"{is_member} #{name:<30} {ch_id}  ({member_count} members)")
+            if purpose:
+                print(f"    {purpose}")
+
+        print()
+        print("★ = bot is a member (can read history)")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-comms/scripts/post_message.py
+++ b/sre-agent/.claude/skills/incident-comms/scripts/post_message.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Post a message to a Slack channel.
+
+Usage:
+    python post_message.py --channel CHANNEL_ID --text MESSAGE [--thread THREAD_TS]
+
+Examples:
+    python post_message.py --channel C123ABC456 --text "Investigation update: found root cause"
+    python post_message.py --channel C123ABC456 --text "Rollback completed" --thread 1705320123.456789
+"""
+
+import argparse
+import json
+import sys
+
+from slack_client import post_message
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Post a message to a Slack channel")
+    parser.add_argument(
+        "--channel",
+        required=True,
+        help="Channel ID (e.g., C123ABC456)",
+    )
+    parser.add_argument(
+        "--text",
+        required=True,
+        help="Message text (supports Slack markdown)",
+    )
+    parser.add_argument(
+        "--thread",
+        help="Thread timestamp to reply to",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    try:
+        result = post_message(
+            channel_id=args.channel,
+            text=args.text,
+            thread_ts=args.thread,
+        )
+
+        message = result.get("message", {})
+
+        if args.json:
+            output = {
+                "success": True,
+                "channel": result.get("channel"),
+                "timestamp": message.get("ts"),
+                "text": message.get("text"),
+            }
+            print(json.dumps(output, indent=2))
+        else:
+            print("=" * 60)
+            print("MESSAGE POSTED SUCCESSFULLY")
+            print("=" * 60)
+            print(f"Channel: {result.get('channel')}")
+            print(f"Timestamp: {message.get('ts')}")
+            if args.thread:
+                print(f"Thread: {args.thread}")
+            print()
+            print("Message:")
+            print("-" * 40)
+            print(message.get("text", args.text))
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-comms/scripts/search_messages.py
+++ b/sre-agent/.claude/skills/incident-comms/scripts/search_messages.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Search for messages across Slack channels.
+
+Usage:
+    python search_messages.py --query SEARCH_QUERY [--count N]
+
+Examples:
+    python search_messages.py --query "error timeout"
+    python search_messages.py --query "in:#incidents api error"
+    python search_messages.py --query "from:@oncall database" --count 30
+"""
+
+import argparse
+import json
+import sys
+
+from slack_client import format_message, search_messages
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Search for messages across Slack channels"
+    )
+    parser.add_argument(
+        "--query",
+        required=True,
+        help="Search query (supports Slack search operators)",
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=20,
+        help="Number of results (default: 20)",
+    )
+    parser.add_argument(
+        "--sort",
+        choices=["score", "timestamp"],
+        default="timestamp",
+        help="Sort field (default: timestamp)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    try:
+        result = search_messages(
+            query=args.query,
+            count=args.count,
+            sort=args.sort,
+        )
+
+        messages = result.get("messages", {}).get("matches", [])
+        total = result.get("messages", {}).get("total", 0)
+
+        if args.json:
+            output = {
+                "query": args.query,
+                "total_matches": total,
+                "returned": len(messages),
+                "messages": [
+                    {
+                        "timestamp": m.get("ts"),
+                        "user": m.get("user") or m.get("username"),
+                        "channel": m.get("channel", {}).get("name"),
+                        "text": m.get("text", "")[:1000],
+                        "permalink": m.get("permalink"),
+                    }
+                    for m in messages
+                ],
+            }
+            print(json.dumps(output, indent=2))
+        else:
+            print("=" * 60)
+            print("SLACK SEARCH RESULTS")
+            print("=" * 60)
+            print(f"Query: {args.query}")
+            print(f"Total matches: {total}")
+            print(f"Showing: {len(messages)} results")
+            print()
+
+            if not messages:
+                print("No messages found matching your query.")
+            else:
+                for msg in messages:
+                    channel_name = msg.get("channel", {}).get("name", "unknown")
+                    print(f"#{channel_name}")
+                    print(format_message(msg))
+                    if msg.get("permalink"):
+                        print(f"  Link: {msg['permalink']}")
+                    print("-" * 40)
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-comms/scripts/slack_client.py
+++ b/sre-agent/.claude/skills/incident-comms/scripts/slack_client.py
@@ -1,0 +1,286 @@
+"""Shared Slack API client with credential proxy support.
+
+This client is designed to work with the OpenSRE credential proxy.
+Credentials are injected automatically - scripts should NOT check for
+SLACK_BOT_TOKEN in environment variables.
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+def get_config() -> dict[str, Any]:
+    """Load configuration from standard locations."""
+    config = {}
+
+    # Check for config file
+    config_paths = [
+        Path.home() / ".opensre" / "config.json",
+        Path("/etc/opensre/config.json"),
+    ]
+
+    for path in config_paths:
+        if path.exists():
+            with open(path) as f:
+                config = json.load(f)
+                break
+
+    # Environment overrides
+    if os.getenv("TENANT_ID"):
+        config["tenant_id"] = os.getenv("TENANT_ID")
+    if os.getenv("TEAM_ID"):
+        config["team_id"] = os.getenv("TEAM_ID")
+
+    return config
+
+
+def get_api_url(endpoint: str) -> str:
+    """Get the Slack API URL for an endpoint.
+
+    In production, this routes through the credential proxy.
+    """
+    base_url = os.getenv("SLACK_BASE_URL")
+    if not base_url:
+        # Fall back to direct API (for local development only)
+        base_url = "https://slack.com/api"
+
+    return f"{base_url.rstrip('/')}{endpoint}"
+
+
+def get_headers() -> dict[str, str]:
+    """Get headers for Slack API requests.
+
+    The credential proxy will inject Authorization header.
+    """
+    config = get_config()
+
+    headers = {
+        "Content-Type": "application/json; charset=utf-8",
+    }
+
+    # Proxy mode - use JWT for credential-resolver auth
+    sandbox_jwt = os.getenv("SANDBOX_JWT")
+    if sandbox_jwt:
+        headers["X-Sandbox-JWT"] = sandbox_jwt
+    else:
+        # Fallback for local dev
+        headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+        headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    # For local development, allow direct token usage
+    token = os.getenv("SLACK_BOT_TOKEN")
+    if token and not os.getenv("SLACK_BASE_URL"):
+        headers["Authorization"] = f"Bearer {token}"
+
+    return headers
+
+
+def api_request(
+    method: str,
+    endpoint: str,
+    params: dict[str, Any] | None = None,
+    json_data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Make a request to the Slack API.
+
+    Args:
+        method: HTTP method
+        endpoint: API endpoint
+        params: Query parameters
+        json_data: JSON body
+
+    Returns:
+        Parsed JSON response
+
+    Raises:
+        RuntimeError: If the request fails
+    """
+    url = get_api_url(endpoint)
+    headers = get_headers()
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.request(
+            method=method,
+            url=url,
+            headers=headers,
+            params=params,
+            json=json_data,
+        )
+
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"Slack API error {response.status_code}: {response.text}"
+            )
+
+        if not response.text:
+            # Empty response from credential-resolver means the Slack proxy
+            # endpoint is not deployed. The catch-all ext_authz handler returns
+            # 200 with empty body for unrecognized paths.
+            raise RuntimeError(
+                "Slack proxy returned empty response. "
+                "The credential-resolver may need to be redeployed, "
+                "or Slack credentials are not configured for this workspace."
+            )
+
+        data = response.json()
+        if not data.get("ok"):
+            raise RuntimeError(f"Slack API error: {data.get('error', 'unknown')}")
+
+        return data
+
+
+def search_messages(
+    query: str,
+    count: int = 20,
+    sort: str = "timestamp",
+    sort_dir: str = "desc",
+) -> dict[str, Any]:
+    """Search for messages across channels.
+
+    Args:
+        query: Search query (supports Slack search operators)
+        count: Number of results to return
+        sort: Sort field (score, timestamp)
+        sort_dir: Sort direction (asc, desc)
+
+    Returns:
+        Search results with messages
+    """
+    return api_request(
+        "GET",
+        "/search.messages",
+        params={
+            "query": query,
+            "count": count,
+            "sort": sort,
+            "sort_dir": sort_dir,
+        },
+    )
+
+
+def get_channel_history(
+    channel_id: str,
+    limit: int = 100,
+    oldest: str | None = None,
+    latest: str | None = None,
+) -> dict[str, Any]:
+    """Get message history from a channel.
+
+    Args:
+        channel_id: Channel ID (e.g., C123ABC)
+        limit: Maximum messages to return
+        oldest: Start timestamp (Unix)
+        latest: End timestamp (Unix)
+
+    Returns:
+        Channel history with messages
+    """
+    params = {"channel": channel_id, "limit": limit}
+    if oldest:
+        params["oldest"] = oldest
+    if latest:
+        params["latest"] = latest
+
+    return api_request("GET", "/conversations.history", params=params)
+
+
+def get_thread_replies(
+    channel_id: str,
+    thread_ts: str,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """Get replies to a thread.
+
+    Args:
+        channel_id: Channel ID
+        thread_ts: Thread parent timestamp
+        limit: Maximum replies to return
+
+    Returns:
+        Thread replies
+    """
+    return api_request(
+        "GET",
+        "/conversations.replies",
+        params={
+            "channel": channel_id,
+            "ts": thread_ts,
+            "limit": limit,
+        },
+    )
+
+
+def post_message(
+    channel_id: str,
+    text: str,
+    thread_ts: str | None = None,
+) -> dict[str, Any]:
+    """Post a message to a channel.
+
+    Args:
+        channel_id: Channel ID
+        text: Message text (supports Slack markdown)
+        thread_ts: Optional thread timestamp to reply to
+
+    Returns:
+        Posted message details
+    """
+    data = {"channel": channel_id, "text": text}
+    if thread_ts:
+        data["thread_ts"] = thread_ts
+
+    return api_request("POST", "/chat.postMessage", json_data=data)
+
+
+def get_user_info(user_id: str) -> dict[str, Any]:
+    """Get user information.
+
+    Args:
+        user_id: User ID (e.g., U123ABC)
+
+    Returns:
+        User profile information
+    """
+    return api_request("GET", "/users.info", params={"user": user_id})
+
+
+def format_message(message: dict[str, Any], include_user: bool = True) -> str:
+    """Format a Slack message for display.
+
+    Args:
+        message: Message object from API
+        include_user: Whether to include user info
+
+    Returns:
+        Formatted string
+    """
+    ts = message.get("ts", "")
+    text = message.get("text", "")[:500]  # Truncate long messages
+    user = message.get("user", "unknown")
+    message.get("channel", {})
+
+    # Convert timestamp to readable format
+    if ts:
+        import datetime
+
+        try:
+            dt = datetime.datetime.fromtimestamp(float(ts))
+            time_str = dt.strftime("%Y-%m-%d %H:%M:%S")
+        except (ValueError, OSError):
+            time_str = ts
+    else:
+        time_str = "unknown"
+
+    output = f"[{time_str}]"
+    if include_user:
+        output += f" <{user}>"
+    output += f": {text}"
+
+    if message.get("reply_count"):
+        output += f" ({message['reply_count']} replies)"
+
+    return output

--- a/sre-agent/.claude/skills/incident-firehydrant/SKILL.md
+++ b/sre-agent/.claude/skills/incident-firehydrant/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: incident-firehydrant
+description: FireHydrant incident management with service catalog. Use for listing incidents, tracking milestones, analyzing MTTR, and service impact analysis across environments.
+allowed-tools: Bash(python *)
+---
+
+# FireHydrant Integration
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `FIREHYDRANT_API_KEY`. Just run the scripts directly.
+
+## Available Scripts
+
+All scripts are in `.claude/skills/incident-firehydrant/scripts/`
+
+### list_incidents.py
+```bash
+python .claude/skills/incident-firehydrant/scripts/list_incidents.py [--status open] [--severity SEV] [--environment-id ID] [--max-results N]
+```
+
+### get_incident.py
+```bash
+python .claude/skills/incident-firehydrant/scripts/get_incident.py --incident-id ID
+```
+
+### get_incident_timeline.py
+```bash
+python .claude/skills/incident-firehydrant/scripts/get_incident_timeline.py --incident-id ID
+```
+
+### list_incidents_by_date_range.py
+```bash
+python .claude/skills/incident-firehydrant/scripts/list_incidents_by_date_range.py --since "2024-01-01T00:00:00Z" --until "2024-01-31T23:59:59Z"
+```
+
+### list_services.py / list_environments.py
+```bash
+python .claude/skills/incident-firehydrant/scripts/list_services.py
+python .claude/skills/incident-firehydrant/scripts/list_environments.py
+```
+
+### get_alert_analytics.py
+```bash
+python .claude/skills/incident-firehydrant/scripts/get_alert_analytics.py --since "2024-01-01T00:00:00Z" --until "2024-01-31T23:59:59Z" [--service-id ID]
+```
+
+### calculate_mttr.py
+```bash
+python .claude/skills/incident-firehydrant/scripts/calculate_mttr.py [--severity SEV] [--service-id ID] [--days 30]
+```

--- a/sre-agent/.claude/skills/incident-firehydrant/scripts/calculate_mttr.py
+++ b/sre-agent/.claude/skills/incident-firehydrant/scripts/calculate_mttr.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Calculate MTTR for FireHydrant incidents."""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+from firehydrant_client import firehydrant_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Calculate MTTR")
+    parser.add_argument("--severity", help="Severity filter")
+    parser.add_argument("--service-id", help="Service ID filter")
+    parser.add_argument("--days", type=int, default=30)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        since = (datetime.now(timezone.utc) - timedelta(days=args.days)).isoformat()
+        until = datetime.now(timezone.utc).isoformat()
+        params = {"per_page": 100, "start_date": since, "end_date": until}
+        if args.severity:
+            params["severity"] = args.severity
+
+        mttr_values, page = [], 1
+        while True:
+            params["page"] = page
+            data = firehydrant_request("GET", "/incidents", params=params)
+            incidents = data.get("data", [])
+            if not incidents:
+                break
+            for inc in incidents:
+                resolved_at = None
+                for ms in inc.get("milestones", []):
+                    if (ms.get("type") or ms.get("slug")) == "resolved":
+                        resolved_at = ms.get("occurred_at") or ms.get("created_at")
+                start = inc.get("started_at") or inc.get("created_at", "")
+                if start and resolved_at:
+                    try:
+                        mttr = (
+                            datetime.fromisoformat(resolved_at.replace("Z", "+00:00"))
+                            - datetime.fromisoformat(start.replace("Z", "+00:00"))
+                        ).total_seconds() / 60
+                        mttr_values.append(mttr)
+                    except (ValueError, KeyError, TypeError):
+                        pass
+            page += 1
+            if len(incidents) < params["per_page"]:
+                break
+
+        mttr_values.sort()
+        if not mttr_values:
+            result = {
+                "severity": args.severity,
+                "service_id": args.service_id,
+                "period_days": args.days,
+                "incident_count": 0,
+                "message": "No resolved incidents",
+            }
+        else:
+            count = len(mttr_values)
+            avg = sum(mttr_values) / count
+            result = {
+                "severity": args.severity,
+                "service_id": args.service_id,
+                "period_days": args.days,
+                "incident_count": count,
+                "mttr_minutes": round(avg, 2),
+                "mttr_hours": round(avg / 60, 2),
+                "median_minutes": round(mttr_values[count // 2], 2),
+                "p95_minutes": (
+                    round(mttr_values[int(count * 0.95)], 2)
+                    if count > 1
+                    else round(mttr_values[0], 2)
+                ),
+                "fastest_resolution_minutes": round(min(mttr_values), 2),
+                "slowest_resolution_minutes": round(max(mttr_values), 2),
+            }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(
+                f"MTTR (last {args.days} days): {result.get('incident_count', 0)} incidents"
+            )
+            if result.get("mttr_minutes"):
+                print(
+                    f"Avg: {result['mttr_minutes']} min | Median: {result['median_minutes']} min | P95: {result['p95_minutes']} min"
+                )
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-firehydrant/scripts/firehydrant_client.py
+++ b/sre-agent/.claude/skills/incident-firehydrant/scripts/firehydrant_client.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Shared FireHydrant API client with proxy support."""
+
+import os
+
+import httpx
+
+
+def get_base_url() -> str:
+    proxy_url = os.getenv("FIREHYDRANT_BASE_URL")
+    if proxy_url:
+        return proxy_url.rstrip("/")
+    return "https://api.firehydrant.io/v1"
+
+
+def get_headers() -> dict[str, str]:
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    api_key = os.getenv("FIREHYDRANT_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    else:
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            headers["X-Tenant-Id"] = os.getenv("OPENSRE_TENANT_ID", "local")
+            headers["X-Team-Id"] = os.getenv("OPENSRE_TEAM_ID", "local")
+    return headers
+
+
+def firehydrant_request(method, path, params=None, json_body=None):
+    url = f"{get_base_url()}/{path.lstrip('/')}"
+    with httpx.Client(timeout=30.0) as client:
+        response = client.request(
+            method, url, headers=get_headers(), params=params, json=json_body
+        )
+        response.raise_for_status()
+        return None if response.status_code == 204 else response.json()

--- a/sre-agent/.claude/skills/incident-firehydrant/scripts/get_alert_analytics.py
+++ b/sre-agent/.claude/skills/incident-firehydrant/scripts/get_alert_analytics.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Analyze FireHydrant incident patterns for fatigue reduction."""
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from datetime import datetime
+
+from firehydrant_client import firehydrant_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get alert analytics")
+    parser.add_argument("--since", required=True)
+    parser.add_argument("--until", required=True)
+    parser.add_argument("--service-id", help="Optional service ID filter")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        params = {"per_page": 100, "start_date": args.since, "end_date": args.until}
+        all_incidents, page = [], 1
+        while len(all_incidents) < 1000:
+            params["page"] = page
+            data = firehydrant_request("GET", "/incidents", params=params)
+            incidents = data.get("data", [])
+            if not incidents:
+                break
+            for inc in incidents:
+                resolved_at = None
+                for ms in inc.get("milestones", []):
+                    if (ms.get("type") or ms.get("slug")) == "resolved":
+                        resolved_at = ms.get("occurred_at") or ms.get("created_at")
+                mttr = None
+                start = inc.get("started_at") or inc.get("created_at", "")
+                if start and resolved_at:
+                    try:
+                        mttr = round(
+                            (
+                                datetime.fromisoformat(
+                                    resolved_at.replace("Z", "+00:00")
+                                )
+                                - datetime.fromisoformat(start.replace("Z", "+00:00"))
+                            ).total_seconds()
+                            / 60,
+                            2,
+                        )
+                    except (ValueError, KeyError, TypeError):
+                        pass
+                all_incidents.append(
+                    {
+                        "name": (inc.get("name") or "Unknown")[:100],
+                        "status": inc.get("current_milestone"),
+                        "severity": inc.get("severity"),
+                        "created_at": inc.get("created_at"),
+                        "mttr_minutes": mttr,
+                        "services": [s.get("name") for s in inc.get("services", [])],
+                    }
+                )
+            page += 1
+            if len(incidents) < params["per_page"]:
+                break
+
+        stats = defaultdict(
+            lambda: {
+                "fire_count": 0,
+                "resolved_count": 0,
+                "mttr_values": [],
+                "hours": defaultdict(int),
+                "services": set(),
+            }
+        )
+        for inc in all_incidents:
+            s = stats[inc["name"]]
+            s["fire_count"] += 1
+            for svc in inc.get("services", []):
+                s["services"].add(svc)
+            if inc["status"] in ("resolved", "closed", "post_incident"):
+                s["resolved_count"] += 1
+            if inc["mttr_minutes"]:
+                s["mttr_values"].append(inc["mttr_minutes"])
+            if inc["created_at"]:
+                try:
+                    s["hours"][
+                        datetime.fromisoformat(
+                            inc["created_at"].replace("Z", "+00:00")
+                        ).hour
+                    ] += 1
+                except (ValueError, KeyError, TypeError):
+                    pass
+
+        analytics = []
+        for name, s in stats.items():
+            fc = s["fire_count"]
+            avg_mttr = (
+                round(sum(s["mttr_values"]) / len(s["mttr_values"]), 2)
+                if s["mttr_values"]
+                else None
+            )
+            is_noisy = fc > 10
+            is_flapping = fc > 20 and avg_mttr and avg_mttr < 10
+            off = sum(s["hours"].get(h, 0) for h in [0, 1, 2, 3, 4, 5, 22, 23])
+            analytics.append(
+                {
+                    "incident_name": name,
+                    "fire_count": fc,
+                    "avg_mttr_minutes": avg_mttr,
+                    "services": list(s["services"]),
+                    "off_hours_rate": round(off / fc * 100, 1) if fc > 0 else 0,
+                    "classification": {
+                        "is_noisy": is_noisy,
+                        "is_flapping": is_flapping,
+                        "reason": (
+                            "High frequency"
+                            if is_noisy
+                            else ("Quick auto-resolve" if is_flapping else None)
+                        ),
+                    },
+                }
+            )
+        analytics.sort(key=lambda x: x["fire_count"], reverse=True)
+
+        result = {
+            "ok": True,
+            "period": {"since": args.since, "until": args.until},
+            "summary": {
+                "total_unique": len(analytics),
+                "total_count": len(all_incidents),
+                "noisy": sum(1 for a in analytics if a["classification"]["is_noisy"]),
+            },
+            "alert_analytics": analytics[:50],
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Total: {len(all_incidents)} | Unique: {len(analytics)}")
+            for a in analytics[:20]:
+                tag = " [NOISY]" if a["classification"]["is_noisy"] else ""
+                print(f"  {a['fire_count']}x {a['incident_name']}{tag}")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-firehydrant/scripts/get_incident.py
+++ b/sre-agent/.claude/skills/incident-firehydrant/scripts/get_incident.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Get details of a specific FireHydrant incident."""
+
+import argparse
+import json
+import sys
+
+from firehydrant_client import firehydrant_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get FireHydrant incident details")
+    parser.add_argument("--incident-id", required=True)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        inc = firehydrant_request("GET", f"/incidents/{args.incident_id}")
+        milestones = [
+            {
+                "type": ms.get("type") or ms.get("slug"),
+                "occurred_at": ms.get("occurred_at") or ms.get("created_at"),
+                "duration_ms": ms.get("duration"),
+            }
+            for ms in inc.get("milestones", [])
+        ]
+        roles = [
+            {
+                "role": a.get("incident_role", {}).get("name"),
+                "user": a.get("user", {}).get("name"),
+                "email": a.get("user", {}).get("email"),
+            }
+            for a in inc.get("role_assignments", [])
+        ]
+
+        result = {
+            "id": inc.get("id"),
+            "name": inc.get("name"),
+            "description": inc.get("description"),
+            "status": inc.get("current_milestone"),
+            "severity": inc.get("severity"),
+            "created_at": inc.get("created_at"),
+            "customer_impact_summary": inc.get("customer_impact_summary"),
+            "milestones": milestones,
+            "role_assignments": roles,
+            "services": [
+                {"id": s.get("id"), "name": s.get("name")}
+                for s in inc.get("services", [])
+            ],
+            "environments": [
+                {"id": e.get("id"), "name": e.get("name")}
+                for e in inc.get("environments", [])
+            ],
+            "functionalities": [
+                {"id": f.get("id"), "name": f.get("name")}
+                for f in inc.get("functionalities", [])
+            ],
+            "slack_channel_name": inc.get("slack_channel_name"),
+            "incident_url": inc.get("incident_url"),
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Incident: {result['name']}")
+            print(f"Status: {result['status']} | Severity: {result['severity']}")
+            if roles:
+                print("Roles:")
+                for r in roles:
+                    print(f"  {r['role']}: {r['user']}")
+            if milestones:
+                print("Milestones:")
+                for m in milestones:
+                    print(f"  {m['type']}: {m['occurred_at']}")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-firehydrant/scripts/get_incident_timeline.py
+++ b/sre-agent/.claude/skills/incident-firehydrant/scripts/get_incident_timeline.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Get timeline events for a FireHydrant incident."""
+
+import argparse
+import json
+import sys
+
+from firehydrant_client import firehydrant_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get incident timeline")
+    parser.add_argument("--incident-id", required=True)
+    parser.add_argument("--max-results", type=int, default=50)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        data = firehydrant_request(
+            "GET",
+            f"/incidents/{args.incident_id}/events",
+            params={"per_page": args.max_results},
+        )
+        events = [
+            {
+                "id": e.get("id"),
+                "type": e.get("type"),
+                "occurred_at": e.get("occurred_at") or e.get("created_at"),
+                "description": e.get("description")
+                or e.get("body")
+                or e.get("summary"),
+                "author": (
+                    e.get("author", {}).get("name")
+                    if isinstance(e.get("author"), dict)
+                    else e.get("author")
+                ),
+                "visibility": e.get("visibility"),
+            }
+            for e in data.get("data", [])
+        ]
+
+        if args.json:
+            print(json.dumps(events, indent=2))
+        else:
+            print(f"Timeline: {len(events)} events")
+            for e in events:
+                print(
+                    f"  [{e.get('occurred_at', '?')}] {e.get('type', '?')} - {(e.get('description', '') or '')[:100]}"
+                )
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-firehydrant/scripts/list_environments.py
+++ b/sre-agent/.claude/skills/incident-firehydrant/scripts/list_environments.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""List all FireHydrant environments."""
+
+import argparse
+import json
+import sys
+
+from firehydrant_client import firehydrant_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List environments")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    try:
+        data = firehydrant_request("GET", "/environments", params={"per_page": 100})
+        envs = [
+            {
+                "id": e.get("id"),
+                "name": e.get("name"),
+                "description": e.get("description"),
+                "slug": e.get("slug"),
+                "active_incidents_count": len(e.get("active_incidents", [])),
+            }
+            for e in data.get("data", [])
+        ]
+
+        if args.json:
+            print(json.dumps(envs, indent=2))
+        else:
+            print(f"Environments: {len(envs)}")
+            for e in envs:
+                print(
+                    f"  {e['name']} ({e.get('slug', '')}) - {e['active_incidents_count']} active incidents"
+                )
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-firehydrant/scripts/list_incidents.py
+++ b/sre-agent/.claude/skills/incident-firehydrant/scripts/list_incidents.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""List FireHydrant incidents with optional filters."""
+
+import argparse
+import json
+import sys
+
+from firehydrant_client import firehydrant_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List FireHydrant incidents")
+    parser.add_argument("--status", help="Filter: open, in_progress, resolved, closed")
+    parser.add_argument("--severity", help="Filter by severity")
+    parser.add_argument("--environment-id", help="Filter by environment ID")
+    parser.add_argument("--max-results", type=int, default=100)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        params = {"per_page": min(args.max_results, 100)}
+        if args.status:
+            params["status"] = args.status
+        if args.severity:
+            params["severity"] = args.severity
+        if args.environment_id:
+            params["environment_id"] = args.environment_id
+
+        all_incidents, page = [], 1
+        while len(all_incidents) < args.max_results:
+            params["page"] = page
+            data = firehydrant_request("GET", "/incidents", params=params)
+            incidents = data.get("data", [])
+            if not incidents:
+                break
+            for inc in incidents:
+                milestones = {}
+                for ms in inc.get("milestones", []):
+                    ms_type = ms.get("type") or ms.get("slug")
+                    if ms_type:
+                        milestones[ms_type] = ms.get("occurred_at") or ms.get(
+                            "created_at"
+                        )
+                all_incidents.append(
+                    {
+                        "id": inc.get("id"),
+                        "name": inc.get("name"),
+                        "status": inc.get("current_milestone"),
+                        "severity": inc.get("severity"),
+                        "created_at": inc.get("created_at"),
+                        "resolved_at": milestones.get("resolved"),
+                        "services": [s.get("name") for s in inc.get("services", [])],
+                        "environments": [
+                            e.get("name") for e in inc.get("environments", [])
+                        ],
+                        "incident_url": inc.get("incident_url"),
+                    }
+                )
+            page += 1
+            if len(incidents) < params["per_page"]:
+                break
+
+        result = {
+            "ok": True,
+            "total_count": len(all_incidents),
+            "incidents": all_incidents,
+        }
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Found: {len(all_incidents)} incidents")
+            for i in all_incidents:
+                svcs = f" [{', '.join(i['services'])}]" if i["services"] else ""
+                print(f"  [{i.get('status', '?')}] {i.get('name', '')}{svcs}")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-firehydrant/scripts/list_incidents_by_date_range.py
+++ b/sre-agent/.claude/skills/incident-firehydrant/scripts/list_incidents_by_date_range.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""List FireHydrant incidents within a date range with MTTR."""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+
+from firehydrant_client import firehydrant_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List incidents by date range")
+    parser.add_argument("--since", required=True)
+    parser.add_argument("--until", required=True)
+    parser.add_argument("--severity", help="Severity filter")
+    parser.add_argument("--max-results", type=int, default=500)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        params = {"per_page": 100, "start_date": args.since, "end_date": args.until}
+        if args.severity:
+            params["severity"] = args.severity
+
+        all_incidents, page = [], 1
+        while len(all_incidents) < args.max_results:
+            params["page"] = page
+            data = firehydrant_request("GET", "/incidents", params=params)
+            incidents = data.get("data", [])
+            if not incidents:
+                break
+            for inc in incidents:
+                resolved_at = None
+                for ms in inc.get("milestones", []):
+                    if (ms.get("type") or ms.get("slug")) == "resolved":
+                        resolved_at = ms.get("occurred_at") or ms.get("created_at")
+                mttr = None
+                start = inc.get("started_at") or inc.get("created_at", "")
+                if start and resolved_at:
+                    try:
+                        mttr = round(
+                            (
+                                datetime.fromisoformat(
+                                    resolved_at.replace("Z", "+00:00")
+                                )
+                                - datetime.fromisoformat(start.replace("Z", "+00:00"))
+                            ).total_seconds()
+                            / 60,
+                            2,
+                        )
+                    except (ValueError, KeyError, TypeError):
+                        pass
+                all_incidents.append(
+                    {
+                        "id": inc.get("id"),
+                        "name": inc.get("name"),
+                        "status": inc.get("current_milestone"),
+                        "severity": inc.get("severity"),
+                        "created_at": inc.get("created_at"),
+                        "resolved_at": resolved_at,
+                        "mttr_minutes": mttr,
+                        "services": [s.get("name") for s in inc.get("services", [])],
+                    }
+                )
+            page += 1
+            if len(incidents) < params["per_page"]:
+                break
+
+        mttr_values = sorted(
+            [i["mttr_minutes"] for i in all_incidents if i["mttr_minutes"]]
+        )
+        by_severity, by_service = {}, {}
+        for i in all_incidents:
+            s = i["severity"] or "Unknown"
+            by_severity[s] = by_severity.get(s, 0) + 1
+            for svc in i.get("services", []):
+                if svc:
+                    by_service[svc] = by_service.get(svc, 0) + 1
+
+        result = {
+            "ok": True,
+            "period": {"since": args.since, "until": args.until},
+            "total_incidents": len(all_incidents),
+            "summary": {
+                "resolved_count": len(mttr_values),
+                "avg_mttr_minutes": (
+                    round(sum(mttr_values) / len(mttr_values), 2)
+                    if mttr_values
+                    else None
+                ),
+                "median_mttr_minutes": (
+                    round(mttr_values[len(mttr_values) // 2], 2)
+                    if mttr_values
+                    else None
+                ),
+            },
+            "by_severity": by_severity,
+            "by_service": dict(
+                sorted(by_service.items(), key=lambda x: x[1], reverse=True)[:10]
+            ),
+            "incidents": all_incidents,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Period: {args.since} to {args.until}")
+            print(f"Total: {len(all_incidents)} | Resolved: {len(mttr_values)}")
+            if mttr_values:
+                print(f"Avg MTTR: {result['summary']['avg_mttr_minutes']} min")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-firehydrant/scripts/list_services.py
+++ b/sre-agent/.claude/skills/incident-firehydrant/scripts/list_services.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""List all FireHydrant services."""
+
+import argparse
+import json
+import sys
+
+from firehydrant_client import firehydrant_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List services")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    try:
+        all_services, page = [], 1
+        while True:
+            data = firehydrant_request(
+                "GET", "/services", params={"per_page": 100, "page": page}
+            )
+            services = data.get("data", [])
+            if not services:
+                break
+            for s in services:
+                all_services.append(
+                    {
+                        "id": s.get("id"),
+                        "name": s.get("name"),
+                        "description": s.get("description"),
+                        "tier": s.get("service_tier"),
+                        "owner": (
+                            s.get("owner", {}).get("name")
+                            if isinstance(s.get("owner"), dict)
+                            else None
+                        ),
+                        "labels": s.get("labels", {}),
+                        "active_incidents_count": (
+                            len(s.get("active_incidents", []))
+                            if isinstance(s.get("active_incidents"), list)
+                            else 0
+                        ),
+                    }
+                )
+            page += 1
+            if len(services) < 100:
+                break
+
+        if args.json:
+            print(json.dumps(all_services, indent=2))
+        else:
+            print(f"Services: {len(all_services)}")
+            for s in all_services:
+                print(
+                    f"  {s['name']} (tier: {s.get('tier', '?')}, owner: {s.get('owner', '?')})"
+                )
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-incidentio/SKILL.md
+++ b/sre-agent/.claude/skills/incident-incidentio/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: incident-incidentio
+description: Incident.io incident management and analytics. Use for listing, searching, and analyzing incidents. Supports MTTR calculations, severity analysis, and alert fatigue detection via alert route analytics.
+allowed-tools: Bash(python *)
+---
+
+# Incident.io Integration
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `INCIDENTIO_API_KEY` in environment variables - they won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `INCIDENTIO_BASE_URL` - Proxy base URL (set automatically in production)
+
+---
+
+## Available Scripts
+
+All scripts are in `.claude/skills/incident-incidentio/scripts/`
+
+### list_incidents.py - List Incidents
+```bash
+python .claude/skills/incident-incidentio/scripts/list_incidents.py [--status STATUS] [--severity-id ID] [--max-results N]
+
+# Examples:
+python .claude/skills/incident-incidentio/scripts/list_incidents.py --status active
+python .claude/skills/incident-incidentio/scripts/list_incidents.py --status resolved --max-results 20
+```
+
+### get_incident.py - Get Incident Details
+```bash
+python .claude/skills/incident-incidentio/scripts/get_incident.py --incident-id INCIDENT_ID
+```
+
+### get_incident_updates.py - Get Timeline Updates
+```bash
+python .claude/skills/incident-incidentio/scripts/get_incident_updates.py --incident-id INCIDENT_ID [--max-results 50]
+```
+
+### list_incidents_by_date_range.py - Historical Incidents with MTTR
+```bash
+python .claude/skills/incident-incidentio/scripts/list_incidents_by_date_range.py --since "2024-01-01T00:00:00Z" --until "2024-01-31T23:59:59Z" [--status STATUS] [--max-results N]
+```
+
+### list_severities.py - List Severity Levels
+```bash
+python .claude/skills/incident-incidentio/scripts/list_severities.py
+```
+
+### list_incident_types.py - List Incident Types
+```bash
+python .claude/skills/incident-incidentio/scripts/list_incident_types.py
+```
+
+### get_alert_analytics.py - Alert Fatigue Analysis
+```bash
+python .claude/skills/incident-incidentio/scripts/get_alert_analytics.py --since "2024-01-01T00:00:00Z" --until "2024-01-31T23:59:59Z"
+```
+
+### calculate_mttr.py - MTTR Statistics
+```bash
+python .claude/skills/incident-incidentio/scripts/calculate_mttr.py [--severity-id ID] [--days 30]
+```
+
+---
+
+## Investigation Workflow
+
+### Incident Analysis
+```
+1. List recent incidents:
+   list_incidents.py --status active
+
+2. Get incident details:
+   get_incident.py --incident-id <id>
+
+3. Review timeline:
+   get_incident_updates.py --incident-id <id>
+
+4. Compute MTTR for severity assessment:
+   calculate_mttr.py --days 30
+```
+
+### Alert Fatigue Analysis
+```
+1. Get alert analytics for the period:
+   get_alert_analytics.py --since "2024-01-01T00:00:00Z" --until "2024-01-31T23:59:59Z"
+
+2. Review noisy routes (high fire count, low ack rate)
+
+3. Check historical MTTR by severity:
+   calculate_mttr.py --severity-id <sev_id>
+```

--- a/sre-agent/.claude/skills/incident-incidentio/scripts/calculate_mttr.py
+++ b/sre-agent/.claude/skills/incident-incidentio/scripts/calculate_mttr.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Calculate MTTR statistics for Incident.io incidents.
+
+Usage:
+    python calculate_mttr.py [--severity-id ID] [--days 30]
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+from incidentio_client import incidentio_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Calculate MTTR")
+    parser.add_argument("--severity-id", help="Optional severity ID filter")
+    parser.add_argument(
+        "--days", type=int, default=30, help="Days to analyze (default: 30)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        since = (datetime.now(timezone.utc) - timedelta(days=args.days)).isoformat()
+        until = datetime.now(timezone.utc).isoformat()
+
+        params = {
+            "page_size": 100,
+            "created_at[gte]": since,
+            "created_at[lte]": until,
+            "status": "closed",
+        }
+
+        all_incidents = []
+        next_cursor = None
+
+        while len(all_incidents) < 500:
+            if next_cursor:
+                params["after"] = next_cursor
+
+            data = incidentio_request("GET", "/incidents", params=params)
+            incidents = data.get("incidents", [])
+
+            if not incidents:
+                break
+
+            for inc in incidents:
+                created_at = datetime.fromisoformat(
+                    inc["created_at"].replace("Z", "+00:00")
+                )
+                resolved_at = inc.get("resolved_at")
+                mttr_minutes = None
+                if resolved_at:
+                    resolved_dt = datetime.fromisoformat(
+                        resolved_at.replace("Z", "+00:00")
+                    )
+                    mttr_minutes = (resolved_dt - created_at).total_seconds() / 60
+
+                all_incidents.append(
+                    {
+                        "severity": inc.get("severity", {}).get("name"),
+                        "severity_id": inc.get("severity", {}).get("id"),
+                        "mttr_minutes": (
+                            round(mttr_minutes, 2) if mttr_minutes else None
+                        ),
+                    }
+                )
+
+            pagination = data.get("pagination_meta", {})
+            if pagination.get("after"):
+                next_cursor = pagination["after"]
+            else:
+                break
+
+        # Filter by severity if specified
+        if args.severity_id:
+            all_incidents = [
+                i for i in all_incidents if i.get("severity_id") == args.severity_id
+            ]
+
+        mttr_values = sorted(
+            [i["mttr_minutes"] for i in all_incidents if i["mttr_minutes"]]
+        )
+
+        if not mttr_values:
+            result = {
+                "severity_id": args.severity_id,
+                "period_days": args.days,
+                "incident_count": 0,
+                "message": "No resolved incidents in this period",
+            }
+        else:
+            count = len(mttr_values)
+            avg_mttr = sum(mttr_values) / count
+            result = {
+                "severity_id": args.severity_id,
+                "period_days": args.days,
+                "incident_count": count,
+                "mttr_minutes": round(avg_mttr, 2),
+                "mttr_hours": round(avg_mttr / 60, 2),
+                "median_minutes": round(mttr_values[count // 2], 2),
+                "p95_minutes": (
+                    round(mttr_values[int(count * 0.95)], 2)
+                    if count > 1
+                    else round(mttr_values[0], 2)
+                ),
+                "fastest_resolution_minutes": round(min(mttr_values), 2),
+                "slowest_resolution_minutes": round(max(mttr_values), 2),
+            }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"MTTR Statistics (last {args.days} days)")
+            if args.severity_id:
+                print(f"Severity filter: {args.severity_id}")
+            print(f"Incidents analyzed: {result.get('incident_count', 0)}")
+            if result.get("mttr_minutes"):
+                print(
+                    f"Average MTTR: {result['mttr_minutes']} min ({result['mttr_hours']} hrs)"
+                )
+                print(f"Median MTTR: {result['median_minutes']} min")
+                print(f"P95 MTTR: {result['p95_minutes']} min")
+                print(f"Fastest: {result['fastest_resolution_minutes']} min")
+                print(f"Slowest: {result['slowest_resolution_minutes']} min")
+            else:
+                print(result.get("message", "No data"))
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-incidentio/scripts/get_alert_analytics.py
+++ b/sre-agent/.claude/skills/incident-incidentio/scripts/get_alert_analytics.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Analyze Incident.io alert patterns for fatigue reduction.
+
+Usage:
+    python get_alert_analytics.py --since "2024-01-01T00:00:00Z" --until "2024-01-31T23:59:59Z"
+"""
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from datetime import datetime
+
+from incidentio_client import incidentio_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get alert analytics")
+    parser.add_argument("--since", required=True, help="Start date (ISO format)")
+    parser.add_argument("--until", required=True, help="End date (ISO format)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        params = {
+            "page_size": 100,
+            "created_at[gte]": args.since,
+            "created_at[lte]": args.until,
+        }
+
+        all_alerts = []
+        next_cursor = None
+
+        while True:
+            if next_cursor:
+                params["after"] = next_cursor
+
+            data = incidentio_request("GET", "/alerts", params=params)
+            alerts = data.get("alerts", [])
+
+            if not alerts:
+                break
+
+            all_alerts.extend(alerts)
+
+            pagination = data.get("pagination_meta", {})
+            if pagination.get("after"):
+                next_cursor = pagination["after"]
+            else:
+                break
+
+        route_stats = defaultdict(
+            lambda: {
+                "fire_count": 0,
+                "acknowledged_count": 0,
+                "hours_distribution": defaultdict(int),
+            }
+        )
+
+        for alert in all_alerts:
+            route = alert.get("alert_route", {}).get("name", "Unknown")
+            stats = route_stats[route]
+            stats["fire_count"] += 1
+            if alert.get("status") == "acknowledged":
+                stats["acknowledged_count"] += 1
+            created = datetime.fromisoformat(alert["created_at"].replace("Z", "+00:00"))
+            stats["hours_distribution"][created.hour] += 1
+
+        route_analytics = []
+        for route, stats in route_stats.items():
+            fire_count = stats["fire_count"]
+            ack_count = stats["acknowledged_count"]
+            ack_rate = round(ack_count / fire_count * 100, 1) if fire_count > 0 else 0
+
+            hours_dist = dict(stats["hours_distribution"])
+            off_hours_count = sum(
+                hours_dist.get(h, 0) for h in [0, 1, 2, 3, 4, 5, 22, 23]
+            )
+            off_hours_rate = (
+                round(off_hours_count / fire_count * 100, 1) if fire_count > 0 else 0
+            )
+
+            is_noisy = fire_count > 10 and ack_rate < 50
+
+            route_analytics.append(
+                {
+                    "route": route,
+                    "fire_count": fire_count,
+                    "acknowledgment_rate": ack_rate,
+                    "off_hours_rate": off_hours_rate,
+                    "classification": {
+                        "is_noisy": is_noisy,
+                        "reason": "High frequency, low ack rate" if is_noisy else None,
+                    },
+                }
+            )
+
+        route_analytics.sort(key=lambda x: x["fire_count"], reverse=True)
+        noisy_routes = sum(
+            1 for r in route_analytics if r["classification"]["is_noisy"]
+        )
+
+        result = {
+            "ok": True,
+            "period": {"since": args.since, "until": args.until},
+            "summary": {
+                "total_alerts": len(all_alerts),
+                "unique_routes": len(route_analytics),
+                "noisy_routes_count": noisy_routes,
+            },
+            "route_analytics": route_analytics[:30],
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Period: {args.since} to {args.until}")
+            print(f"Total alerts: {len(all_alerts)}")
+            print(f"Unique routes: {len(route_analytics)}")
+            print(f"Noisy routes: {noisy_routes}")
+            print()
+            for r in route_analytics[:20]:
+                noisy = " [NOISY]" if r["classification"]["is_noisy"] else ""
+                print(
+                    f"  {r['route']}: {r['fire_count']} fires, {r['acknowledgment_rate']}% ack rate{noisy}"
+                )
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-incidentio/scripts/get_incident.py
+++ b/sre-agent/.claude/skills/incident-incidentio/scripts/get_incident.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Get details of a specific Incident.io incident.
+
+Usage:
+    python get_incident.py --incident-id INCIDENT_ID
+"""
+
+import argparse
+import json
+import sys
+
+from incidentio_client import incidentio_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Incident.io incident details")
+    parser.add_argument("--incident-id", required=True, help="Incident ID")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        data = incidentio_request("GET", f"/incidents/{args.incident_id}")
+        incident = data.get("incident", {})
+
+        roles = []
+        for role in incident.get("incident_role_assignments", []):
+            roles.append(
+                {
+                    "role": role.get("role", {}).get("name"),
+                    "assignee": role.get("assignee", {}).get("name"),
+                }
+            )
+
+        custom_fields = [
+            {
+                "name": cf.get("custom_field", {}).get("name"),
+                "value": cf.get("value_text")
+                or cf.get("value_option", {}).get("value"),
+            }
+            for cf in incident.get("custom_field_entries", [])
+        ]
+
+        result = {
+            "id": incident["id"],
+            "name": incident.get("name"),
+            "reference": incident.get("reference"),
+            "status": incident.get("status", {}).get("category"),
+            "severity": incident.get("severity", {}).get("name"),
+            "created_at": incident.get("created_at"),
+            "updated_at": incident.get("updated_at"),
+            "resolved_at": incident.get("resolved_at"),
+            "summary": incident.get("summary"),
+            "postmortem_document_url": incident.get("postmortem_document_url"),
+            "slack_channel_id": incident.get("slack_channel_id"),
+            "slack_channel_name": incident.get("slack_channel_name"),
+            "roles": roles,
+            "custom_fields": custom_fields,
+            "url": incident.get("permalink"),
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Incident: {result.get('reference', '')} - {result.get('name', '')}")
+            print(f"Status: {result.get('status', '?')}")
+            print(f"Severity: {result.get('severity', '?')}")
+            print(f"Created: {result.get('created_at', '?')}")
+            if result.get("resolved_at"):
+                print(f"Resolved: {result['resolved_at']}")
+            if result.get("summary"):
+                print(f"Summary: {result['summary']}")
+            if roles:
+                print("Roles:")
+                for r in roles:
+                    print(f"  {r['role']}: {r['assignee']}")
+            if custom_fields:
+                print("Custom Fields:")
+                for cf in custom_fields:
+                    print(f"  {cf['name']}: {cf['value']}")
+            if result.get("url"):
+                print(f"URL: {result['url']}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-incidentio/scripts/get_incident_updates.py
+++ b/sre-agent/.claude/skills/incident-incidentio/scripts/get_incident_updates.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Get timeline updates for an Incident.io incident.
+
+Usage:
+    python get_incident_updates.py --incident-id INCIDENT_ID [--max-results 50]
+"""
+
+import argparse
+import json
+import sys
+
+from incidentio_client import incidentio_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get incident timeline updates")
+    parser.add_argument("--incident-id", required=True, help="Incident ID")
+    parser.add_argument(
+        "--max-results", type=int, default=50, help="Maximum results (default: 50)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        data = incidentio_request(
+            "GET",
+            "/incident_updates",
+            params={"incident_id": args.incident_id, "page_size": args.max_results},
+        )
+
+        updates = []
+        for update in data.get("incident_updates", []):
+            updates.append(
+                {
+                    "id": update["id"],
+                    "created_at": update.get("created_at"),
+                    "message": update.get("message"),
+                    "updater": update.get("updater", {}).get("name"),
+                    "new_status": update.get("new_incident_status", {}).get("category"),
+                    "new_severity": update.get("new_severity", {}).get("name"),
+                }
+            )
+
+        if args.json:
+            print(json.dumps(updates, indent=2))
+        else:
+            print(
+                f"Timeline updates for incident {args.incident_id}: {len(updates)} entries"
+            )
+            print()
+            for u in updates:
+                print(f"  [{u.get('created_at', '?')}] {u.get('updater', 'Unknown')}")
+                if u.get("new_status"):
+                    print(f"    Status changed to: {u['new_status']}")
+                if u.get("new_severity"):
+                    print(f"    Severity changed to: {u['new_severity']}")
+                if u.get("message"):
+                    print(f"    {u['message']}")
+                print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-incidentio/scripts/incidentio_client.py
+++ b/sre-agent/.claude/skills/incident-incidentio/scripts/incidentio_client.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Shared Incident.io API client with proxy support.
+
+Credentials are injected transparently by the proxy layer.
+"""
+
+import os
+
+import httpx
+
+
+def get_base_url() -> str:
+    """Get Incident.io API base URL.
+
+    Supports two modes:
+    1. Proxy mode (production): Uses INCIDENTIO_BASE_URL
+    2. Direct mode (testing): Uses https://api.incident.io/v2
+    """
+    proxy_url = os.getenv("INCIDENTIO_BASE_URL")
+    if proxy_url:
+        return proxy_url.rstrip("/")
+    return "https://api.incident.io/v2"
+
+
+def get_headers() -> dict[str, str]:
+    """Get API headers.
+
+    In proxy mode: includes tenant context for credential lookup.
+    In direct mode: includes Bearer auth with API key.
+    """
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    api_key = os.getenv("INCIDENTIO_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    else:
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            headers["X-Tenant-Id"] = os.getenv("OPENSRE_TENANT_ID", "local")
+            headers["X-Team-Id"] = os.getenv("OPENSRE_TEAM_ID", "local")
+
+    return headers
+
+
+def incidentio_request(
+    method: str,
+    path: str,
+    params: dict | None = None,
+    json_body: dict | None = None,
+) -> dict | list | None:
+    """Make a request to Incident.io API."""
+    base_url = get_base_url()
+    url = f"{base_url}/{path.lstrip('/')}"
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.request(
+            method,
+            url,
+            headers=get_headers(),
+            params=params,
+            json=json_body,
+        )
+        response.raise_for_status()
+        if response.status_code == 204:
+            return None
+        return response.json()

--- a/sre-agent/.claude/skills/incident-incidentio/scripts/list_incident_types.py
+++ b/sre-agent/.claude/skills/incident-incidentio/scripts/list_incident_types.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""List all Incident.io incident types.
+
+Usage:
+    python list_incident_types.py [--json]
+"""
+
+import argparse
+import json
+import sys
+
+from incidentio_client import incidentio_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List incident types")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        data = incidentio_request("GET", "/incident_types")
+        types = []
+        for t in data.get("incident_types", []):
+            types.append(
+                {
+                    "id": t["id"],
+                    "name": t["name"],
+                    "description": t.get("description"),
+                    "is_default": t.get("is_default", False),
+                }
+            )
+
+        if args.json:
+            print(json.dumps(types, indent=2))
+        else:
+            print(f"Incident types: {len(types)}")
+            for t in types:
+                default = " (default)" if t.get("is_default") else ""
+                print(f"  [{t['id']}] {t['name']}{default}")
+                if t.get("description"):
+                    print(f"    {t['description']}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-incidentio/scripts/list_incidents.py
+++ b/sre-agent/.claude/skills/incident-incidentio/scripts/list_incidents.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""List Incident.io incidents with optional filters.
+
+Usage:
+    python list_incidents.py [--status active] [--severity-id ID] [--max-results 100]
+"""
+
+import argparse
+import json
+import sys
+
+from incidentio_client import incidentio_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Incident.io incidents")
+    parser.add_argument(
+        "--status", help="Filter by status (triage, active, resolved, closed)"
+    )
+    parser.add_argument("--severity-id", help="Filter by severity ID")
+    parser.add_argument(
+        "--max-results", type=int, default=100, help="Maximum results (default: 100)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        params = {"page_size": min(args.max_results, 100)}
+        if args.status:
+            params["status"] = args.status
+        if args.severity_id:
+            params["severity_id"] = args.severity_id
+
+        all_incidents = []
+        next_cursor = None
+
+        while len(all_incidents) < args.max_results:
+            if next_cursor:
+                params["after"] = next_cursor
+
+            data = incidentio_request("GET", "/incidents", params=params)
+            incidents = data.get("incidents", [])
+
+            if not incidents:
+                break
+
+            for inc in incidents:
+                all_incidents.append(
+                    {
+                        "id": inc["id"],
+                        "name": inc.get("name"),
+                        "reference": inc.get("reference"),
+                        "status": inc.get("status", {}).get("category"),
+                        "severity": inc.get("severity", {}).get("name"),
+                        "created_at": inc.get("created_at"),
+                        "updated_at": inc.get("updated_at"),
+                        "summary": inc.get("summary"),
+                        "incident_lead": inc.get("incident_lead", {}).get("name"),
+                        "url": inc.get("permalink"),
+                    }
+                )
+
+            pagination = data.get("pagination_meta", {})
+            if pagination.get("after"):
+                next_cursor = pagination["after"]
+            else:
+                break
+
+        by_status = {}
+        by_severity = {}
+        for inc in all_incidents:
+            s = inc.get("status") or "unknown"
+            by_status[s] = by_status.get(s, 0) + 1
+            sev = inc.get("severity") or "unknown"
+            by_severity[sev] = by_severity.get(sev, 0) + 1
+
+        result = {
+            "ok": True,
+            "total_count": len(all_incidents),
+            "summary": {"by_status": by_status, "by_severity": by_severity},
+            "incidents": all_incidents,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Found: {len(all_incidents)} incidents")
+            if by_status:
+                print(
+                    f"By status: {', '.join(f'{k}: {v}' for k, v in by_status.items())}"
+                )
+            if by_severity:
+                print(
+                    f"By severity: {', '.join(f'{k}: {v}' for k, v in by_severity.items())}"
+                )
+            print()
+            for inc in all_incidents:
+                print(
+                    f"  [{inc.get('status', '?')}] {inc.get('reference', '')} - {inc.get('name', '')}"
+                )
+                print(
+                    f"    Severity: {inc.get('severity', '?')} | Lead: {inc.get('incident_lead', 'Unassigned')}"
+                )
+                if inc.get("url"):
+                    print(f"    URL: {inc['url']}")
+                print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-incidentio/scripts/list_incidents_by_date_range.py
+++ b/sre-agent/.claude/skills/incident-incidentio/scripts/list_incidents_by_date_range.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""List Incident.io incidents within a date range with MTTR computation.
+
+Usage:
+    python list_incidents_by_date_range.py --since "2024-01-01T00:00:00Z" --until "2024-01-31T23:59:59Z"
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+
+from incidentio_client import incidentio_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List incidents by date range")
+    parser.add_argument("--since", required=True, help="Start date (ISO format)")
+    parser.add_argument("--until", required=True, help="End date (ISO format)")
+    parser.add_argument("--status", help="Optional status filter")
+    parser.add_argument(
+        "--max-results", type=int, default=500, help="Maximum results (default: 500)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        params = {
+            "page_size": 100,
+            "created_at[gte]": args.since,
+            "created_at[lte]": args.until,
+        }
+        if args.status:
+            params["status"] = args.status
+
+        all_incidents = []
+        next_cursor = None
+
+        while len(all_incidents) < args.max_results:
+            if next_cursor:
+                params["after"] = next_cursor
+
+            data = incidentio_request("GET", "/incidents", params=params)
+            incidents = data.get("incidents", [])
+
+            if not incidents:
+                break
+
+            for inc in incidents:
+                created_at = datetime.fromisoformat(
+                    inc["created_at"].replace("Z", "+00:00")
+                )
+                mttr_minutes = None
+                resolved_at = inc.get("resolved_at")
+                if resolved_at:
+                    resolved_dt = datetime.fromisoformat(
+                        resolved_at.replace("Z", "+00:00")
+                    )
+                    mttr_minutes = (resolved_dt - created_at).total_seconds() / 60
+
+                all_incidents.append(
+                    {
+                        "id": inc["id"],
+                        "name": inc.get("name"),
+                        "reference": inc.get("reference"),
+                        "status": inc.get("status", {}).get("category"),
+                        "severity": inc.get("severity", {}).get("name"),
+                        "created_at": inc["created_at"],
+                        "resolved_at": resolved_at,
+                        "mttr_minutes": (
+                            round(mttr_minutes, 2) if mttr_minutes else None
+                        ),
+                        "incident_lead": inc.get("incident_lead", {}).get("name"),
+                        "url": inc.get("permalink"),
+                    }
+                )
+
+            pagination = data.get("pagination_meta", {})
+            if pagination.get("after"):
+                next_cursor = pagination["after"]
+            else:
+                break
+
+        resolved = [i for i in all_incidents if i["mttr_minutes"]]
+        mttr_values = [i["mttr_minutes"] for i in resolved]
+
+        by_severity = {}
+        for inc in all_incidents:
+            sev = inc["severity"] or "Unknown"
+            by_severity[sev] = by_severity.get(sev, 0) + 1
+
+        result = {
+            "ok": True,
+            "period": {"since": args.since, "until": args.until},
+            "total_incidents": len(all_incidents),
+            "summary": {
+                "resolved_count": len(resolved),
+                "avg_mttr_minutes": (
+                    round(sum(mttr_values) / len(mttr_values), 2)
+                    if mttr_values
+                    else None
+                ),
+                "median_mttr_minutes": (
+                    round(sorted(mttr_values)[len(mttr_values) // 2], 2)
+                    if mttr_values
+                    else None
+                ),
+            },
+            "by_severity": by_severity,
+            "incidents": all_incidents,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Period: {args.since} to {args.until}")
+            print(f"Total incidents: {len(all_incidents)}")
+            print(f"Resolved: {len(resolved)}")
+            if mttr_values:
+                print(f"Avg MTTR: {result['summary']['avg_mttr_minutes']} min")
+                print(f"Median MTTR: {result['summary']['median_mttr_minutes']} min")
+            print(
+                f"By severity: {', '.join(f'{k}: {v}' for k, v in by_severity.items())}"
+            )
+            print()
+            for inc in all_incidents[:20]:
+                mttr = f" (MTTR: {inc['mttr_minutes']}m)" if inc["mttr_minutes"] else ""
+                print(
+                    f"  [{inc.get('status', '?')}] {inc.get('reference', '')} - {inc.get('name', '')}{mttr}"
+                )
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/incident-incidentio/scripts/list_severities.py
+++ b/sre-agent/.claude/skills/incident-incidentio/scripts/list_severities.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""List all Incident.io severity levels.
+
+Usage:
+    python list_severities.py [--json]
+"""
+
+import argparse
+import json
+import sys
+
+from incidentio_client import incidentio_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List severity levels")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        data = incidentio_request("GET", "/severities")
+        severities = []
+        for sev in data.get("severities", []):
+            severities.append(
+                {
+                    "id": sev["id"],
+                    "name": sev["name"],
+                    "description": sev.get("description"),
+                    "rank": sev.get("rank"),
+                }
+            )
+
+        if args.json:
+            print(json.dumps(severities, indent=2))
+        else:
+            print(f"Severity levels: {len(severities)}")
+            for s in severities:
+                print(f"  [{s['id']}] {s['name']} (rank: {s.get('rank', '?')})")
+                if s.get("description"):
+                    print(f"    {s['description']}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-aws/SKILL.md
+++ b/sre-agent/.claude/skills/infrastructure-aws/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: infrastructure-aws
+description: AWS cloud infrastructure inspection. Use when investigating EC2 instances, ECS tasks/services, Lambda functions, CloudWatch logs/metrics, or AWS resource issues.
+allowed-tools: Bash(python *)
+---
+
+# AWS Infrastructure
+
+## Authentication
+
+**IMPORTANT**: Credentials are fetched automatically from the credential resolver. Do NOT check for `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` in environment variables — they won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration you CAN check (non-secret):
+- `CONFIGURED_INTEGRATIONS` — JSON list, check if `aws` is present
+
+---
+
+## MANDATORY: Logs/Metrics-First Investigation
+
+**Start with CloudWatch logs or metrics, then drill into resources.**
+
+```
+CLOUDWATCH LOGS/METRICS → IDENTIFY RESOURCE → DESCRIBE RESOURCE → CHECK ALARMS
+```
+
+## Available Scripts
+
+All scripts are in `.claude/skills/infrastructure-aws/scripts/`
+
+### get_cloudwatch_logs.py - CloudWatch Log Queries (START HERE for log investigation)
+```bash
+python .claude/skills/infrastructure-aws/scripts/get_cloudwatch_logs.py --log-group /aws/lambda/my-function --filter "ERROR" --hours 1
+python .claude/skills/infrastructure-aws/scripts/get_cloudwatch_logs.py --log-group /ecs/my-service --filter "Exception" --hours 6 --limit 50
+```
+
+### get_cloudwatch_metrics.py - CloudWatch Metrics
+```bash
+python .claude/skills/infrastructure-aws/scripts/get_cloudwatch_metrics.py --namespace AWS/EC2 --metric CPUUtilization --dimension InstanceId=i-1234567890abcdef0 --hours 1
+python .claude/skills/infrastructure-aws/scripts/get_cloudwatch_metrics.py --namespace AWS/ECS --metric CPUUtilization --dimension ClusterName=prod,ServiceName=api --hours 6 --period 300
+```
+
+### list_cloudwatch_alarms.py - CloudWatch Alarms
+```bash
+python .claude/skills/infrastructure-aws/scripts/list_cloudwatch_alarms.py
+python .claude/skills/infrastructure-aws/scripts/list_cloudwatch_alarms.py --state ALARM
+```
+
+### list_ec2_instances.py - List EC2 Instances
+```bash
+python .claude/skills/infrastructure-aws/scripts/list_ec2_instances.py
+python .claude/skills/infrastructure-aws/scripts/list_ec2_instances.py --filters "Name=tag:env,Values=production"
+python .claude/skills/infrastructure-aws/scripts/list_ec2_instances.py --filters "Name=instance-state-name,Values=running"
+```
+
+### describe_ec2_instance.py - Detailed EC2 Instance Info
+```bash
+python .claude/skills/infrastructure-aws/scripts/describe_ec2_instance.py --instance-id i-1234567890abcdef0
+```
+
+### list_ecs_services.py - List ECS Services
+```bash
+python .claude/skills/infrastructure-aws/scripts/list_ecs_services.py --cluster prod-api
+python .claude/skills/infrastructure-aws/scripts/list_ecs_services.py --cluster prod-api --json
+```
+
+### describe_ecs_service.py - ECS Service Details
+```bash
+python .claude/skills/infrastructure-aws/scripts/describe_ecs_service.py --cluster prod-api --service api-handler
+```
+
+### list_lambda_functions.py - List Lambda Functions
+```bash
+python .claude/skills/infrastructure-aws/scripts/list_lambda_functions.py
+python .claude/skills/infrastructure-aws/scripts/list_lambda_functions.py --prefix api-
+```
+
+### get_lambda_logs.py - Lambda Invocation Logs
+```bash
+python .claude/skills/infrastructure-aws/scripts/get_lambda_logs.py --function-name api-handler --hours 1
+python .claude/skills/infrastructure-aws/scripts/get_lambda_logs.py --function-name api-handler --filter "ERROR" --limit 20
+```
+
+---
+
+## Investigation Workflows
+
+### EC2 Instance Issue
+```
+1. list_ec2_instances.py --filters "Name=instance-state-name,Values=running"
+2. describe_ec2_instance.py --instance-id <id>
+3. get_cloudwatch_metrics.py --namespace AWS/EC2 --metric CPUUtilization --dimension InstanceId=<id>
+4. list_cloudwatch_alarms.py --state ALARM
+```
+
+### ECS Task Failure
+```
+1. list_ecs_services.py --cluster <cluster>
+2. describe_ecs_service.py --cluster <cluster> --service <service>
+3. get_cloudwatch_logs.py --log-group /ecs/<service> --filter "ERROR" --hours 1
+4. get_cloudwatch_metrics.py --namespace AWS/ECS --metric CPUUtilization --dimension ClusterName=<cluster>,ServiceName=<service>
+```
+
+### Lambda Error Investigation
+```
+1. list_lambda_functions.py
+2. get_lambda_logs.py --function-name <function> --filter "ERROR" --hours 1
+3. get_cloudwatch_metrics.py --namespace AWS/Lambda --metric Errors --dimension FunctionName=<function>
+4. get_cloudwatch_metrics.py --namespace AWS/Lambda --metric Duration --dimension FunctionName=<function>
+```
+
+### Cost / Resource Audit
+```
+1. list_ec2_instances.py
+2. list_ecs_services.py --cluster <cluster>
+3. list_lambda_functions.py
+4. get_cloudwatch_metrics.py (check utilization of resources)
+```
+
+## Output Format
+
+When reporting findings, use this structure:
+
+```
+## AWS Analysis
+
+**Service**: <EC2/ECS/Lambda/CloudWatch>
+**Region**: <region>
+**Resource**: <resource identifier>
+
+### Findings
+- [Finding with evidence]
+
+### Root Cause Hypothesis
+[Based on metrics and logs]
+
+### Recommended Action
+[Specific remediation step]
+```

--- a/sre-agent/.claude/skills/infrastructure-aws/scripts/aws_client.py
+++ b/sre-agent/.claude/skills/infrastructure-aws/scripts/aws_client.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Shared AWS client with credential-resolver support.
+
+Credentials are fetched from the credential-resolver at runtime.
+In local dev, boto3 auto-discovers from environment or profile.
+"""
+
+import json
+import os
+import sys
+from datetime import datetime
+
+import boto3
+import requests
+
+
+def get_boto3_session() -> boto3.Session:
+    """Create boto3 session with credentials from credential-resolver.
+
+    Priority:
+    1. Credential-resolver (multi-tenant sandbox mode)
+    2. boto3 default chain (env vars, profile, IRSA — local dev)
+    """
+    cred_url = os.getenv("CREDENTIAL_RESOLVER_URL")
+    jwt = os.getenv("SANDBOX_JWT")
+
+    if cred_url and jwt:
+        try:
+            resp = requests.get(
+                f"{cred_url}/api/credentials/aws",
+                headers={"X-Sandbox-JWT": jwt},
+                timeout=5,
+            )
+            resp.raise_for_status()
+            creds = resp.json()
+            return boto3.Session(
+                aws_access_key_id=creds.get("aws_access_key_id")
+                or creds.get("access_key_id"),
+                aws_secret_access_key=creds.get("aws_secret_access_key")
+                or creds.get("secret_access_key"),
+                region_name=creds.get("region")
+                or creds.get("aws_region_name")
+                or "us-east-1",
+            )
+        except Exception as e:
+            print(f"[aws-auth] Credential-resolver error: {e}", file=sys.stderr)
+            print("[aws-auth] Falling back to default boto3 chain", file=sys.stderr)
+
+    # Local dev: boto3 auto-discovers from env/profile
+    return boto3.Session(region_name=os.getenv("AWS_DEFAULT_REGION", "us-east-1"))
+
+
+def get_client(service_name: str):
+    """Get a boto3 client for the given AWS service."""
+    session = get_boto3_session()
+    return session.client(service_name)
+
+
+def format_output(data: dict) -> str:
+    """Format output as JSON string."""
+    return json.dumps(data, indent=2, default=str)
+
+
+def format_timestamp(ts) -> str:
+    """Format a timestamp (datetime or epoch ms) to ISO string."""
+    if isinstance(ts, (int, float)):
+        return datetime.utcfromtimestamp(ts / 1000).isoformat() + "Z"
+    if isinstance(ts, datetime):
+        return ts.isoformat()
+    return str(ts)

--- a/sre-agent/.claude/skills/infrastructure-aws/scripts/describe_ec2_instance.py
+++ b/sre-agent/.claude/skills/infrastructure-aws/scripts/describe_ec2_instance.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Describe an EC2 instance with detailed info and status checks.
+
+Usage:
+    python describe_ec2_instance.py --instance-id i-1234567890abcdef0
+"""
+
+import argparse
+import sys
+
+from aws_client import format_output, get_client
+
+
+def get_instance_name(instance: dict) -> str:
+    """Extract Name tag from instance."""
+    for tag in instance.get("Tags", []):
+        if tag["Key"] == "Name":
+            return tag["Value"]
+    return ""
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Describe EC2 instance")
+    parser.add_argument("--instance-id", required=True, help="EC2 instance ID")
+    args = parser.parse_args()
+
+    try:
+        ec2 = get_client("ec2")
+
+        # Describe instance
+        response = ec2.describe_instances(InstanceIds=[args.instance_id])
+        if not response["Reservations"] or not response["Reservations"][0]["Instances"]:
+            print(f"Instance {args.instance_id} not found", file=sys.stderr)
+            sys.exit(1)
+
+        inst = response["Reservations"][0]["Instances"][0]
+
+        # Get status checks
+        status_response = ec2.describe_instance_status(InstanceIds=[args.instance_id])
+        status_info = {}
+        if status_response.get("InstanceStatuses"):
+            status = status_response["InstanceStatuses"][0]
+            status_info = {
+                "instance_status": status.get("InstanceStatus", {}).get(
+                    "Status", "unknown"
+                ),
+                "system_status": status.get("SystemStatus", {}).get(
+                    "Status", "unknown"
+                ),
+            }
+
+        # Build output
+        result = {
+            "instance_id": inst["InstanceId"],
+            "name": get_instance_name(inst),
+            "state": inst["State"]["Name"],
+            "type": inst["InstanceType"],
+            "platform": inst.get("PlatformDetails", ""),
+            "architecture": inst.get("Architecture", ""),
+            "private_ip": inst.get("PrivateIpAddress", ""),
+            "public_ip": inst.get("PublicIpAddress", ""),
+            "vpc_id": inst.get("VpcId", ""),
+            "subnet_id": inst.get("SubnetId", ""),
+            "az": inst.get("Placement", {}).get("AvailabilityZone", ""),
+            "launch_time": str(inst.get("LaunchTime", "")),
+            "ami_id": inst.get("ImageId", ""),
+            "key_name": inst.get("KeyName", ""),
+            "security_groups": [
+                {"id": sg["GroupId"], "name": sg["GroupName"]}
+                for sg in inst.get("SecurityGroups", [])
+            ],
+            "iam_role": inst.get("IamInstanceProfile", {}).get("Arn", ""),
+            "tags": {tag["Key"]: tag["Value"] for tag in inst.get("Tags", [])},
+            "status_checks": status_info,
+            "root_device": {
+                "type": inst.get("RootDeviceType", ""),
+                "name": inst.get("RootDeviceName", ""),
+            },
+            "ebs_optimized": inst.get("EbsOptimized", False),
+        }
+
+        print(format_output(result))
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-aws/scripts/describe_ecs_service.py
+++ b/sre-agent/.claude/skills/infrastructure-aws/scripts/describe_ecs_service.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Describe an ECS service with events, task definition, and deployment info.
+
+Usage:
+    python describe_ecs_service.py --cluster prod-api --service api-handler
+"""
+
+import argparse
+import sys
+
+from aws_client import format_output, get_client
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Describe ECS service")
+    parser.add_argument("--cluster", required=True, help="ECS cluster name or ARN")
+    parser.add_argument("--service", required=True, help="ECS service name or ARN")
+    args = parser.parse_args()
+
+    try:
+        ecs = get_client("ecs")
+
+        response = ecs.describe_services(
+            cluster=args.cluster,
+            services=[args.service],
+        )
+
+        if not response.get("services"):
+            print(
+                f"Service {args.service} not found in cluster {args.cluster}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        svc = response["services"][0]
+
+        # Get task definition details
+        task_def = {}
+        if svc.get("taskDefinition"):
+            td_response = ecs.describe_task_definition(
+                taskDefinition=svc["taskDefinition"]
+            )
+            td = td_response.get("taskDefinition", {})
+            task_def = {
+                "arn": td.get("taskDefinitionArn", ""),
+                "cpu": td.get("cpu", ""),
+                "memory": td.get("memory", ""),
+                "containers": [
+                    {
+                        "name": c["name"],
+                        "image": c.get("image", ""),
+                        "cpu": c.get("cpu", 0),
+                        "memory": c.get("memory", 0),
+                        "essential": c.get("essential", True),
+                    }
+                    for c in td.get("containerDefinitions", [])
+                ],
+            }
+
+        # Get recent events
+        events = [
+            {
+                "timestamp": str(e.get("createdAt", "")),
+                "message": e.get("message", ""),
+            }
+            for e in svc.get("events", [])[:10]
+        ]
+
+        # Get deployments
+        deployments = [
+            {
+                "id": d.get("id", ""),
+                "status": d.get("status", ""),
+                "desired": d.get("desiredCount", 0),
+                "running": d.get("runningCount", 0),
+                "pending": d.get("pendingCount", 0),
+                "task_definition": d.get("taskDefinition", "").split("/")[-1],
+                "created": str(d.get("createdAt", "")),
+                "updated": str(d.get("updatedAt", "")),
+                "rollout_state": d.get("rolloutState", ""),
+            }
+            for d in svc.get("deployments", [])
+        ]
+
+        # List running tasks
+        tasks_response = ecs.list_tasks(
+            cluster=args.cluster,
+            serviceName=args.service,
+            desiredStatus="RUNNING",
+        )
+        running_task_arns = tasks_response.get("taskArns", [])
+
+        result = {
+            "name": svc["serviceName"],
+            "status": svc["status"],
+            "cluster": args.cluster,
+            "desired_count": svc.get("desiredCount", 0),
+            "running_count": svc.get("runningCount", 0),
+            "pending_count": svc.get("pendingCount", 0),
+            "launch_type": svc.get("launchType", ""),
+            "created": str(svc.get("createdAt", "")),
+            "task_definition": task_def,
+            "deployments": deployments,
+            "running_tasks": len(running_task_arns),
+            "recent_events": events,
+            "load_balancers": [
+                {
+                    "target_group_arn": lb.get("targetGroupArn", ""),
+                    "container_name": lb.get("containerName", ""),
+                    "container_port": lb.get("containerPort", 0),
+                }
+                for lb in svc.get("loadBalancers", [])
+            ],
+        }
+
+        print(format_output(result))
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-aws/scripts/get_cloudwatch_logs.py
+++ b/sre-agent/.claude/skills/infrastructure-aws/scripts/get_cloudwatch_logs.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Query CloudWatch Logs with filter pattern.
+
+Usage:
+    python get_cloudwatch_logs.py --log-group /aws/lambda/my-function --filter "ERROR" --hours 1
+    python get_cloudwatch_logs.py --log-group /ecs/my-service --hours 6 --limit 50
+    python get_cloudwatch_logs.py --log-group /aws/lambda/api --filter "statusCode=500" --hours 24
+"""
+
+import argparse
+import sys
+import time
+
+from aws_client import format_output, format_timestamp, get_client
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Query CloudWatch Logs")
+    parser.add_argument("--log-group", required=True, help="Log group name")
+    parser.add_argument(
+        "--filter", default="", help="Filter pattern (CloudWatch filter syntax)"
+    )
+    parser.add_argument(
+        "--hours", type=float, default=1, help="Hours to look back (default: 1)"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=100, help="Max events to return (default: 100)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        logs = get_client("logs")
+
+        now_ms = int(time.time() * 1000)
+        start_ms = now_ms - int(args.hours * 3600 * 1000)
+
+        kwargs = {
+            "logGroupName": args.log_group,
+            "startTime": start_ms,
+            "endTime": now_ms,
+            "limit": args.limit,
+            "interleaved": True,
+        }
+        if args.filter:
+            kwargs["filterPattern"] = args.filter
+
+        events = []
+        response = logs.filter_log_events(**kwargs)
+        events.extend(response.get("events", []))
+
+        # Paginate if needed (up to limit)
+        while "nextToken" in response and len(events) < args.limit:
+            kwargs["nextToken"] = response["nextToken"]
+            response = logs.filter_log_events(**kwargs)
+            events.extend(response.get("events", []))
+
+        events = events[: args.limit]
+
+        formatted_events = [
+            {
+                "timestamp": format_timestamp(e.get("timestamp", 0)),
+                "log_stream": e.get("logStreamName", ""),
+                "message": e.get("message", "").strip(),
+            }
+            for e in events
+        ]
+
+        if args.json:
+            print(
+                format_output(
+                    {
+                        "log_group": args.log_group,
+                        "filter": args.filter,
+                        "hours": args.hours,
+                        "count": len(formatted_events),
+                        "events": formatted_events,
+                    }
+                )
+            )
+        else:
+            print(f"Log Group: {args.log_group}")
+            print(f"Filter: {args.filter or '(none)'}")
+            print(f"Time Range: last {args.hours}h")
+            print(f"Events: {len(formatted_events)}")
+            print()
+            for event in formatted_events:
+                print(f"[{event['timestamp']}] {event['message']}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-aws/scripts/get_cloudwatch_metrics.py
+++ b/sre-agent/.claude/skills/infrastructure-aws/scripts/get_cloudwatch_metrics.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Get CloudWatch metrics for a resource.
+
+Usage:
+    python get_cloudwatch_metrics.py --namespace AWS/EC2 --metric CPUUtilization --dimension InstanceId=i-1234 --hours 1
+    python get_cloudwatch_metrics.py --namespace AWS/ECS --metric CPUUtilization --dimension ClusterName=prod,ServiceName=api --hours 6 --period 300
+    python get_cloudwatch_metrics.py --namespace AWS/Lambda --metric Errors --dimension FunctionName=handler --hours 24 --stat Sum
+"""
+
+import argparse
+import sys
+from datetime import datetime, timedelta
+
+from aws_client import format_output, get_client
+
+
+def parse_dimensions(dim_str: str) -> list[dict]:
+    """Parse dimension string like 'InstanceId=i-1234,ClusterName=prod'."""
+    dimensions = []
+    for pair in dim_str.split(","):
+        name, _, value = pair.partition("=")
+        if name and value:
+            dimensions.append({"Name": name.strip(), "Value": value.strip()})
+    return dimensions
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get CloudWatch metrics")
+    parser.add_argument(
+        "--namespace", required=True, help="Metric namespace (e.g., AWS/EC2)"
+    )
+    parser.add_argument(
+        "--metric", required=True, help="Metric name (e.g., CPUUtilization)"
+    )
+    parser.add_argument(
+        "--dimension", required=True, help="Dimensions (e.g., InstanceId=i-1234)"
+    )
+    parser.add_argument(
+        "--hours", type=float, default=1, help="Hours to look back (default: 1)"
+    )
+    parser.add_argument(
+        "--period", type=int, default=60, help="Period in seconds (default: 60)"
+    )
+    parser.add_argument(
+        "--stat",
+        default="Average",
+        help="Statistic: Average, Sum, Maximum, Minimum, SampleCount (default: Average)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        cw = get_client("cloudwatch")
+
+        end_time = datetime.utcnow()
+        start_time = end_time - timedelta(hours=args.hours)
+
+        response = cw.get_metric_statistics(
+            Namespace=args.namespace,
+            MetricName=args.metric,
+            Dimensions=parse_dimensions(args.dimension),
+            StartTime=start_time,
+            EndTime=end_time,
+            Period=args.period,
+            Statistics=[args.stat],
+        )
+
+        datapoints = sorted(
+            response.get("Datapoints", []),
+            key=lambda dp: dp["Timestamp"],
+        )
+
+        formatted_points = [
+            {
+                "timestamp": dp["Timestamp"].isoformat(),
+                "value": dp.get(args.stat, 0),
+                "unit": dp.get("Unit", ""),
+            }
+            for dp in datapoints
+        ]
+
+        if args.json:
+            print(
+                format_output(
+                    {
+                        "namespace": args.namespace,
+                        "metric": args.metric,
+                        "dimension": args.dimension,
+                        "stat": args.stat,
+                        "period": args.period,
+                        "hours": args.hours,
+                        "count": len(formatted_points),
+                        "datapoints": formatted_points,
+                    }
+                )
+            )
+        else:
+            print(f"Namespace: {args.namespace}")
+            print(f"Metric: {args.metric} ({args.stat})")
+            print(f"Dimensions: {args.dimension}")
+            print(f"Period: {args.period}s, Range: last {args.hours}h")
+            print(f"Datapoints: {len(formatted_points)}")
+            print()
+            if formatted_points:
+                print(f"{'TIMESTAMP':<28} {'VALUE':>12} {'UNIT':<10}")
+                print("-" * 50)
+                for dp in formatted_points:
+                    print(
+                        f"{dp['timestamp']:<28} {dp['value']:>12.2f} {dp['unit']:<10}"
+                    )
+            else:
+                print("No datapoints found for the specified time range.")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-aws/scripts/get_lambda_logs.py
+++ b/sre-agent/.claude/skills/infrastructure-aws/scripts/get_lambda_logs.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Get recent Lambda invocation logs from CloudWatch.
+
+Usage:
+    python get_lambda_logs.py --function-name api-handler --hours 1
+    python get_lambda_logs.py --function-name api-handler --filter "ERROR" --limit 20
+"""
+
+import argparse
+import sys
+import time
+
+from aws_client import format_output, format_timestamp, get_client
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Lambda function logs")
+    parser.add_argument("--function-name", required=True, help="Lambda function name")
+    parser.add_argument("--filter", default="", help="Filter pattern")
+    parser.add_argument(
+        "--hours", type=float, default=1, help="Hours to look back (default: 1)"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=50, help="Max events to return (default: 50)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        logs = get_client("logs")
+
+        log_group = f"/aws/lambda/{args.function_name}"
+
+        now_ms = int(time.time() * 1000)
+        start_ms = now_ms - int(args.hours * 3600 * 1000)
+
+        kwargs = {
+            "logGroupName": log_group,
+            "startTime": start_ms,
+            "endTime": now_ms,
+            "limit": args.limit,
+            "interleaved": True,
+        }
+        if args.filter:
+            kwargs["filterPattern"] = args.filter
+
+        events = []
+        try:
+            response = logs.filter_log_events(**kwargs)
+            events.extend(response.get("events", []))
+
+            while "nextToken" in response and len(events) < args.limit:
+                kwargs["nextToken"] = response["nextToken"]
+                response = logs.filter_log_events(**kwargs)
+                events.extend(response.get("events", []))
+        except logs.exceptions.ResourceNotFoundException:
+            print(
+                f"Log group {log_group} not found. Function may not have been invoked yet.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        events = events[: args.limit]
+
+        formatted_events = [
+            {
+                "timestamp": format_timestamp(e.get("timestamp", 0)),
+                "message": e.get("message", "").strip(),
+            }
+            for e in events
+        ]
+
+        if args.json:
+            print(
+                format_output(
+                    {
+                        "function_name": args.function_name,
+                        "log_group": log_group,
+                        "filter": args.filter,
+                        "hours": args.hours,
+                        "count": len(formatted_events),
+                        "events": formatted_events,
+                    }
+                )
+            )
+        else:
+            print(f"Function: {args.function_name}")
+            print(f"Log Group: {log_group}")
+            print(f"Filter: {args.filter or '(none)'}")
+            print(f"Time Range: last {args.hours}h")
+            print(f"Events: {len(formatted_events)}")
+            print()
+            for event in formatted_events:
+                print(f"[{event['timestamp']}] {event['message']}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-aws/scripts/list_cloudwatch_alarms.py
+++ b/sre-agent/.claude/skills/infrastructure-aws/scripts/list_cloudwatch_alarms.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""List CloudWatch alarms with state.
+
+Usage:
+    python list_cloudwatch_alarms.py
+    python list_cloudwatch_alarms.py --state ALARM
+    python list_cloudwatch_alarms.py --json
+"""
+
+import argparse
+import sys
+
+from aws_client import format_output, get_client
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List CloudWatch alarms")
+    parser.add_argument(
+        "--state", choices=["OK", "ALARM", "INSUFFICIENT_DATA"], help="Filter by state"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        cw = get_client("cloudwatch")
+
+        kwargs = {}
+        if args.state:
+            kwargs["StateValue"] = args.state
+
+        alarms = []
+        response = cw.describe_alarms(**kwargs)
+        for alarm in response.get("MetricAlarms", []):
+            alarms.append(
+                {
+                    "name": alarm["AlarmName"],
+                    "state": alarm["StateValue"],
+                    "metric": alarm.get("MetricName", ""),
+                    "namespace": alarm.get("Namespace", ""),
+                    "description": alarm.get("AlarmDescription", ""),
+                    "state_reason": alarm.get("StateReason", ""),
+                    "state_updated": str(alarm.get("StateUpdatedTimestamp", "")),
+                    "threshold": alarm.get("Threshold"),
+                    "comparison": alarm.get("ComparisonOperator", ""),
+                    "period": alarm.get("Period"),
+                }
+            )
+
+        # Also include composite alarms
+        for alarm in response.get("CompositeAlarms", []):
+            alarms.append(
+                {
+                    "name": alarm["AlarmName"],
+                    "state": alarm["StateValue"],
+                    "metric": "(composite)",
+                    "namespace": "",
+                    "description": alarm.get("AlarmDescription", ""),
+                    "state_reason": alarm.get("StateReason", ""),
+                    "state_updated": str(alarm.get("StateUpdatedTimestamp", "")),
+                }
+            )
+
+        if args.json:
+            print(format_output({"count": len(alarms), "alarms": alarms}))
+        else:
+            print(f"CloudWatch Alarms: {len(alarms)}")
+            print()
+            if alarms:
+                print(f"{'NAME':<40} {'STATE':<20} {'NAMESPACE':<16} {'METRIC':<20}")
+                print("-" * 96)
+                for alarm in alarms:
+                    print(
+                        f"{alarm['name']:<40} {alarm['state']:<20} "
+                        f"{alarm['namespace']:<16} {alarm['metric']:<20}"
+                    )
+                    if alarm["state"] == "ALARM" and alarm.get("state_reason"):
+                        print(f"  → {alarm['state_reason'][:100]}")
+            else:
+                print("No alarms found.")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-aws/scripts/list_ec2_instances.py
+++ b/sre-agent/.claude/skills/infrastructure-aws/scripts/list_ec2_instances.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""List EC2 instances with status, type, and IPs.
+
+Usage:
+    python list_ec2_instances.py [--filters "Name=tag:env,Values=production"]
+    python list_ec2_instances.py --filters "Name=instance-state-name,Values=running"
+    python list_ec2_instances.py --json
+"""
+
+import argparse
+import sys
+
+from aws_client import format_output, get_client
+
+
+def parse_filters(filter_str: str) -> list[dict]:
+    """Parse AWS filter string into filter list.
+
+    Format: "Name=tag:env,Values=production Name=instance-state-name,Values=running"
+    """
+    filters = []
+    for part in filter_str.split(" "):
+        part = part.strip()
+        if not part:
+            continue
+        kv = {}
+        for item in part.split(","):
+            key, _, val = item.partition("=")
+            if key == "Name":
+                kv["Name"] = val
+            elif key == "Values":
+                kv.setdefault("Values", []).append(val)
+        if "Name" in kv and "Values" in kv:
+            filters.append(kv)
+    return filters
+
+
+def get_instance_name(instance: dict) -> str:
+    """Extract Name tag from instance."""
+    for tag in instance.get("Tags", []):
+        if tag["Key"] == "Name":
+            return tag["Value"]
+    return ""
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List EC2 instances")
+    parser.add_argument(
+        "--filters", help="AWS filters (e.g., 'Name=tag:env,Values=production')"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        ec2 = get_client("ec2")
+        kwargs = {}
+        if args.filters:
+            kwargs["Filters"] = parse_filters(args.filters)
+
+        response = ec2.describe_instances(**kwargs)
+
+        instances = []
+        for reservation in response.get("Reservations", []):
+            for inst in reservation.get("Instances", []):
+                instances.append(
+                    {
+                        "instance_id": inst["InstanceId"],
+                        "name": get_instance_name(inst),
+                        "state": inst["State"]["Name"],
+                        "type": inst["InstanceType"],
+                        "private_ip": inst.get("PrivateIpAddress", ""),
+                        "public_ip": inst.get("PublicIpAddress", ""),
+                        "az": inst.get("Placement", {}).get("AvailabilityZone", ""),
+                        "launch_time": str(inst.get("LaunchTime", "")),
+                    }
+                )
+
+        if args.json:
+            print(format_output({"count": len(instances), "instances": instances}))
+        else:
+            print(f"EC2 Instances: {len(instances)}")
+            print()
+            print(
+                f"{'INSTANCE ID':<22} {'NAME':<30} {'STATE':<12} {'TYPE':<14} {'PRIVATE IP':<16} {'PUBLIC IP':<16}"
+            )
+            print("-" * 110)
+            for inst in instances:
+                print(
+                    f"{inst['instance_id']:<22} {inst['name']:<30} {inst['state']:<12} "
+                    f"{inst['type']:<14} {inst['private_ip']:<16} {inst['public_ip']:<16}"
+                )
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-aws/scripts/list_ecs_services.py
+++ b/sre-agent/.claude/skills/infrastructure-aws/scripts/list_ecs_services.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""List ECS services in a cluster with task counts.
+
+Usage:
+    python list_ecs_services.py --cluster prod-api
+    python list_ecs_services.py --cluster prod-api --json
+"""
+
+import argparse
+import sys
+
+from aws_client import format_output, get_client
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List ECS services")
+    parser.add_argument("--cluster", required=True, help="ECS cluster name or ARN")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        ecs = get_client("ecs")
+
+        # List service ARNs
+        service_arns = []
+        paginator = ecs.get_paginator("list_services")
+        for page in paginator.paginate(cluster=args.cluster):
+            service_arns.extend(page.get("serviceArns", []))
+
+        if not service_arns:
+            print(f"No services found in cluster {args.cluster}")
+            return
+
+        # Describe services (max 10 per call)
+        services = []
+        for i in range(0, len(service_arns), 10):
+            batch = service_arns[i : i + 10]
+            response = ecs.describe_services(cluster=args.cluster, services=batch)
+            for svc in response.get("services", []):
+                services.append(
+                    {
+                        "name": svc["serviceName"],
+                        "status": svc["status"],
+                        "desired": svc.get("desiredCount", 0),
+                        "running": svc.get("runningCount", 0),
+                        "pending": svc.get("pendingCount", 0),
+                        "launch_type": svc.get("launchType", ""),
+                        "task_definition": svc.get("taskDefinition", "").split("/")[-1],
+                        "created": str(svc.get("createdAt", "")),
+                    }
+                )
+
+        if args.json:
+            print(
+                format_output(
+                    {
+                        "cluster": args.cluster,
+                        "count": len(services),
+                        "services": services,
+                    }
+                )
+            )
+        else:
+            print(f"Cluster: {args.cluster}")
+            print(f"Services: {len(services)}")
+            print()
+            print(
+                f"{'NAME':<30} {'STATUS':<10} {'DESIRED':>8} {'RUNNING':>8} {'PENDING':>8} {'LAUNCH TYPE':<12} {'TASK DEF':<30}"
+            )
+            print("-" * 106)
+            for svc in services:
+                print(
+                    f"{svc['name']:<30} {svc['status']:<10} {svc['desired']:>8} "
+                    f"{svc['running']:>8} {svc['pending']:>8} {svc['launch_type']:<12} "
+                    f"{svc['task_definition']:<30}"
+                )
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-aws/scripts/list_lambda_functions.py
+++ b/sre-agent/.claude/skills/infrastructure-aws/scripts/list_lambda_functions.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""List Lambda functions with runtime, memory, and last modified.
+
+Usage:
+    python list_lambda_functions.py
+    python list_lambda_functions.py --prefix api-
+    python list_lambda_functions.py --json
+"""
+
+import argparse
+import sys
+
+from aws_client import format_output, get_client
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Lambda functions")
+    parser.add_argument("--prefix", help="Filter by function name prefix")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        lam = get_client("lambda")
+
+        functions = []
+        paginator = lam.get_paginator("list_functions")
+        for page in paginator.paginate():
+            for fn in page.get("Functions", []):
+                name = fn["FunctionName"]
+                if args.prefix and not name.startswith(args.prefix):
+                    continue
+                functions.append(
+                    {
+                        "name": name,
+                        "runtime": fn.get("Runtime", ""),
+                        "memory": fn.get("MemorySize", 0),
+                        "timeout": fn.get("Timeout", 0),
+                        "code_size_mb": round(fn.get("CodeSize", 0) / 1024 / 1024, 1),
+                        "last_modified": fn.get("LastModified", ""),
+                        "handler": fn.get("Handler", ""),
+                        "description": fn.get("Description", ""),
+                        "architecture": fn.get("Architectures", ["x86_64"])[0],
+                    }
+                )
+
+        if args.json:
+            print(format_output({"count": len(functions), "functions": functions}))
+        else:
+            print(f"Lambda Functions: {len(functions)}")
+            print()
+            if functions:
+                print(
+                    f"{'NAME':<40} {'RUNTIME':<16} {'MEMORY':>8} {'TIMEOUT':>8} {'LAST MODIFIED':<26}"
+                )
+                print("-" * 98)
+                for fn in functions:
+                    print(
+                        f"{fn['name']:<40} {fn['runtime']:<16} {fn['memory']:>6}MB "
+                        f"{fn['timeout']:>6}s {fn['last_modified']:<26}"
+                    )
+            else:
+                print("No Lambda functions found.")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-azure/SKILL.md
+++ b/sre-agent/.claude/skills/infrastructure-azure/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: infrastructure-azure
+description: Azure cloud infrastructure inspection. Use when investigating Azure VMs, AKS clusters, Log Analytics (KQL), Monitor metrics/alerts, Cost Management, or NSG rules.
+allowed-tools: Bash(python *)
+---
+
+# Azure Infrastructure
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `AZURE_CLIENT_SECRET` or `AZURE_TENANT_ID` in environment variables - they won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `AZURE_SUBSCRIPTION_ID` - Azure subscription ID
+- `AZURE_RESOURCE_GROUP` - Default resource group
+
+---
+
+## MANDATORY: Query-First Investigation
+
+**Start with Log Analytics or Monitor metrics, then drill into resources.**
+
+```
+LOG ANALYTICS / METRICS → IDENTIFY RESOURCE → DESCRIBE RESOURCE → CHECK ALERTS
+```
+
+## Available Scripts
+
+All scripts are in `.claude/skills/infrastructure-azure/scripts/`
+
+### query_log_analytics.py - KQL Log Queries (START HERE for log investigation)
+```bash
+python .claude/skills/infrastructure-azure/scripts/query_log_analytics.py --workspace-id WORKSPACE_ID --query "AzureDiagnostics | where Level == 'Error' | limit 50"
+python .claude/skills/infrastructure-azure/scripts/query_log_analytics.py --workspace-id WORKSPACE_ID --query "Heartbeat | summarize count() by Computer" --timespan PT1H
+```
+
+### query_resource_graph.py - Cross-Subscription Resource Queries
+```bash
+python .claude/skills/infrastructure-azure/scripts/query_resource_graph.py --query "Resources | where type == 'microsoft.compute/virtualmachines' | project name, location"
+```
+
+### get_monitor_metrics.py - Azure Monitor Metrics
+```bash
+python .claude/skills/infrastructure-azure/scripts/get_monitor_metrics.py --resource-id RESOURCE_ID --metrics "Percentage CPU,Network In" --interval PT5M
+```
+
+### list_monitor_alerts.py - Alert Rules
+```bash
+python .claude/skills/infrastructure-azure/scripts/list_monitor_alerts.py [--resource-group RG]
+```
+
+### list_vms.py / describe_vm.py - Virtual Machines
+```bash
+python .claude/skills/infrastructure-azure/scripts/list_vms.py [--resource-group RG]
+python .claude/skills/infrastructure-azure/scripts/describe_vm.py --resource-group RG --vm-name VM
+```
+
+### list_aks_clusters.py / describe_aks_cluster.py - AKS Clusters
+```bash
+python .claude/skills/infrastructure-azure/scripts/list_aks_clusters.py [--resource-group RG]
+python .claude/skills/infrastructure-azure/scripts/describe_aks_cluster.py --resource-group RG --cluster-name CLUSTER
+```
+
+### query_costs.py - Cost Management
+```bash
+python .claude/skills/infrastructure-azure/scripts/query_costs.py --start 2026-01-01 --end 2026-02-01 [--granularity Monthly] [--group-by ResourceGroup,ServiceName]
+```
+
+### get_nsg_rules.py - Network Security Group Rules
+```bash
+python .claude/skills/infrastructure-azure/scripts/get_nsg_rules.py --resource-group RG --nsg-name NSG
+```
+
+---
+
+## KQL Query Reference
+
+```kql
+// Errors in last hour
+AzureDiagnostics | where Level == "Error" | where TimeGenerated > ago(1h) | limit 50
+
+// CPU usage
+Perf | where CounterName == "% Processor Time" | summarize avg(CounterValue) by bin(TimeGenerated, 5m), Computer
+
+// Heartbeat (availability)
+Heartbeat | summarize count() by Computer, bin(TimeGenerated, 1h)
+
+// Resource Graph - find VMs
+Resources | where type == "microsoft.compute/virtualmachines" | project name, location, properties.hardwareProfile.vmSize
+```
+
+---
+
+## Investigation Workflow
+
+### VM Performance Issue
+```
+1. get_monitor_metrics.py --resource-id <vm-id> --metrics "Percentage CPU,Network In"
+2. query_log_analytics.py --query "Perf | where Computer == '<vm>' | where CounterName == '% Processor Time'"
+3. describe_vm.py --resource-group <rg> --vm-name <vm>
+```
+
+### Cost Spike
+```
+1. query_costs.py --start <start> --end <end> --group-by ResourceGroup,ServiceName
+2. query_resource_graph.py --query "Resources | summarize count() by type, location"
+```

--- a/sre-agent/.claude/skills/infrastructure-azure/scripts/azure_client.py
+++ b/sre-agent/.claude/skills/infrastructure-azure/scripts/azure_client.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Shared Azure client with proxy support.
+
+Credentials are injected transparently by the proxy layer.
+"""
+
+import json
+import os
+from datetime import datetime
+
+
+def get_config() -> dict[str, str | None]:
+    """Get Azure configuration from environment."""
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+        "subscription_id": os.getenv("AZURE_SUBSCRIPTION_ID", ""),
+        "resource_group": os.getenv("AZURE_RESOURCE_GROUP"),
+    }
+
+
+def get_credentials():
+    """Get Azure credentials.
+
+    Supports:
+    1. Service principal (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID)
+    2. DefaultAzureCredential (CLI, managed identity, etc.)
+    """
+    from azure.identity import DefaultAzureCredential
+
+    return DefaultAzureCredential()
+
+
+def get_subscription_id() -> str:
+    """Get the Azure subscription ID."""
+    sub_id = os.getenv("AZURE_SUBSCRIPTION_ID", "")
+    if not sub_id:
+        raise RuntimeError("AZURE_SUBSCRIPTION_ID must be set")
+    return sub_id
+
+
+def serialize_value(value):
+    """Serialize a value for JSON output."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+def format_output(data: dict) -> str:
+    """Format output as JSON string."""
+    return json.dumps(data, indent=2, default=str)

--- a/sre-agent/.claude/skills/infrastructure-azure/scripts/describe_aks_cluster.py
+++ b/sre-agent/.claude/skills/infrastructure-azure/scripts/describe_aks_cluster.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Get details about an AKS cluster."""
+
+import argparse
+import sys
+
+from azure_client import format_output, get_credentials, get_subscription_id
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Describe AKS cluster")
+    parser.add_argument("--resource-group", required=True, help="Resource group name")
+    parser.add_argument("--cluster-name", required=True, help="AKS cluster name")
+    args = parser.parse_args()
+
+    try:
+        from azure.mgmt.containerservice import ContainerServiceClient
+
+        credential = get_credentials()
+        subscription_id = get_subscription_id()
+        aks_client = ContainerServiceClient(credential, subscription_id)
+
+        cluster = aks_client.managed_clusters.get(
+            args.resource_group, args.cluster_name
+        )
+
+        agent_pools = []
+        if cluster.agent_pool_profiles:
+            for pool in cluster.agent_pool_profiles:
+                agent_pools.append(
+                    {
+                        "name": pool.name,
+                        "count": pool.count,
+                        "vm_size": pool.vm_size,
+                        "os_type": pool.os_type.value if pool.os_type else None,
+                        "mode": pool.mode.value if pool.mode else None,
+                    }
+                )
+
+        result = {
+            "name": cluster.name,
+            "id": cluster.id,
+            "location": cluster.location,
+            "kubernetes_version": cluster.kubernetes_version,
+            "provisioning_state": cluster.provisioning_state,
+            "fqdn": cluster.fqdn,
+            "node_resource_group": cluster.node_resource_group,
+            "agent_pools": agent_pools,
+            "tags": cluster.tags or {},
+        }
+
+        print(format_output(result))
+
+    except Exception as e:
+        print(format_output({"error": str(e), "cluster_name": args.cluster_name}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-azure/scripts/describe_vm.py
+++ b/sre-agent/.claude/skills/infrastructure-azure/scripts/describe_vm.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Get details about an Azure Virtual Machine."""
+
+import argparse
+import sys
+
+from azure_client import format_output, get_credentials, get_subscription_id
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Describe Azure VM")
+    parser.add_argument("--resource-group", required=True, help="Resource group name")
+    parser.add_argument("--vm-name", required=True, help="VM name")
+    args = parser.parse_args()
+
+    try:
+        from azure.mgmt.compute import ComputeManagementClient
+
+        credential = get_credentials()
+        subscription_id = get_subscription_id()
+        compute_client = ComputeManagementClient(credential, subscription_id)
+
+        vm = compute_client.virtual_machines.get(
+            args.resource_group, args.vm_name, expand="instanceView"
+        )
+
+        statuses = []
+        if vm.instance_view and vm.instance_view.statuses:
+            statuses = [
+                {"code": s.code, "level": s.level.value, "message": s.message}
+                for s in vm.instance_view.statuses
+            ]
+
+        result = {
+            "name": vm.name,
+            "id": vm.id,
+            "location": vm.location,
+            "vm_size": vm.hardware_profile.vm_size,
+            "os_type": (
+                vm.storage_profile.os_disk.os_type.value
+                if vm.storage_profile.os_disk.os_type
+                else None
+            ),
+            "provisioning_state": vm.provisioning_state,
+            "statuses": statuses,
+            "tags": vm.tags or {},
+            "zones": vm.zones,
+            "network_interfaces": (
+                [ni.id for ni in vm.network_profile.network_interfaces]
+                if vm.network_profile
+                else []
+            ),
+        }
+
+        print(format_output(result))
+
+    except Exception as e:
+        print(format_output({"error": str(e), "vm_name": args.vm_name}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-azure/scripts/get_monitor_metrics.py
+++ b/sre-agent/.claude/skills/infrastructure-azure/scripts/get_monitor_metrics.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Get Azure Monitor metrics for a resource."""
+
+import argparse
+import sys
+from datetime import timedelta
+
+from azure_client import format_output, get_credentials
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Azure Monitor metrics")
+    parser.add_argument("--resource-id", required=True, help="Full Azure resource ID")
+    parser.add_argument("--metrics", required=True, help="Comma-separated metric names")
+    parser.add_argument("--timespan", help="ISO 8601 duration (default: PT1H)")
+    parser.add_argument(
+        "--interval", default="PT5M", help="Aggregation interval (default: PT5M)"
+    )
+    parser.add_argument(
+        "--aggregations",
+        default="Average",
+        help="Comma-separated aggregations (default: Average)",
+    )
+    args = parser.parse_args()
+
+    try:
+        from azure.monitor.query import MetricsQueryClient
+
+        credential = get_credentials()
+        client = MetricsQueryClient(credential)
+
+        metric_names = [m.strip() for m in args.metrics.split(",")]
+        aggregations = [a.strip() for a in args.aggregations.split(",")]
+        timespan = args.timespan if args.timespan else timedelta(hours=1)
+
+        response = client.query_resource(
+            resource_uri=args.resource_id,
+            metric_names=metric_names,
+            timespan=timespan,
+            granularity=args.interval,
+            aggregations=aggregations,
+        )
+
+        metrics_data = []
+        for metric in response.metrics:
+            metric_dict = {
+                "name": metric.name,
+                "unit": str(metric.unit),
+                "timeseries": [],
+            }
+            for timeseries in metric.timeseries:
+                ts_data = {"data": []}
+                for data_point in timeseries.data:
+                    point = {"timestamp": data_point.timestamp.isoformat()}
+                    if data_point.average is not None:
+                        point["average"] = data_point.average
+                    if data_point.maximum is not None:
+                        point["maximum"] = data_point.maximum
+                    if data_point.minimum is not None:
+                        point["minimum"] = data_point.minimum
+                    if data_point.total is not None:
+                        point["total"] = data_point.total
+                    ts_data["data"].append(point)
+                metric_dict["timeseries"].append(ts_data)
+            metrics_data.append(metric_dict)
+
+        print(
+            format_output(
+                {
+                    "resource_id": args.resource_id,
+                    "interval": args.interval,
+                    "metrics": metrics_data,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e), "resource_id": args.resource_id}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-azure/scripts/get_nsg_rules.py
+++ b/sre-agent/.claude/skills/infrastructure-azure/scripts/get_nsg_rules.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Get Azure Network Security Group (NSG) rules."""
+
+import argparse
+import sys
+
+from azure_client import format_output, get_credentials, get_subscription_id
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get NSG rules")
+    parser.add_argument("--resource-group", required=True, help="Resource group name")
+    parser.add_argument("--nsg-name", required=True, help="NSG name")
+    args = parser.parse_args()
+
+    try:
+        from azure.mgmt.network import NetworkManagementClient
+
+        credential = get_credentials()
+        subscription_id = get_subscription_id()
+        network_client = NetworkManagementClient(credential, subscription_id)
+
+        nsg = network_client.network_security_groups.get(
+            args.resource_group, args.nsg_name
+        )
+
+        rules = []
+        if nsg.security_rules:
+            for rule in nsg.security_rules:
+                rules.append(
+                    {
+                        "name": rule.name,
+                        "priority": rule.priority,
+                        "direction": rule.direction,
+                        "access": rule.access,
+                        "protocol": rule.protocol,
+                        "source_address_prefix": rule.source_address_prefix,
+                        "source_port_range": rule.source_port_range,
+                        "destination_address_prefix": rule.destination_address_prefix,
+                        "destination_port_range": rule.destination_port_range,
+                        "description": rule.description,
+                    }
+                )
+
+        print(
+            format_output(
+                {
+                    "subscription_id": subscription_id,
+                    "resource_group": args.resource_group,
+                    "nsg_name": args.nsg_name,
+                    "rule_count": len(rules),
+                    "rules": rules,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e), "nsg_name": args.nsg_name}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-azure/scripts/list_aks_clusters.py
+++ b/sre-agent/.claude/skills/infrastructure-azure/scripts/list_aks_clusters.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""List Azure Kubernetes Service (AKS) clusters."""
+
+import argparse
+import sys
+
+from azure_client import format_output, get_credentials, get_subscription_id
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List AKS clusters")
+    parser.add_argument("--resource-group", help="Resource group name (default: all)")
+    args = parser.parse_args()
+
+    try:
+        from azure.mgmt.containerservice import ContainerServiceClient
+
+        credential = get_credentials()
+        subscription_id = get_subscription_id()
+        aks_client = ContainerServiceClient(credential, subscription_id)
+
+        if args.resource_group:
+            clusters = aks_client.managed_clusters.list_by_resource_group(
+                args.resource_group
+            )
+        else:
+            clusters = aks_client.managed_clusters.list()
+
+        cluster_list = []
+        for cluster in clusters:
+            cluster_list.append(
+                {
+                    "name": cluster.name,
+                    "id": cluster.id,
+                    "location": cluster.location,
+                    "kubernetes_version": cluster.kubernetes_version,
+                    "provisioning_state": cluster.provisioning_state,
+                    "fqdn": cluster.fqdn,
+                    "tags": cluster.tags or {},
+                }
+            )
+
+        print(
+            format_output(
+                {
+                    "subscription_id": subscription_id,
+                    "resource_group": args.resource_group,
+                    "cluster_count": len(cluster_list),
+                    "clusters": cluster_list,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-azure/scripts/list_monitor_alerts.py
+++ b/sre-agent/.claude/skills/infrastructure-azure/scripts/list_monitor_alerts.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""List Azure Monitor alert rules."""
+
+import argparse
+import sys
+
+from azure_client import format_output, get_credentials, get_subscription_id
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Azure Monitor alerts")
+    parser.add_argument("--resource-group", help="Resource group name (default: all)")
+    args = parser.parse_args()
+
+    try:
+        from azure.mgmt.monitor import MonitorManagementClient
+
+        credential = get_credentials()
+        subscription_id = get_subscription_id()
+        client = MonitorManagementClient(credential, subscription_id)
+
+        if args.resource_group:
+            alerts = client.alert_rules.list_by_resource_group(args.resource_group)
+        else:
+            alerts = client.alert_rules.list_by_subscription()
+
+        alert_list = []
+        for alert in alerts:
+            alert_list.append(
+                {
+                    "name": alert.name,
+                    "id": alert.id,
+                    "location": alert.location,
+                    "enabled": alert.is_enabled,
+                    "description": getattr(alert, "description", None),
+                }
+            )
+
+        print(
+            format_output(
+                {
+                    "resource_group": args.resource_group,
+                    "subscription_id": subscription_id,
+                    "alert_count": len(alert_list),
+                    "alerts": alert_list,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-azure/scripts/list_vms.py
+++ b/sre-agent/.claude/skills/infrastructure-azure/scripts/list_vms.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""List Azure Virtual Machines."""
+
+import argparse
+import sys
+
+from azure_client import format_output, get_credentials, get_subscription_id
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Azure VMs")
+    parser.add_argument("--resource-group", help="Resource group name (default: all)")
+    args = parser.parse_args()
+
+    try:
+        from azure.mgmt.compute import ComputeManagementClient
+
+        credential = get_credentials()
+        subscription_id = get_subscription_id()
+        compute_client = ComputeManagementClient(credential, subscription_id)
+
+        if args.resource_group:
+            vms = compute_client.virtual_machines.list(args.resource_group)
+        else:
+            vms = compute_client.virtual_machines.list_all()
+
+        vm_list = []
+        for vm in vms:
+            vm_list.append(
+                {
+                    "name": vm.name,
+                    "id": vm.id,
+                    "location": vm.location,
+                    "vm_size": vm.hardware_profile.vm_size,
+                    "provisioning_state": vm.provisioning_state,
+                    "tags": vm.tags or {},
+                }
+            )
+
+        print(
+            format_output(
+                {
+                    "subscription_id": subscription_id,
+                    "resource_group": args.resource_group,
+                    "vm_count": len(vm_list),
+                    "vms": vm_list,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-azure/scripts/query_costs.py
+++ b/sre-agent/.claude/skills/infrastructure-azure/scripts/query_costs.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Query Azure Cost Management data."""
+
+import argparse
+import sys
+
+from azure_client import format_output, get_credentials, get_subscription_id
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Query Azure Cost Management")
+    parser.add_argument("--start", required=True, help="Start date (YYYY-MM-DD)")
+    parser.add_argument("--end", required=True, help="End date (YYYY-MM-DD)")
+    parser.add_argument(
+        "--granularity",
+        default="Monthly",
+        choices=["Daily", "Monthly"],
+        help="Granularity",
+    )
+    parser.add_argument(
+        "--group-by",
+        help="Comma-separated dimensions (e.g., ResourceGroup,ServiceName)",
+    )
+    parser.add_argument("--scope", help="Scope (default: /subscriptions/<sub-id>)")
+    args = parser.parse_args()
+
+    try:
+        from azure.mgmt.costmanagement import CostManagementClient
+        from azure.mgmt.costmanagement.models import (
+            QueryAggregation,
+            QueryDataset,
+            QueryDefinition,
+            QueryGrouping,
+            QueryTimePeriod,
+        )
+
+        credential = get_credentials()
+        subscription_id = get_subscription_id()
+        cost_client = CostManagementClient(credential)
+
+        dataset = QueryDataset(
+            granularity=args.granularity,
+            aggregation={"totalCost": QueryAggregation(name="Cost", function="Sum")},
+        )
+
+        if args.group_by:
+            dataset.grouping = [
+                QueryGrouping(type="Dimension", name=dim.strip())
+                for dim in args.group_by.split(",")
+            ]
+
+        query = QueryDefinition(
+            type="Usage",
+            timeframe="Custom",
+            time_period=QueryTimePeriod(from_property=args.start, to=args.end),
+            dataset=dataset,
+        )
+
+        scope = args.scope or f"/subscriptions/{subscription_id}"
+        result = cost_client.query.usage(scope, query)
+
+        rows = []
+        if result.rows:
+            columns = [col.name for col in result.columns]
+            for row in result.rows:
+                row_dict = {}
+                for i, col in enumerate(columns):
+                    row_dict[col] = row[i]
+                rows.append(row_dict)
+
+        total_cost = sum(float(row.get("Cost", 0)) for row in rows)
+
+        print(
+            format_output(
+                {
+                    "scope": scope,
+                    "time_period": {"start": args.start, "end": args.end},
+                    "granularity": args.granularity,
+                    "total_cost": round(total_cost, 2),
+                    "currency": "USD",
+                    "row_count": len(rows),
+                    "rows": rows,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-azure/scripts/query_log_analytics.py
+++ b/sre-agent/.claude/skills/infrastructure-azure/scripts/query_log_analytics.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Query Azure Log Analytics using KQL."""
+
+import argparse
+import sys
+from datetime import datetime, timedelta
+
+from azure_client import format_output, get_credentials
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Query Azure Log Analytics")
+    parser.add_argument(
+        "--workspace-id", required=True, help="Log Analytics workspace ID (GUID)"
+    )
+    parser.add_argument("--query", required=True, help="KQL query string")
+    parser.add_argument(
+        "--timespan", help="ISO 8601 duration (e.g., PT1H, P1D). Default: PT24H"
+    )
+    args = parser.parse_args()
+
+    try:
+        from azure.monitor.query import LogsQueryClient
+
+        credential = get_credentials()
+        client = LogsQueryClient(credential)
+
+        timespan = args.timespan if args.timespan else timedelta(hours=24)
+
+        response = client.query_workspace(
+            workspace_id=args.workspace_id,
+            query=args.query,
+            timespan=timespan,
+        )
+
+        if response.status == "Success":
+            tables = []
+            for table in response.tables:
+                rows = []
+                for row in table.rows:
+                    row_dict = {}
+                    for i, column in enumerate(table.columns):
+                        value = row[i]
+                        if isinstance(value, datetime):
+                            value = value.isoformat()
+                        row_dict[column.name] = value
+                    rows.append(row_dict)
+                tables.append(
+                    {"name": table.name, "row_count": len(rows), "rows": rows}
+                )
+
+            print(
+                format_output(
+                    {
+                        "workspace_id": args.workspace_id,
+                        "query": args.query,
+                        "status": "Success",
+                        "tables": tables,
+                    }
+                )
+            )
+        else:
+            print(
+                format_output(
+                    {
+                        "workspace_id": args.workspace_id,
+                        "query": args.query,
+                        "status": "Partial",
+                        "error": "Partial results or query timeout",
+                    }
+                )
+            )
+
+    except Exception as e:
+        print(format_output({"error": str(e), "workspace_id": args.workspace_id}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-azure/scripts/query_resource_graph.py
+++ b/sre-agent/.claude/skills/infrastructure-azure/scripts/query_resource_graph.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Query Azure resources using Azure Resource Graph (KQL-based)."""
+
+import argparse
+import sys
+from datetime import datetime
+
+from azure_client import format_output, get_credentials, get_subscription_id
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Query Azure Resource Graph")
+    parser.add_argument("--query", required=True, help="KQL query string")
+    parser.add_argument(
+        "--subscriptions", nargs="*", help="Subscription IDs (defaults to configured)"
+    )
+    args = parser.parse_args()
+
+    try:
+        from azure.mgmt.resourcegraph import ResourceGraphClient
+        from azure.mgmt.resourcegraph.models import QueryRequest
+
+        credential = get_credentials()
+        client = ResourceGraphClient(credential)
+
+        subscriptions = args.subscriptions or [get_subscription_id()]
+        query_request = QueryRequest(subscriptions=subscriptions, query=args.query)
+        response = client.resources(query_request)
+
+        results = []
+        for item in response.data:
+            item_dict = dict(item)
+            for key, value in item_dict.items():
+                if isinstance(value, datetime):
+                    item_dict[key] = value.isoformat()
+            results.append(item_dict)
+
+        print(
+            format_output(
+                {
+                    "query": args.query,
+                    "total_records": response.total_records,
+                    "count": response.count,
+                    "results": results,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e), "query": args.query}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-docker/SKILL.md
+++ b/sre-agent/.claude/skills/infrastructure-docker/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: infrastructure-docker
+description: Docker container debugging and management. Use when investigating container issues, checking logs, resource usage, or Docker Compose services.
+allowed-tools: Bash(python *)
+---
+
+# Docker Debugging
+
+## Authentication
+
+Docker commands run directly via the Docker CLI. No API keys are needed - the Docker socket must be accessible in the sandbox environment.
+
+---
+
+## Available Scripts
+
+All scripts are in `.claude/skills/infrastructure-docker/scripts/`
+
+### container_ps.py - List Containers
+```bash
+python .claude/skills/infrastructure-docker/scripts/container_ps.py [--all]
+```
+
+### container_logs.py - Get Container Logs
+```bash
+python .claude/skills/infrastructure-docker/scripts/container_logs.py --container NAME_OR_ID [--tail 100]
+```
+
+### container_inspect.py - Inspect Container
+```bash
+python .claude/skills/infrastructure-docker/scripts/container_inspect.py --container NAME_OR_ID
+```
+
+### container_stats.py - Resource Usage Statistics
+```bash
+python .claude/skills/infrastructure-docker/scripts/container_stats.py [--container NAME_OR_ID]
+```
+
+### image_list.py - List Docker Images
+```bash
+python .claude/skills/infrastructure-docker/scripts/image_list.py [--filter "reference=myapp*"]
+```
+
+### compose_ps.py - List Compose Services
+```bash
+python .claude/skills/infrastructure-docker/scripts/compose_ps.py [--file docker-compose.yml] [--cwd /path]
+```
+
+### compose_logs.py - Get Compose Service Logs
+```bash
+python .claude/skills/infrastructure-docker/scripts/compose_logs.py [--services "api,db"] [--tail 100]
+```
+
+---
+
+## Investigation Workflow
+
+### Container Debugging
+```
+1. List containers: container_ps.py --all
+2. Check logs: container_logs.py --container <name> --tail 200
+3. Check resources: container_stats.py --container <name>
+4. Inspect config: container_inspect.py --container <name>
+```
+
+### Docker Compose Debugging
+```
+1. Check services: compose_ps.py
+2. Check logs: compose_logs.py --services "api,worker" --tail 100
+```
+
+---
+
+## Anti-Patterns to Avoid
+
+1. **Never run destructive commands** without explicit user approval (docker rm, docker rmi, docker system prune)
+2. **Always use --tail** for logs to avoid overwhelming output
+3. **Check container status first** before trying to exec into it

--- a/sre-agent/.claude/skills/infrastructure-docker/scripts/compose_logs.py
+++ b/sre-agent/.claude/skills/infrastructure-docker/scripts/compose_logs.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Get Docker Compose service logs.
+
+Usage:
+    python compose_logs.py [--services "api,db"] [--tail 100]
+"""
+
+import argparse
+import json
+import sys
+
+from docker_runner import run_docker
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Docker Compose logs")
+    parser.add_argument(
+        "--file", default="docker-compose.yml", help="Compose file path"
+    )
+    parser.add_argument("--services", default="", help="Comma-separated service names")
+    parser.add_argument(
+        "--tail", type=int, default=100, help="Lines from end (default: 100)"
+    )
+    parser.add_argument("--cwd", default=".", help="Working directory")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    docker_args = ["compose", "-f", args.file, "logs", "--tail", str(args.tail)]
+    if args.services:
+        docker_args.extend(args.services.split(","))
+
+    result = run_docker(docker_args, cwd=args.cwd or None)
+    if result.get("ok"):
+        result["logs"] = result.get("stdout", "")
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        if not result.get("ok"):
+            print(
+                f"Error: {result.get('error', result.get('stderr', 'Unknown'))}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(result.get("logs", ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-docker/scripts/compose_ps.py
+++ b/sre-agent/.claude/skills/infrastructure-docker/scripts/compose_ps.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""List Docker Compose services.
+
+Usage:
+    python compose_ps.py [--file docker-compose.yml] [--cwd /path]
+"""
+
+import argparse
+import json
+import sys
+
+from docker_runner import run_docker
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Docker Compose services")
+    parser.add_argument(
+        "--file", default="docker-compose.yml", help="Compose file path"
+    )
+    parser.add_argument("--cwd", default=".", help="Working directory")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    result = run_docker(
+        ["compose", "-f", args.file, "ps", "--format", "json"], cwd=args.cwd or None
+    )
+    if result.get("ok"):
+        try:
+            result["services"] = json.loads(result.get("stdout", "[]"))
+        except json.JSONDecodeError:
+            result["services"] = []
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        if not result.get("ok"):
+            print(
+                f"Error: {result.get('error', result.get('stderr', 'Unknown'))}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        services = result.get("services", [])
+        if isinstance(services, list):
+            for svc in services:
+                if isinstance(svc, dict):
+                    print(
+                        f"  {svc.get('Name', '?'):30s} {svc.get('State', '?'):15s} {svc.get('Status', '')}"
+                    )
+        else:
+            print(result.get("stdout", ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-docker/scripts/container_inspect.py
+++ b/sre-agent/.claude/skills/infrastructure-docker/scripts/container_inspect.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Inspect a Docker container.
+
+Usage:
+    python container_inspect.py --container NAME_OR_ID
+"""
+
+import argparse
+import json
+import sys
+
+from docker_runner import run_docker
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Inspect a Docker container")
+    parser.add_argument("--container", required=True, help="Container name or ID")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    result = run_docker(["inspect", args.container])
+    if result.get("ok"):
+        try:
+            result["inspection"] = json.loads(result.get("stdout", "[]"))
+        except json.JSONDecodeError:
+            result["inspection"] = []
+
+    if args.json:
+        # Redact environment variables in JSON output too
+        _sensitive_patterns = [
+            "password",
+            "secret",
+            "token",
+            "key",
+            "credential",
+            "auth",
+            "dsn",
+            "url",
+            "uri",
+            "connection",
+            "api_key",
+            "apikey",
+            "access_key",
+            "private",
+            "jwt",
+        ]
+        for item in result.get("inspection", []):
+            env_list = item.get("Config", {}).get("Env", [])
+            for i, e in enumerate(env_list):
+                key = e.split("=")[0] if "=" in e else e
+                val = e.split("=", 1)[1] if "=" in e else ""
+                key_lower = key.lower()
+                if any(s in key_lower for s in _sensitive_patterns) or (
+                    "://" in val and "@" in val
+                ):
+                    env_list[i] = f"{key}=***REDACTED***"
+        # Remove raw stdout to avoid leaking unredacted data
+        result.pop("stdout", None)
+        print(json.dumps(result, indent=2))
+    else:
+        if not result.get("ok"):
+            print(
+                f"Error: {result.get('error', result.get('stderr', 'Unknown'))}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        inspection = result.get("inspection", [{}])
+        if inspection:
+            info = inspection[0]
+            state = info.get("State", {})
+            config = info.get("Config", {})
+            print(f"Container: {info.get('Name', '?').lstrip('/')}")
+            print(f"Image: {config.get('Image', '?')}")
+            print(
+                f"Status: {state.get('Status', '?')} (Running: {state.get('Running', '?')})"
+            )
+            print(f"Started: {state.get('StartedAt', '?')}")
+            env = config.get("Env", [])
+            if env:
+                print(f"\nEnvironment ({len(env)} vars):")
+                _sensitive_patterns = [
+                    "password",
+                    "secret",
+                    "token",
+                    "key",
+                    "credential",
+                    "auth",
+                    "dsn",
+                    "url",
+                    "uri",
+                    "connection",
+                    "api_key",
+                    "apikey",
+                    "access_key",
+                    "private",
+                    "jwt",
+                ]
+                for e in env[:20]:
+                    key = e.split("=")[0] if "=" in e else e
+                    val = e.split("=", 1)[1] if "=" in e else ""
+                    key_lower = key.lower()
+                    # Redact if key matches sensitive pattern or value looks like a URL with credentials
+                    if any(s in key_lower for s in _sensitive_patterns) or (
+                        "://" in val and "@" in val
+                    ):
+                        print(f"  {key}=***REDACTED***")
+                    else:
+                        print(f"  {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-docker/scripts/container_logs.py
+++ b/sre-agent/.claude/skills/infrastructure-docker/scripts/container_logs.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Get Docker container logs.
+
+Usage:
+    python container_logs.py --container NAME_OR_ID [--tail 100]
+"""
+
+import argparse
+import json
+import sys
+
+from docker_runner import run_docker
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get container logs")
+    parser.add_argument("--container", required=True, help="Container name or ID")
+    parser.add_argument(
+        "--tail", type=int, default=100, help="Lines from end (default: 100)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    result = run_docker(["logs", "--tail", str(args.tail), args.container])
+    if result.get("ok"):
+        result["logs"] = result.get("stdout", "") + result.get("stderr", "")
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        if not result.get("ok"):
+            print(
+                f"Error: {result.get('error', result.get('stderr', 'Unknown'))}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(result.get("logs", ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-docker/scripts/container_ps.py
+++ b/sre-agent/.claude/skills/infrastructure-docker/scripts/container_ps.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""List Docker containers.
+
+Usage:
+    python container_ps.py [--all]
+"""
+
+import argparse
+import json
+import sys
+
+from docker_runner import parse_pipe_delimited, run_docker
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Docker containers")
+    parser.add_argument("--all", action="store_true", help="Include stopped containers")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    docker_args = [
+        "ps",
+        "--format",
+        "{{.ID}}|{{.Names}}|{{.Image}}|{{.Status}}|{{.Ports}}",
+    ]
+    if args.all:
+        docker_args.append("-a")
+
+    result = run_docker(docker_args)
+    if result.get("ok"):
+        result["containers"] = parse_pipe_delimited(
+            result.get("stdout", ""), ["id", "name", "image", "status", "ports"]
+        )
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        if not result.get("ok"):
+            print(
+                f"Error: {result.get('error', result.get('stderr', 'Unknown'))}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        for c in result.get("containers", []):
+            print(f"  {c['name']:30s} {c['status']:20s} {c['image']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-docker/scripts/container_stats.py
+++ b/sre-agent/.claude/skills/infrastructure-docker/scripts/container_stats.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Get Docker container resource usage statistics.
+
+Usage:
+    python container_stats.py [--container NAME_OR_ID]
+"""
+
+import argparse
+import json
+import sys
+
+from docker_runner import parse_pipe_delimited, run_docker
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Container resource usage stats")
+    parser.add_argument("--container", default="", help="Specific container (optional)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    docker_args = [
+        "stats",
+        "--no-stream",
+        "--format",
+        "{{.Name}}|{{.CPUPerc}}|{{.MemUsage}}|{{.NetIO}}|{{.BlockIO}}",
+    ]
+    if args.container:
+        docker_args.append(args.container)
+
+    result = run_docker(docker_args, timeout_s=30.0)
+    if result.get("ok"):
+        result["stats"] = parse_pipe_delimited(
+            result.get("stdout", ""), ["name", "cpu", "memory", "net_io", "block_io"]
+        )
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        if not result.get("ok"):
+            print(
+                f"Error: {result.get('error', result.get('stderr', 'Unknown'))}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(f"{'NAME':30s} {'CPU':10s} {'MEMORY':25s} {'NET I/O':20s}")
+        print("-" * 85)
+        for s in result.get("stats", []):
+            print(f"{s['name']:30s} {s['cpu']:10s} {s['memory']:25s} {s['net_io']:20s}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-docker/scripts/docker_runner.py
+++ b/sre-agent/.claude/skills/infrastructure-docker/scripts/docker_runner.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Shared Docker command runner.
+
+Provides subprocess-based Docker CLI execution with structured output.
+"""
+
+import subprocess
+from typing import Any
+
+_ALLOWED_SUBCOMMANDS = frozenset(
+    {
+        "ps",
+        "logs",
+        "inspect",
+        "stats",
+        "top",
+        "events",
+        "diff",
+        "images",
+        "info",
+        "version",
+    }
+)
+
+# For multi-level commands (docker container ls, docker network inspect),
+# block destructive sub-subcommands
+_BLOCKED_SUB_SUBCOMMANDS = frozenset(
+    {
+        "rm",
+        "remove",
+        "prune",
+        "kill",
+        "stop",
+        "pause",
+        "unpause",
+        "create",
+        "run",
+        "exec",
+        "attach",
+        "commit",
+        "export",
+        "import",
+        "push",
+        "pull",
+        "build",
+        "tag",
+        "rmi",
+        "load",
+        "save",
+        "connect",
+        "disconnect",
+    }
+)
+
+# These top-level commands are allowed but restricted to read-only sub-subcommands
+_MULTI_LEVEL_COMMANDS = frozenset(
+    {
+        "container",
+        "image",
+        "system",
+        "network",
+        "volume",
+        "compose",
+    }
+)
+
+
+def run_docker(
+    args: list[str],
+    cwd: str | None = None,
+    timeout_s: float = 300.0,
+) -> dict[str, Any]:
+    """Run a docker command and return structured output."""
+    subcmd = args[0] if args else ""
+    all_allowed = _ALLOWED_SUBCOMMANDS | _MULTI_LEVEL_COMMANDS
+    if subcmd not in all_allowed:
+        allowed = ", ".join(sorted(all_allowed))
+        return {
+            "ok": False,
+            "error": f"Subcommand '{subcmd}' not allowed. Allowed: {allowed}",
+            "cmd": f"docker {' '.join(args)}",
+        }
+    # For multi-level commands, check that the sub-subcommand is not destructive
+    if subcmd in _MULTI_LEVEL_COMMANDS and len(args) > 1:
+        sub_subcmd = args[1]
+        if sub_subcmd in _BLOCKED_SUB_SUBCOMMANDS:
+            return {
+                "ok": False,
+                "error": f"Destructive operation 'docker {subcmd} {sub_subcmd}' is not allowed.",
+                "cmd": f"docker {' '.join(args)}",
+            }
+    cmd = ["docker"] + args
+    try:
+        result = subprocess.run(
+            cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout_s
+        )
+        return {
+            "ok": result.returncode == 0,
+            "exit_code": result.returncode,
+            "stdout": result.stdout[-20000:] if result.stdout else "",
+            "stderr": result.stderr[-5000:] if result.stderr else "",
+            "cmd": " ".join(cmd),
+        }
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": "Command timed out", "cmd": " ".join(cmd)}
+    except FileNotFoundError:
+        return {"ok": False, "error": "docker not found in PATH", "cmd": " ".join(cmd)}
+    except Exception as e:
+        return {"ok": False, "error": str(e), "cmd": " ".join(cmd)}
+
+
+def parse_pipe_delimited(output: str, field_names: list[str]) -> list[dict[str, str]]:
+    """Parse pipe-delimited docker format output into list of dicts."""
+    items = []
+    for line in output.strip().split("\n"):
+        if line:
+            parts = line.split("|")
+            if len(parts) >= len(field_names):
+                items.append({name: parts[i] for i, name in enumerate(field_names)})
+    return items

--- a/sre-agent/.claude/skills/infrastructure-docker/scripts/image_list.py
+++ b/sre-agent/.claude/skills/infrastructure-docker/scripts/image_list.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""List Docker images.
+
+Usage:
+    python image_list.py [--filter "reference=myapp*"]
+"""
+
+import argparse
+import json
+import sys
+
+from docker_runner import parse_pipe_delimited, run_docker
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Docker images")
+    parser.add_argument("--filter", default="", help="Filter pattern")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    docker_args = [
+        "images",
+        "--format",
+        "{{.Repository}}|{{.Tag}}|{{.ID}}|{{.Size}}|{{.CreatedAt}}",
+    ]
+    if args.filter:
+        docker_args.extend(["--filter", args.filter])
+
+    result = run_docker(docker_args)
+    if result.get("ok"):
+        result["images"] = parse_pipe_delimited(
+            result.get("stdout", ""), ["repository", "tag", "id", "size", "created"]
+        )
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        if not result.get("ok"):
+            print(
+                f"Error: {result.get('error', result.get('stderr', 'Unknown'))}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(f"{'REPOSITORY':40s} {'TAG':15s} {'SIZE':10s} {'ID':15s}")
+        for img in result.get("images", []):
+            print(
+                f"{img['repository']:40s} {img['tag']:15s} {img['size']:10s} {img['id']:15s}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-gcp/SKILL.md
+++ b/sre-agent/.claude/skills/infrastructure-gcp/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: infrastructure-gcp
+description: Google Cloud Platform infrastructure inspection. Use when investigating GCP Compute instances, GKE clusters, Cloud Functions, Cloud SQL, or project metadata.
+allowed-tools: Bash(python *)
+---
+
+# GCP Infrastructure
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `GCP_SERVICE_ACCOUNT_KEY` in environment variables - it won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `GCP_PROJECT_ID` - GCP project ID
+
+---
+
+## Available Scripts
+
+All scripts are in `.claude/skills/infrastructure-gcp/scripts/`
+
+### list_compute_instances.py - List Compute Engine VMs
+```bash
+python .claude/skills/infrastructure-gcp/scripts/list_compute_instances.py [--zone us-central1-a]
+```
+
+### list_gke_clusters.py - List GKE Clusters
+```bash
+python .claude/skills/infrastructure-gcp/scripts/list_gke_clusters.py
+```
+
+### list_cloud_functions.py - List Cloud Functions
+```bash
+python .claude/skills/infrastructure-gcp/scripts/list_cloud_functions.py
+```
+
+### list_cloud_sql.py - List Cloud SQL Instances
+```bash
+python .claude/skills/infrastructure-gcp/scripts/list_cloud_sql.py
+```
+
+### get_project_metadata.py - Project Info
+```bash
+python .claude/skills/infrastructure-gcp/scripts/get_project_metadata.py
+```
+
+---
+
+## Investigation Workflow
+
+### GKE Cluster Issue
+```
+1. list_gke_clusters.py
+2. Use infrastructure-kubernetes skill for pod-level debugging
+```
+
+### Compute Instance Issue
+```
+1. list_compute_instances.py --zone <zone>
+2. Check instance status and IPs
+```

--- a/sre-agent/.claude/skills/infrastructure-gcp/scripts/gcp_client.py
+++ b/sre-agent/.claude/skills/infrastructure-gcp/scripts/gcp_client.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Shared GCP client with credential support.
+
+Credentials are injected transparently by the proxy layer.
+"""
+
+import json
+import os
+
+
+def get_config() -> dict[str, str | None]:
+    """Get GCP configuration from environment."""
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+        "project_id": os.getenv("GCP_PROJECT_ID", ""),
+    }
+
+
+def get_project_id() -> str:
+    """Get the GCP project ID."""
+    project_id = os.getenv("GCP_PROJECT_ID", "")
+    if not project_id:
+        raise RuntimeError("GCP_PROJECT_ID must be set")
+    return project_id
+
+
+def get_credentials():
+    """Get GCP credentials.
+
+    Supports:
+    1. Service account key (GCP_SERVICE_ACCOUNT_KEY env var)
+    2. Application default credentials
+    """
+    sa_key = os.getenv("GCP_SERVICE_ACCOUNT_KEY")
+    if sa_key:
+        from google.oauth2 import service_account
+
+        credentials_dict = json.loads(sa_key)
+        return service_account.Credentials.from_service_account_info(credentials_dict)
+
+    from google.auth import default
+
+    credentials, _ = default()
+    return credentials
+
+
+def build_service(service_name: str, version: str):
+    """Build a Google API service client."""
+    from googleapiclient import discovery
+
+    return discovery.build(service_name, version, credentials=get_credentials())
+
+
+def format_output(data: dict) -> str:
+    """Format output as JSON string."""
+    return json.dumps(data, indent=2, default=str)

--- a/sre-agent/.claude/skills/infrastructure-gcp/scripts/get_project_metadata.py
+++ b/sre-agent/.claude/skills/infrastructure-gcp/scripts/get_project_metadata.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Get GCP project metadata."""
+
+import sys
+
+from gcp_client import build_service, format_output, get_project_id
+
+
+def main():
+    try:
+        project_id = get_project_id()
+        crm = build_service("cloudresourcemanager", "v1")
+
+        project = crm.projects().get(projectId=project_id).execute()
+
+        print(
+            format_output(
+                {
+                    "project_id": project["projectId"],
+                    "project_number": project["projectNumber"],
+                    "name": project.get("name"),
+                    "lifecycle_state": project.get("lifecycleState"),
+                    "create_time": project.get("createTime"),
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-gcp/scripts/list_cloud_functions.py
+++ b/sre-agent/.claude/skills/infrastructure-gcp/scripts/list_cloud_functions.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""List GCP Cloud Functions."""
+
+import sys
+
+from gcp_client import build_service, format_output, get_project_id
+
+
+def main():
+    try:
+        project_id = get_project_id()
+        functions = build_service("cloudfunctions", "v1")
+
+        parent = f"projects/{project_id}/locations/-"
+        result = (
+            functions.projects().locations().functions().list(parent=parent).execute()
+        )
+
+        function_list = []
+        for function in result.get("functions", []):
+            function_list.append(
+                {
+                    "name": function["name"].split("/")[-1],
+                    "runtime": function.get("runtime"),
+                    "status": function.get("status"),
+                    "entry_point": function.get("entryPoint"),
+                    "https_trigger": function.get("httpsTrigger", {}).get("url"),
+                    "update_time": function.get("updateTime"),
+                }
+            )
+
+        print(
+            format_output(
+                {
+                    "project_id": project_id,
+                    "function_count": len(function_list),
+                    "functions": function_list,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-gcp/scripts/list_cloud_sql.py
+++ b/sre-agent/.claude/skills/infrastructure-gcp/scripts/list_cloud_sql.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""List GCP Cloud SQL instances."""
+
+import sys
+
+from gcp_client import build_service, format_output, get_project_id
+
+
+def main():
+    try:
+        project_id = get_project_id()
+        sqladmin = build_service("sqladmin", "v1beta4")
+
+        result = sqladmin.instances().list(project=project_id).execute()
+
+        instances = []
+        for instance in result.get("items", []):
+            instances.append(
+                {
+                    "name": instance["name"],
+                    "database_version": instance.get("databaseVersion"),
+                    "state": instance.get("state"),
+                    "region": instance.get("region"),
+                    "tier": instance["settings"].get("tier"),
+                    "ip_addresses": [
+                        ip["ipAddress"] for ip in instance.get("ipAddresses", [])
+                    ],
+                }
+            )
+
+        print(
+            format_output(
+                {
+                    "project_id": project_id,
+                    "instance_count": len(instances),
+                    "instances": instances,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-gcp/scripts/list_compute_instances.py
+++ b/sre-agent/.claude/skills/infrastructure-gcp/scripts/list_compute_instances.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""List GCP Compute Engine VM instances."""
+
+import argparse
+import sys
+
+from gcp_client import build_service, format_output, get_project_id
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Compute Engine instances")
+    parser.add_argument(
+        "--zone", help="Zone filter (e.g., us-central1-a). Default: all zones"
+    )
+    args = parser.parse_args()
+
+    try:
+        project_id = get_project_id()
+        compute = build_service("compute", "v1")
+
+        instances = []
+
+        if args.zone:
+            result = (
+                compute.instances().list(project=project_id, zone=args.zone).execute()
+            )
+            for instance in result.get("items", []):
+                instances.append(_parse_instance(instance, args.zone))
+        else:
+            zones_result = compute.zones().list(project=project_id).execute()
+            for zone_data in zones_result.get("items", []):
+                zone_name = zone_data["name"]
+                result = (
+                    compute.instances()
+                    .list(project=project_id, zone=zone_name)
+                    .execute()
+                )
+                for instance in result.get("items", []):
+                    instances.append(_parse_instance(instance, zone_name))
+
+        print(
+            format_output(
+                {
+                    "project_id": project_id,
+                    "zone": args.zone or "all",
+                    "instance_count": len(instances),
+                    "instances": instances,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+def _parse_instance(instance: dict, zone: str) -> dict:
+    return {
+        "name": instance["name"],
+        "zone": zone,
+        "machine_type": instance["machineType"].split("/")[-1],
+        "status": instance["status"],
+        "internal_ip": (
+            instance["networkInterfaces"][0].get("networkIP")
+            if instance.get("networkInterfaces")
+            else None
+        ),
+        "external_ip": (
+            instance["networkInterfaces"][0].get("accessConfigs", [{}])[0].get("natIP")
+            if instance.get("networkInterfaces")
+            else None
+        ),
+    }
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-gcp/scripts/list_gke_clusters.py
+++ b/sre-agent/.claude/skills/infrastructure-gcp/scripts/list_gke_clusters.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""List Google Kubernetes Engine (GKE) clusters."""
+
+import sys
+
+from gcp_client import build_service, format_output, get_project_id
+
+
+def main():
+    try:
+        project_id = get_project_id()
+        container = build_service("container", "v1")
+
+        parent = f"projects/{project_id}/locations/-"
+        result = (
+            container.projects().locations().clusters().list(parent=parent).execute()
+        )
+
+        clusters = []
+        for cluster in result.get("clusters", []):
+            clusters.append(
+                {
+                    "name": cluster["name"],
+                    "location": cluster["location"],
+                    "status": cluster["status"],
+                    "current_master_version": cluster.get("currentMasterVersion"),
+                    "current_node_version": cluster.get("currentNodeVersion"),
+                    "current_node_count": cluster.get("currentNodeCount"),
+                    "endpoint": cluster.get("endpoint"),
+                }
+            )
+
+        print(
+            format_output(
+                {
+                    "project_id": project_id,
+                    "cluster_count": len(clusters),
+                    "clusters": clusters,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-kubernetes/SKILL.md
+++ b/sre-agent/.claude/skills/infrastructure-kubernetes/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: infrastructure-kubernetes
+description: Kubernetes debugging methodology and scripts. Use for pod crashes, CrashLoopBackOff, OOMKilled, deployment issues, resource problems, or container failures.
+---
+
+# Kubernetes Debugging
+
+## Core Principle: Events Before Logs
+
+**ALWAYS check pod events BEFORE logs.** Events explain 80% of issues faster:
+- OOMKilled -> Memory limit exceeded
+- ImagePullBackOff -> Image not found or auth issue
+- FailedScheduling -> No nodes with enough resources
+- CrashLoopBackOff -> Container crashing repeatedly
+
+## Access Mode
+
+Scripts support two modes. Try **direct mode first** (no --cluster-id), then gateway if direct fails.
+
+### Direct mode (kubectl / kubeconfig)
+Run scripts WITHOUT --cluster-id. They use the local kubeconfig (~/.kube/config) or in-cluster service account.
+```bash
+python .claude/skills/infrastructure-kubernetes/scripts/list_pods.py -n otel-demo
+python .claude/skills/infrastructure-kubernetes/scripts/get_events.py <pod-name> -n otel-demo
+python .claude/skills/infrastructure-kubernetes/scripts/get_logs.py <pod-name> -n otel-demo --tail 100
+```
+
+You can also run kubectl directly if the scripts don't cover your use case:
+```bash
+kubectl get pods -n <namespace>
+kubectl get events -n <namespace> --sort-by=.lastTimestamp
+kubectl logs -n <namespace> <pod-name> --tail=100
+kubectl describe pod -n <namespace> <pod-name>
+```
+
+### Gateway mode (remote clusters via k8s-gateway)
+Only if `K8S_GATEWAY_URL` is configured and clusters are registered. Use --cluster-id.
+```bash
+python .claude/skills/infrastructure-kubernetes/scripts/list_clusters.py
+python .claude/skills/infrastructure-kubernetes/scripts/list_pods.py -n production --cluster-id <CLUSTER_ID>
+```
+
+## Available Scripts
+
+All scripts are in `.claude/skills/infrastructure-kubernetes/scripts/`
+
+### list_pods.py - List pods with status
+```bash
+python .claude/skills/infrastructure-kubernetes/scripts/list_pods.py -n <namespace> [--label <selector>]
+```
+
+### get_events.py - Get pod events (USE FIRST!)
+```bash
+python .claude/skills/infrastructure-kubernetes/scripts/get_events.py <pod-name> -n <namespace>
+```
+
+### get_logs.py - Get pod logs
+```bash
+python .claude/skills/infrastructure-kubernetes/scripts/get_logs.py <pod-name> -n <namespace> [--tail N] [--container NAME]
+```
+
+### describe_pod.py - Detailed pod info
+```bash
+python .claude/skills/infrastructure-kubernetes/scripts/describe_pod.py <pod-name> -n <namespace>
+```
+
+### describe_deployment.py - Deployment status and rollout history
+```bash
+python .claude/skills/infrastructure-kubernetes/scripts/describe_deployment.py <deployment-name> -n <namespace>
+```
+
+### list_namespaces.py - List all namespaces
+```bash
+python .claude/skills/infrastructure-kubernetes/scripts/list_namespaces.py
+```
+
+### get_resources.py - Resource usage vs limits
+```bash
+python .claude/skills/infrastructure-kubernetes/scripts/get_resources.py <pod-name> -n <namespace>
+```
+
+### describe_node.py - Node status, conditions, and resource usage
+```bash
+python .claude/skills/infrastructure-kubernetes/scripts/describe_node.py <node-name>
+python .claude/skills/infrastructure-kubernetes/scripts/describe_node.py --all
+```
+
+## Debugging Workflows
+
+### Pod Not Starting (Pending/CrashLoopBackOff)
+1. `list_pods.py` - Check pod status
+2. `get_events.py` - Look for scheduling/pull/crash events
+3. `describe_pod.py` - Check conditions and container states
+4. `get_logs.py` - Only if events don't explain
+
+### Pod Restarting (OOMKilled/Crashes)
+1. `get_events.py` - Check for OOMKilled or error events
+2. `get_resources.py` - Compare usage vs limits
+3. `get_logs.py` - Check for errors before crash
+4. `describe_pod.py` - Check restart count and state
+
+### Deployment Not Progressing
+1. `describe_deployment.py` - Check replica counts and rollout history
+2. `list_pods.py` - Find stuck pods
+3. `get_events.py` - Check events on stuck pods
+
+### Node Resource Issues
+1. `describe_node.py --all` - Check all nodes
+2. `list_pods.py` - Check for Pending pods
+3. `get_events.py` - Look for FailedScheduling
+
+## Common Issues & Solutions
+
+| Event Reason | Meaning | Action |
+|--------------|---------|--------|
+| OOMKilled | Container exceeded memory limit | Increase limits or fix memory leak |
+| ImagePullBackOff | Can't pull image | Check image name, registry auth |
+| CrashLoopBackOff | Container keeps crashing | Check logs for startup errors |
+| FailedScheduling | No node can run pod | Check node resources, taints |
+| Unhealthy | Liveness probe failed | Check probe config, app health |
+
+## Output Format
+
+When reporting findings, use this structure:
+
+```
+## Kubernetes Analysis
+
+**Pod**: <name>
+**Namespace**: <namespace>
+**Status**: <phase> (Restarts: N)
+
+### Events
+- [timestamp] <reason>: <message>
+
+### Issues Found
+1. [Issue description with evidence]
+
+### Root Cause Hypothesis
+[Based on events and logs]
+
+### Recommended Action
+[Specific remediation step]
+```

--- a/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/describe_deployment.py
+++ b/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/describe_deployment.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Describe a Kubernetes deployment with replica status, conditions, and rollout history.
+
+Shows desired vs ready replicas, deployment conditions, revision history,
+and current pod template. Use to diagnose deployment rollout issues,
+scaling problems, or failed updates.
+
+Usage:
+    python describe_deployment.py <deployment-name> -n <namespace>
+    python describe_deployment.py <deployment-name> -n <namespace> --json
+    python describe_deployment.py <deployment-name> -n <namespace> --cluster-id <id>
+
+Examples:
+    python describe_deployment.py payment -n otel-demo
+    python describe_deployment.py frontend -n otel-demo --json
+    python describe_deployment.py frontend -n production --cluster-id abc123
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from k8s_gateway_client import add_cluster_id_arg, execute_command, is_gateway_mode
+from kubernetes import client
+from kubernetes import config as k8s_config
+from kubernetes.client.rest import ApiException
+
+
+def get_k8s_clients():
+    """Get Kubernetes API clients."""
+    in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    kubeconfig = Path.home() / ".kube" / "config"
+
+    if in_cluster.exists():
+        k8s_config.load_incluster_config()
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
+    else:
+        print(
+            "Error: Kubernetes not configured. No in-cluster token or ~/.kube/config.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return client.AppsV1Api(), client.CoreV1Api()
+
+
+def format_deployment(result: dict) -> None:
+    """Print deployment details in human-readable format."""
+    print(f"Deployment: {result.get('name', '-')}")
+    print(f"Namespace:  {result.get('namespace', '-')}")
+    print(f"Created:    {result.get('created', result.get('created_at', '-'))}")
+    print()
+
+    r = result.get("replicas", {})
+    print(
+        f"Replicas:   {r.get('desired', '-')} desired, {r.get('ready', 0)} ready, "
+        f"{r.get('available', 0)} available, {r.get('unavailable', 0)} unavailable"
+    )
+    if result.get("strategy"):
+        s = result["strategy"]
+        st = s if isinstance(s, str) else s.get("type", "-")
+        print(f"Strategy:   {st}")
+    print()
+
+    print("Conditions:")
+    for c in result.get("conditions", []):
+        print(
+            f"  {c.get('type', '-')}: {c.get('status', '-')} - "
+            f"{c.get('reason', '-')}: {c.get('message', '-')}"
+        )
+    print()
+
+    containers = result.get("containers", [])
+    if containers:
+        print("Containers:")
+        for c in containers:
+            print(f"  {c.get('name', '-')}: {c.get('image', '-')}")
+            if c.get("resources"):
+                req = c["resources"].get("requests", {})
+                lim = c["resources"].get("limits", {})
+                if req:
+                    print(
+                        f"    requests: cpu={req.get('cpu', '-')}, memory={req.get('memory', '-')}"
+                    )
+                if lim:
+                    print(
+                        f"    limits:   cpu={lim.get('cpu', '-')}, memory={lim.get('memory', '-')}"
+                    )
+        print()
+
+    revisions = result.get("revisions", [])
+    if revisions:
+        print("Rollout History (last 5):")
+        for rev in revisions:
+            active = " (active)" if rev.get("replicas", 0) > 0 else ""
+            print(
+                f"  Rev {rev.get('revision', '?')}: {rev.get('name', '-')} "
+                f"[{rev.get('ready', 0)}/{rev.get('replicas', 0)} ready]{active}"
+            )
+            if rev.get("image"):
+                print(f"    image: {rev['image']}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Describe Kubernetes deployment")
+    parser.add_argument("deployment_name", help="Deployment name")
+    parser.add_argument(
+        "-n", "--namespace", default="default", help="Kubernetes namespace"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    add_cluster_id_arg(parser)
+    args = parser.parse_args()
+
+    try:
+        if is_gateway_mode(args.cluster_id):
+            result = execute_command(
+                args.cluster_id,
+                "describe_deployment",
+                {
+                    "deployment_name": args.deployment_name,
+                    "namespace": args.namespace,
+                },
+            )
+        else:
+            apps_v1, core_v1 = get_k8s_clients()
+
+            deploy = apps_v1.read_namespaced_deployment(
+                name=args.deployment_name, namespace=args.namespace
+            )
+
+            # Basic info
+            result = {
+                "name": deploy.metadata.name,
+                "namespace": deploy.metadata.namespace,
+                "created": str(deploy.metadata.creation_timestamp),
+                "labels": dict(deploy.metadata.labels or {}),
+            }
+
+            # Replicas
+            spec = deploy.spec
+            status = deploy.status
+            result["replicas"] = {
+                "desired": spec.replicas,
+                "ready": status.ready_replicas or 0,
+                "available": status.available_replicas or 0,
+                "unavailable": status.unavailable_replicas or 0,
+                "updated": status.updated_replicas or 0,
+            }
+
+            # Strategy
+            strategy = spec.strategy
+            if strategy:
+                result["strategy"] = {"type": strategy.type}
+                if strategy.rolling_update:
+                    result["strategy"]["maxSurge"] = str(
+                        strategy.rolling_update.max_surge or ""
+                    )
+                    result["strategy"]["maxUnavailable"] = str(
+                        strategy.rolling_update.max_unavailable or ""
+                    )
+
+            # Conditions
+            conditions = []
+            for c in status.conditions or []:
+                conditions.append(
+                    {
+                        "type": c.type,
+                        "status": c.status,
+                        "reason": c.reason,
+                        "message": c.message,
+                        "last_transition": str(c.last_transition_time),
+                    }
+                )
+            result["conditions"] = conditions
+
+            # Pod template
+            template = spec.template.spec
+            containers = []
+            for c in template.containers:
+                container = {
+                    "name": c.name,
+                    "image": c.image,
+                }
+                if c.resources:
+                    container["resources"] = {
+                        "requests": dict(c.resources.requests or {}),
+                        "limits": dict(c.resources.limits or {}),
+                    }
+                containers.append(container)
+            result["containers"] = containers
+
+            # ReplicaSets (rollout history)
+            selector = deploy.spec.selector.match_labels
+            label_selector = ",".join(f"{k}={v}" for k, v in selector.items())
+            rs_list = apps_v1.list_namespaced_replica_set(
+                namespace=args.namespace, label_selector=label_selector
+            )
+
+            revisions = []
+            for rs in sorted(
+                rs_list.items,
+                key=lambda r: int(
+                    r.metadata.annotations.get("deployment.kubernetes.io/revision", "0")
+                ),
+                reverse=True,
+            )[
+                :5
+            ]:  # Last 5 revisions
+                rev = {
+                    "revision": rs.metadata.annotations.get(
+                        "deployment.kubernetes.io/revision", "?"
+                    ),
+                    "name": rs.metadata.name,
+                    "replicas": rs.status.replicas or 0,
+                    "ready": rs.status.ready_replicas or 0,
+                    "created": str(rs.metadata.creation_timestamp),
+                }
+                # Get image from first container
+                if rs.spec.template.spec.containers:
+                    rev["image"] = rs.spec.template.spec.containers[0].image
+                revisions.append(rev)
+            result["revisions"] = revisions
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            format_deployment(result)
+
+    except ApiException as e:
+        if e.status == 404:
+            print(
+                f"Deployment '{args.deployment_name}' not found in namespace '{args.namespace}'",
+                file=sys.stderr,
+            )
+        else:
+            print(f"Error: Kubernetes API error: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/describe_node.py
+++ b/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/describe_node.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Describe a Kubernetes node with status, conditions, capacity, and resource usage.
+
+Shows node health, allocatable resources, running pods count, and actual
+CPU/memory usage from metrics-server. Use to diagnose node-level issues
+like FailedScheduling, high CPU, memory pressure, or NotReady nodes.
+
+Usage:
+    python describe_node.py <node-name>
+    python describe_node.py --all
+    python describe_node.py --all --json
+
+Examples:
+    python describe_node.py ip-10-0-1-42.ec2.internal
+    python describe_node.py --all
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from kubernetes import client
+from kubernetes import config as k8s_config
+from kubernetes.client.rest import ApiException
+
+
+def get_k8s_clients():
+    """Get Kubernetes API clients."""
+    in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    kubeconfig = Path.home() / ".kube" / "config"
+
+    if in_cluster.exists():
+        k8s_config.load_incluster_config()
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
+    else:
+        print(
+            "Error: Kubernetes not configured. No in-cluster token or ~/.kube/config.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return client.CoreV1Api(), client.CustomObjectsApi()
+
+
+def parse_cpu(cpu_str):
+    """Parse CPU string to millicores."""
+    if not cpu_str:
+        return 0
+    if cpu_str.endswith("n"):
+        return int(cpu_str[:-1]) / 1_000_000
+    if cpu_str.endswith("m"):
+        return int(cpu_str[:-1])
+    return int(float(cpu_str) * 1000)
+
+
+def parse_memory(mem_str):
+    """Parse memory string to MiB."""
+    if not mem_str:
+        return 0
+    units = {"Ki": 1 / 1024, "Mi": 1, "Gi": 1024, "Ti": 1024 * 1024}
+    for suffix, multiplier in units.items():
+        if mem_str.endswith(suffix):
+            return int(float(mem_str[: -len(suffix)]) * multiplier)
+    return int(mem_str) / (1024 * 1024)
+
+
+def describe_node(core_v1, custom_api, node_name):
+    """Get detailed info for a single node."""
+    node = core_v1.read_node(name=node_name)
+
+    # Basic info
+    labels = node.metadata.labels or {}
+    info = {
+        "name": node.metadata.name,
+        "labels": {
+            k: v
+            for k, v in labels.items()
+            if k
+            in (
+                "node.kubernetes.io/instance-type",
+                "topology.kubernetes.io/zone",
+                "kubernetes.io/arch",
+                "kubernetes.io/os",
+            )
+        },
+        "creation": str(node.metadata.creation_timestamp),
+    }
+
+    # Node info
+    node_info = node.status.node_info
+    if node_info:
+        info["runtime"] = {
+            "kubelet": node_info.kubelet_version,
+            "container_runtime": node_info.container_runtime_version,
+            "os_image": node_info.os_image,
+            "kernel": node_info.kernel_version,
+        }
+
+    # Conditions
+    conditions = []
+    for c in node.status.conditions or []:
+        conditions.append(
+            {
+                "type": c.type,
+                "status": c.status,
+                "reason": c.reason,
+                "message": c.message,
+                "last_transition": str(c.last_transition_time),
+            }
+        )
+    info["conditions"] = conditions
+
+    # Capacity and allocatable
+    capacity = node.status.capacity or {}
+    allocatable = node.status.allocatable or {}
+    info["capacity"] = {
+        "cpu": capacity.get("cpu", ""),
+        "memory": capacity.get("memory", ""),
+        "pods": capacity.get("pods", ""),
+    }
+    info["allocatable"] = {
+        "cpu": allocatable.get("cpu", ""),
+        "memory": allocatable.get("memory", ""),
+        "pods": allocatable.get("pods", ""),
+    }
+
+    # Taints
+    taints = []
+    for t in node.spec.taints or []:
+        taints.append({"key": t.key, "value": t.value or "", "effect": t.effect})
+    info["taints"] = taints
+
+    # Pod count on this node
+    pods = core_v1.list_pod_for_all_namespaces(
+        field_selector=f"spec.nodeName={node_name},status.phase!=Succeeded,status.phase!=Failed"
+    )
+    info["running_pods"] = len(pods.items)
+
+    # Metrics from metrics-server
+    info["usage"] = None
+    try:
+        metrics = custom_api.get_cluster_custom_object(
+            group="metrics.k8s.io",
+            version="v1beta1",
+            plural="nodes",
+            name=node_name,
+        )
+        cpu_usage = parse_cpu(metrics.get("usage", {}).get("cpu", "0"))
+        mem_usage = parse_memory(metrics.get("usage", {}).get("memory", "0"))
+        cpu_capacity = parse_cpu(allocatable.get("cpu", "0"))
+        mem_capacity = parse_memory(allocatable.get("memory", "0"))
+
+        info["usage"] = {
+            "cpu": metrics["usage"]["cpu"],
+            "cpu_millicores": int(cpu_usage),
+            "cpu_percent": (
+                round(cpu_usage / cpu_capacity * 100, 1) if cpu_capacity else 0
+            ),
+            "memory": metrics["usage"]["memory"],
+            "memory_mib": int(mem_usage),
+            "memory_percent": (
+                round(mem_usage / mem_capacity * 100, 1) if mem_capacity else 0
+            ),
+        }
+    except Exception:
+        pass
+
+    return info
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Describe Kubernetes node(s)")
+    parser.add_argument("node_name", nargs="?", help="Node name")
+    parser.add_argument("--all", action="store_true", help="Describe all nodes")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    if not args.node_name and not args.all:
+        parser.error("Specify a node name or --all")
+
+    try:
+        core_v1, custom_api = get_k8s_clients()
+
+        if args.all:
+            nodes = core_v1.list_node()
+            results = []
+            for node in nodes.items:
+                results.append(describe_node(core_v1, custom_api, node.metadata.name))
+        else:
+            results = [describe_node(core_v1, custom_api, args.node_name)]
+
+        if args.json:
+            print(json.dumps(results if args.all else results[0], indent=2))
+        else:
+            for info in results:
+                print(f"Node: {info['name']}")
+                if info.get("labels"):
+                    for k, v in info["labels"].items():
+                        short_key = k.split("/")[-1]
+                        print(f"  {short_key}: {v}")
+                print()
+
+                # Conditions
+                print("Conditions:")
+                for c in info["conditions"]:
+                    status_icon = (
+                        "OK"
+                        if (c["type"] == "Ready" and c["status"] == "True")
+                        or (c["type"] != "Ready" and c["status"] == "False")
+                        else "PROBLEM"
+                    )
+                    print(
+                        f"  {c['type']}: {c['status']} [{status_icon}] - {c['reason']}"
+                    )
+                print()
+
+                # Resources
+                print(
+                    f"Capacity:    cpu={info['capacity']['cpu']}, memory={info['capacity']['memory']}, pods={info['capacity']['pods']}"
+                )
+                print(
+                    f"Allocatable: cpu={info['allocatable']['cpu']}, memory={info['allocatable']['memory']}, pods={info['allocatable']['pods']}"
+                )
+                print(f"Running pods: {info['running_pods']}")
+                print()
+
+                if info["usage"]:
+                    print(
+                        f"Usage:       cpu={info['usage']['cpu_millicores']}m ({info['usage']['cpu_percent']}%), "
+                        f"memory={info['usage']['memory_mib']}Mi ({info['usage']['memory_percent']}%)"
+                    )
+                else:
+                    print("Usage:       metrics-server not available")
+                print()
+
+                if info["taints"]:
+                    print("Taints:")
+                    for t in info["taints"]:
+                        print(f"  {t['key']}={t['value']}:{t['effect']}")
+                    print()
+
+                print("-" * 60)
+
+    except ApiException as e:
+        print(f"Error: Kubernetes API error: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/describe_pod.py
+++ b/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/describe_pod.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Get detailed information about a Kubernetes pod.
+
+Usage:
+    python describe_pod.py <pod-name> -n <namespace>
+    python describe_pod.py <pod-name> -n <namespace> --cluster-id <id>
+
+Examples:
+    python describe_pod.py payment-7f8b9c6d5-x2k4m -n otel-demo
+    python describe_pod.py payment-7f8b9c6d5-x2k4m -n production --cluster-id abc123
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from k8s_gateway_client import add_cluster_id_arg, execute_command, is_gateway_mode
+from kubernetes import client
+from kubernetes import config as k8s_config
+from kubernetes.client.rest import ApiException
+
+
+def get_k8s_client():
+    """Get Kubernetes API client.
+
+    Prefers in-cluster service account auth (correct RBAC identity)
+    over kubeconfig (which may resolve to the EC2 node IAM identity).
+    """
+    in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    kubeconfig = Path.home() / ".kube" / "config"
+
+    if in_cluster.exists():
+        k8s_config.load_incluster_config()
+        print("[k8s-auth] Using in-cluster service account", file=sys.stderr)
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
+        print("[k8s-auth] Using kubeconfig (fallback)", file=sys.stderr)
+    else:
+        print(
+            "Error: Kubernetes not configured. No in-cluster token or ~/.kube/config.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return client.CoreV1Api()
+
+
+def format_pod_detail(result: dict) -> None:
+    """Print pod details in human-readable format."""
+    print(f"Pod: {result.get('name', '-')}")
+    print(f"Namespace: {result.get('namespace', '-')}")
+    print(f"Status: {result.get('status', '-')}")
+    print(f"Node: {result.get('node', '-')}")
+    print()
+
+    containers = result.get("containers", [])
+    print("Containers:")
+    for c in containers:
+        status_icon = "+" if c.get("ready") else "-"
+        print(f"  {status_icon} {c.get('name', '-')}")
+        print(f"     Image: {c.get('image', '-')}")
+        print(f"     Restarts: {c.get('restart_count', 0)}")
+        if c.get("resources"):
+            print(f"     Resources: {c['resources']}")
+    print()
+
+    conditions = result.get("conditions", [])
+    print("Conditions:")
+    for cond in conditions:
+        status_icon = "+" if cond.get("status") == "True" else "-"
+        print(f"  {status_icon} {cond.get('type', '-')}: {cond.get('status', '-')}")
+        if cond.get("reason"):
+            print(f"     Reason: {cond['reason']}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get detailed pod information")
+    parser.add_argument("pod_name", help="Name of the pod")
+    parser.add_argument(
+        "-n", "--namespace", default="default", help="Kubernetes namespace"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    add_cluster_id_arg(parser)
+    args = parser.parse_args()
+
+    try:
+        if is_gateway_mode(args.cluster_id):
+            result = execute_command(
+                args.cluster_id,
+                "describe_pod",
+                {"pod_name": args.pod_name, "namespace": args.namespace},
+            )
+        else:
+            core_v1 = get_k8s_client()
+            pod = core_v1.read_namespaced_pod(
+                name=args.pod_name, namespace=args.namespace
+            )
+
+            containers = []
+            for c in pod.spec.containers:
+                container_status = next(
+                    (
+                        cs
+                        for cs in (pod.status.container_statuses or [])
+                        if cs.name == c.name
+                    ),
+                    None,
+                )
+
+                resources = {}
+                if c.resources:
+                    if c.resources.requests:
+                        resources["requests"] = dict(c.resources.requests)
+                    if c.resources.limits:
+                        resources["limits"] = dict(c.resources.limits)
+
+                containers.append(
+                    {
+                        "name": c.name,
+                        "image": c.image,
+                        "ready": container_status.ready if container_status else False,
+                        "restart_count": (
+                            container_status.restart_count if container_status else 0
+                        ),
+                        "resources": resources if resources else None,
+                    }
+                )
+
+            conditions = []
+            for cond in pod.status.conditions or []:
+                conditions.append(
+                    {
+                        "type": cond.type,
+                        "status": cond.status,
+                        "reason": cond.reason,
+                    }
+                )
+
+            result = {
+                "name": pod.metadata.name,
+                "namespace": pod.metadata.namespace,
+                "status": pod.status.phase,
+                "node": pod.spec.node_name,
+                "containers": containers,
+                "conditions": conditions,
+            }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            format_pod_detail(result)
+
+    except ApiException as e:
+        print(f"Error: Kubernetes API error: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/get_events.py
+++ b/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/get_events.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Get events related to a Kubernetes pod.
+
+ALWAYS check events BEFORE logs - events explain most issues faster.
+Common events: OOMKilled, ImagePullBackOff, FailedScheduling, CrashLoopBackOff
+
+Usage:
+    python get_events.py <pod-name> -n <namespace>
+    python get_events.py <pod-name> -n <namespace> --cluster-id <id>
+
+Examples:
+    python get_events.py payment-7f8b9c6d5-x2k4m -n otel-demo
+    python get_events.py payment-7f8b9c6d5-x2k4m -n production --cluster-id abc123
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from k8s_gateway_client import add_cluster_id_arg, execute_command, is_gateway_mode
+from kubernetes import client
+from kubernetes import config as k8s_config
+from kubernetes.client.rest import ApiException
+
+
+def get_k8s_client():
+    """Get Kubernetes API client.
+
+    Prefers in-cluster service account auth (correct RBAC identity)
+    over kubeconfig (which may resolve to the EC2 node IAM identity).
+    """
+    in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    kubeconfig = Path.home() / ".kube" / "config"
+
+    if in_cluster.exists():
+        k8s_config.load_incluster_config()
+        print("[k8s-auth] Using in-cluster service account", file=sys.stderr)
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
+        print("[k8s-auth] Using kubeconfig (fallback)", file=sys.stderr)
+    else:
+        print(
+            "Error: Kubernetes not configured. No in-cluster token or ~/.kube/config.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return client.CoreV1Api()
+
+
+def format_events(pod_name: str, namespace: str, event_list: list[dict]) -> None:
+    """Print events in human-readable format."""
+    print(f"Pod: {pod_name}")
+    print(f"Namespace: {namespace}")
+    print(f"Event count: {len(event_list)}")
+    print()
+
+    if not event_list:
+        print("No events found for this pod.")
+    else:
+        for event in event_list:
+            event_type = "⚠️" if event["type"] == "Warning" else "ℹ️"
+            print(
+                f"{event_type} [{event.get('last_timestamp', '-')}] "
+                f"{event.get('reason', '-')}: {event.get('message', '-')}"
+            )
+            if event.get("count") and event["count"] > 1:
+                print(f"   (occurred {event['count']} times)")
+            print()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get events for a Kubernetes pod")
+    parser.add_argument("pod_name", help="Name of the pod")
+    parser.add_argument(
+        "-n", "--namespace", default="default", help="Kubernetes namespace"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    add_cluster_id_arg(parser)
+    args = parser.parse_args()
+
+    try:
+        if is_gateway_mode(args.cluster_id):
+            result = execute_command(
+                args.cluster_id,
+                "get_pod_events",
+                {"pod_name": args.pod_name, "namespace": args.namespace},
+            )
+            event_list = result.get("events", [])
+        else:
+            core_v1 = get_k8s_client()
+            events = core_v1.list_namespaced_event(
+                namespace=args.namespace,
+                field_selector=f"involvedObject.name={args.pod_name}",
+            )
+
+            event_list = []
+            for event in events.items:
+                event_list.append(
+                    {
+                        "type": event.type,
+                        "reason": event.reason,
+                        "message": event.message,
+                        "count": event.count,
+                        "first_timestamp": str(event.first_timestamp),
+                        "last_timestamp": str(event.last_timestamp),
+                    }
+                )
+
+            # Sort by last timestamp (most recent first)
+            event_list.sort(key=lambda x: x["last_timestamp"] or "", reverse=True)
+
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "pod": args.pod_name,
+                        "namespace": args.namespace,
+                        "event_count": len(event_list),
+                        "events": event_list,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            format_events(args.pod_name, args.namespace, event_list)
+
+    except ApiException as e:
+        print(f"Error: Kubernetes API error: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/get_logs.py
+++ b/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/get_logs.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Get logs from a Kubernetes pod.
+
+Usage:
+    python get_logs.py <pod-name> -n <namespace> [--tail N] [--container NAME]
+    python get_logs.py <pod-name> -n <namespace> --cluster-id <id>
+
+Examples:
+    python get_logs.py payment-7f8b9c6d5-x2k4m -n otel-demo --tail 100
+    python get_logs.py payment-7f8b9c6d5-x2k4m -n otel-demo --container payment
+    python get_logs.py payment-7f8b9c6d5-x2k4m -n production --cluster-id abc123
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from k8s_gateway_client import add_cluster_id_arg, execute_command, is_gateway_mode
+from kubernetes import client
+from kubernetes import config as k8s_config
+from kubernetes.client.rest import ApiException
+
+
+def get_k8s_client():
+    """Get Kubernetes API client.
+
+    Prefers in-cluster service account auth (correct RBAC identity)
+    over kubeconfig (which may resolve to the EC2 node IAM identity).
+    """
+    in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    kubeconfig = Path.home() / ".kube" / "config"
+
+    if in_cluster.exists():
+        k8s_config.load_incluster_config()
+        print("[k8s-auth] Using in-cluster service account", file=sys.stderr)
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
+        print("[k8s-auth] Using kubeconfig (fallback)", file=sys.stderr)
+    else:
+        print(
+            "Error: Kubernetes not configured. No in-cluster token or ~/.kube/config.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return client.CoreV1Api()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get logs from a Kubernetes pod")
+    parser.add_argument("pod_name", help="Name of the pod")
+    parser.add_argument(
+        "-n", "--namespace", default="default", help="Kubernetes namespace"
+    )
+    parser.add_argument(
+        "--tail",
+        type=int,
+        default=100,
+        help="Number of lines to retrieve (default: 100)",
+    )
+    parser.add_argument("--container", help="Container name (for multi-container pods)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    add_cluster_id_arg(parser)
+    args = parser.parse_args()
+
+    try:
+        if is_gateway_mode(args.cluster_id):
+            params = {
+                "pod_name": args.pod_name,
+                "namespace": args.namespace,
+                "tail_lines": args.tail,
+            }
+            if args.container:
+                params["container"] = args.container
+            result = execute_command(args.cluster_id, "get_pod_logs", params)
+            logs = result.get("logs", "")
+        else:
+            core_v1 = get_k8s_client()
+            logs = core_v1.read_namespaced_pod_log(
+                name=args.pod_name,
+                namespace=args.namespace,
+                container=args.container,
+                tail_lines=args.tail,
+            )
+
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "pod": args.pod_name,
+                        "namespace": args.namespace,
+                        "container": args.container,
+                        "lines": args.tail,
+                        "logs": logs,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(f"Pod: {args.pod_name}")
+            print(f"Namespace: {args.namespace}")
+            if args.container:
+                print(f"Container: {args.container}")
+            print(f"Tail: {args.tail} lines")
+            print("-" * 60)
+            print(logs)
+
+    except ApiException as e:
+        print(f"Error: Kubernetes API error: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/get_resources.py
+++ b/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/get_resources.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Get resource allocation and usage for a Kubernetes pod.
+
+Shows configured requests/limits alongside actual runtime usage.
+Requires metrics-server in the cluster for usage data.
+
+Usage:
+    python get_resources.py <pod-name> -n <namespace>
+
+Examples:
+    python get_resources.py payment-7f8b9c6d5-x2k4m -n otel-demo
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from kubernetes import client
+from kubernetes import config as k8s_config
+from kubernetes.client.rest import ApiException
+
+
+def get_k8s_clients():
+    """Get Kubernetes API clients.
+
+    Prefers in-cluster service account auth (correct RBAC identity)
+    over kubeconfig (which may resolve to the EC2 node IAM identity).
+    """
+    in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    kubeconfig = Path.home() / ".kube" / "config"
+
+    if in_cluster.exists():
+        k8s_config.load_incluster_config()
+        print("[k8s-auth] Using in-cluster service account", file=sys.stderr)
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
+        print("[k8s-auth] Using kubeconfig (fallback)", file=sys.stderr)
+    else:
+        print(
+            "Error: Kubernetes not configured. No in-cluster token or ~/.kube/config.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return client.CoreV1Api(), client.CustomObjectsApi()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Get pod resource allocation and usage"
+    )
+    parser.add_argument("pod_name", help="Name of the pod")
+    parser.add_argument(
+        "-n", "--namespace", default="default", help="Kubernetes namespace"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        core_v1, custom_api = get_k8s_clients()
+        pod = core_v1.read_namespaced_pod(name=args.pod_name, namespace=args.namespace)
+
+        containers_data = []
+        for c in pod.spec.containers:
+            container_info = {
+                "name": c.name,
+                "requests": {},
+                "limits": {},
+                "usage": None,
+            }
+
+            if c.resources:
+                if c.resources.requests:
+                    container_info["requests"] = dict(c.resources.requests)
+                if c.resources.limits:
+                    container_info["limits"] = dict(c.resources.limits)
+
+            containers_data.append(container_info)
+
+        # Try to get actual usage from metrics-server
+        metrics_available = False
+        try:
+            metrics = custom_api.get_namespaced_custom_object(
+                group="metrics.k8s.io",
+                version="v1beta1",
+                namespace=args.namespace,
+                plural="pods",
+                name=args.pod_name,
+            )
+
+            for container_metrics in metrics.get("containers", []):
+                name = container_metrics["name"]
+                for container in containers_data:
+                    if container["name"] == name:
+                        container["usage"] = {
+                            "cpu": container_metrics["usage"]["cpu"],
+                            "memory": container_metrics["usage"]["memory"],
+                        }
+                        metrics_available = True
+        except Exception:
+            pass  # Metrics not available
+
+        result = {
+            "pod": args.pod_name,
+            "namespace": args.namespace,
+            "node": pod.spec.node_name,
+            "status": pod.status.phase,
+            "metrics_available": metrics_available,
+            "containers": containers_data,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Pod: {result['pod']}")
+            print(f"Namespace: {result['namespace']}")
+            print(f"Node: {result['node']}")
+            print(f"Status: {result['status']}")
+            print(
+                f"Metrics available: {'Yes' if metrics_available else 'No (metrics-server not installed)'}"
+            )
+            print()
+
+            for c in containers_data:
+                print(f"Container: {c['name']}")
+                print(
+                    f"  Requests: cpu={c['requests'].get('cpu', 'none')}, memory={c['requests'].get('memory', 'none')}"
+                )
+                print(
+                    f"  Limits:   cpu={c['limits'].get('cpu', 'none')}, memory={c['limits'].get('memory', 'none')}"
+                )
+                if c["usage"]:
+                    print(
+                        f"  Usage:    cpu={c['usage']['cpu']}, memory={c['usage']['memory']}"
+                    )
+                print()
+
+    except ApiException as e:
+        print(f"Error: Kubernetes API error: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/k8s_gateway_client.py
+++ b/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/k8s_gateway_client.py
@@ -1,0 +1,148 @@
+"""Shared client for routing K8s commands through the k8s-gateway.
+
+When a customer deploys the k8s-agent Helm chart in their cluster, commands
+can be routed through the k8s-gateway instead of requiring direct K8s API
+access. This module provides the HTTP plumbing for that path.
+
+Usage from other scripts:
+
+    from k8s_gateway_client import is_gateway_mode, execute_command
+
+    if is_gateway_mode(args.cluster_id):
+        result = execute_command(args.cluster_id, "list_pods", {"namespace": "default"})
+    else:
+        # direct k8s API path
+        ...
+"""
+
+import json
+import os
+import sys
+
+import httpx
+
+
+def is_gateway_mode(cluster_id: str | None) -> bool:
+    """Check if we should route through the k8s-gateway."""
+    return bool(cluster_id and os.getenv("K8S_GATEWAY_URL"))
+
+
+def execute_command(
+    cluster_id: str,
+    command: str,
+    params: dict,
+    timeout: float = 30.0,
+) -> dict:
+    """Execute a K8s command on a remote cluster via the k8s-gateway.
+
+    Args:
+        cluster_id: Target cluster ID (from list_clusters.py).
+        command: Gateway command name (list_pods, describe_pod, etc.).
+        params: Command parameters.
+        timeout: Command timeout in seconds.
+
+    Returns:
+        Result dict from the k8s-agent executor.
+
+    Raises:
+        RuntimeError: On gateway errors (cluster not connected, timeout, etc.).
+    """
+    gateway_url = os.environ["K8S_GATEWAY_URL"]
+    org_id = os.environ.get("OPENSRE_TENANT_ID", "")
+
+    if not org_id:
+        raise RuntimeError(
+            "OPENSRE_TENANT_ID not set — cannot identify org for gateway request"
+        )
+
+    url = f"{gateway_url.rstrip('/')}/internal/execute"
+
+    try:
+        with httpx.Client(timeout=timeout + 5.0) as client:
+            response = client.post(
+                url,
+                headers={
+                    "X-Internal-Service": "agent",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "cluster_id": cluster_id,
+                    "org_id": org_id,
+                    "command": command,
+                    "params": params,
+                    "timeout": timeout,
+                },
+            )
+    except httpx.ConnectError:
+        raise RuntimeError(
+            f"Cannot reach k8s-gateway at {gateway_url}. "
+            "Is the k8s-gateway service running?"
+        )
+    except httpx.TimeoutException:
+        raise RuntimeError(
+            f"Timeout waiting for command '{command}' on cluster {cluster_id}"
+        )
+
+    if response.status_code >= 400:
+        raise RuntimeError(f"k8s-gateway error {response.status_code}: {response.text}")
+
+    data = response.json()
+    if not data.get("ok"):
+        raise RuntimeError(
+            f"K8s command '{command}' failed: {data.get('error', 'unknown error')}"
+        )
+
+    return data["result"]
+
+
+def list_connected_clusters() -> list[dict]:
+    """List clusters connected to the k8s-gateway for the current team.
+
+    Returns:
+        List of cluster connection info dicts.
+    """
+    gateway_url = os.environ.get("K8S_GATEWAY_URL")
+    if not gateway_url:
+        return []
+
+    org_id = os.environ.get("OPENSRE_TENANT_ID", "")
+    url = f"{gateway_url.rstrip('/')}/internal/clusters"
+    params = {}
+    if org_id:
+        params["org_id"] = org_id
+
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            response = client.get(
+                url,
+                headers={"X-Internal-Service": "agent"},
+                params=params,
+            )
+        if response.status_code >= 400:
+            print(
+                f"Warning: k8s-gateway returned {response.status_code}",
+                file=sys.stderr,
+            )
+            return []
+        data = response.json()
+        return data.get("clusters", [])
+    except Exception as e:
+        print(f"Warning: cannot reach k8s-gateway: {e}", file=sys.stderr)
+        return []
+
+
+def add_cluster_id_arg(parser) -> None:
+    """Add the --cluster-id argument to an argparse parser."""
+    parser.add_argument(
+        "--cluster-id",
+        dest="cluster_id",
+        help="Route command through k8s-gateway to a remote cluster (from list_clusters.py)",
+    )
+
+
+def print_result(result: dict, json_mode: bool = False) -> None:
+    """Print a gateway result dict as JSON."""
+    if json_mode:
+        print(json.dumps(result, indent=2))
+    else:
+        print(json.dumps(result, indent=2))

--- a/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/list_clusters.py
+++ b/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/list_clusters.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""List available K8s clusters.
+
+In gateway mode (K8S_GATEWAY_URL set): lists remote clusters from config-service.
+In direct mode (kubeconfig available): lists contexts from kubeconfig.
+
+Usage:
+    python list_clusters.py
+    python list_clusters.py --json
+"""
+
+import argparse
+import json
+import os
+import sys
+
+
+def list_kubeconfig_contexts():
+    """List clusters from local kubeconfig."""
+    try:
+        from kubernetes import config as k8s_config
+
+        contexts, active_context = k8s_config.list_kube_config_contexts()
+        if not contexts:
+            return []
+        active_name = active_context.get("name", "") if active_context else ""
+        result = []
+        for ctx in contexts:
+            name = ctx.get("name", "")
+            cluster = ctx.get("context", {}).get("cluster", "")
+            namespace = ctx.get("context", {}).get("namespace", "default")
+            result.append(
+                {
+                    "name": name,
+                    "cluster": cluster,
+                    "namespace": namespace,
+                    "active": name == active_name,
+                    "mode": "direct (kubeconfig)",
+                }
+            )
+        return result
+    except Exception as e:
+        print(f"Warning: Could not read kubeconfig: {e}", file=sys.stderr)
+        return []
+
+
+def list_gateway_clusters():
+    """List remote clusters from config-service gateway."""
+    import httpx
+
+    config_url = os.environ.get("CONFIG_SERVICE_URL")
+    if not config_url:
+        return []
+
+    headers = {}
+    team_token = os.environ.get("TEAM_TOKEN")
+    if team_token:
+        headers["Authorization"] = f"Bearer {team_token}"
+    else:
+        tenant_id = os.environ.get("OPENSRE_TENANT_ID")
+        team_id = os.environ.get("OPENSRE_TEAM_ID")
+        if tenant_id and team_id:
+            headers["X-Org-Id"] = tenant_id
+            headers["X-Team-Node-Id"] = team_id
+
+    try:
+        url = f"{config_url.rstrip('/')}/api/v1/team/k8s-clusters"
+        with httpx.Client(timeout=10.0) as client:
+            response = client.get(url, headers=headers)
+        if response.status_code == 404 or response.status_code >= 400:
+            return []
+        clusters = response.json()
+        for c in clusters:
+            c["mode"] = "gateway (remote)"
+        return clusters or []
+    except Exception:
+        return []
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List available K8s clusters")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    # Try both sources
+    gateway_clusters = list_gateway_clusters()
+    kubeconfig_contexts = list_kubeconfig_contexts()
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "gateway_clusters": gateway_clusters,
+                    "kubeconfig_contexts": kubeconfig_contexts,
+                },
+                indent=2,
+            )
+        )
+        return
+
+    if gateway_clusters:
+        print(f"Gateway clusters: {len(gateway_clusters)}")
+        print(f"{'CLUSTER ID':<38} {'NAME':<25} {'STATUS':<14}")
+        print("-" * 77)
+        for c in gateway_clusters:
+            print(
+                f"{c.get('cluster_id', ''):<38} {c.get('cluster_name', ''):<25} {c.get('status', '?'):<14}"
+            )
+        print()
+
+    if kubeconfig_contexts:
+        print(f"Local kubeconfig contexts: {len(kubeconfig_contexts)}")
+        print(f"{'CONTEXT':<40} {'CLUSTER':<30} {'ACTIVE'}")
+        print("-" * 77)
+        for ctx in kubeconfig_contexts:
+            active = "*" if ctx["active"] else ""
+            print(f"{ctx['name']:<40} {ctx['cluster']:<30} {active}")
+        print()
+        print("Use these contexts with: kubectl --context <CONTEXT_NAME>")
+        print("Or run scripts without --cluster-id to use the active context.")
+
+    if not gateway_clusters and not kubeconfig_contexts:
+        print("No K8s clusters found.")
+        print("  - For local: ensure ~/.kube/config exists")
+        print("  - For remote: configure K8S_GATEWAY_URL and register clusters")
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/list_namespaces.py
+++ b/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/list_namespaces.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""List all namespaces in a Kubernetes cluster.
+
+Supports both direct K8s API access and remote access via k8s-gateway.
+
+Usage:
+    python list_namespaces.py
+    python list_namespaces.py --cluster-id <id>
+    python list_namespaces.py --json
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from k8s_gateway_client import add_cluster_id_arg, execute_command, is_gateway_mode
+from kubernetes import client
+from kubernetes import config as k8s_config
+from kubernetes.client.rest import ApiException
+
+
+def get_k8s_client():
+    """Get Kubernetes API client."""
+    in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    kubeconfig = Path.home() / ".kube" / "config"
+
+    if in_cluster.exists():
+        k8s_config.load_incluster_config()
+        print("[k8s-auth] Using in-cluster service account", file=sys.stderr)
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
+        print("[k8s-auth] Using kubeconfig (fallback)", file=sys.stderr)
+    else:
+        print(
+            "Error: Kubernetes not configured. No in-cluster token or ~/.kube/config.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return client.CoreV1Api()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Kubernetes namespaces")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    add_cluster_id_arg(parser)
+    args = parser.parse_args()
+
+    try:
+        if is_gateway_mode(args.cluster_id):
+            result = execute_command(args.cluster_id, "list_namespaces", {})
+        else:
+            core_v1 = get_k8s_client()
+            namespaces = core_v1.list_namespace()
+            result = {
+                "namespace_count": len(namespaces.items),
+                "namespaces": [
+                    {
+                        "name": ns.metadata.name,
+                        "status": ns.status.phase,
+                        "created_at": str(ns.metadata.creation_timestamp),
+                    }
+                    for ns in namespaces.items
+                ],
+            }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Namespace count: {result['namespace_count']}")
+            print()
+            print(f"{'NAME':<40} {'STATUS':<12}")
+            print("-" * 52)
+            for ns in result["namespaces"]:
+                print(f"{ns['name']:<40} {ns.get('status', '-'):<12}")
+
+    except ApiException as e:
+        print(f"Error: Kubernetes API error: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/list_pods.py
+++ b/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/list_pods.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""List pods in a Kubernetes namespace with their status.
+
+Usage:
+    python list_pods.py -n <namespace> [--label <selector>]
+    python list_pods.py -n <namespace> --cluster-id <id>
+
+Examples:
+    python list_pods.py -n otel-demo
+    python list_pods.py -n otel-demo --label app.kubernetes.io/name=payment
+    python list_pods.py -n production --cluster-id abc123
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from k8s_gateway_client import add_cluster_id_arg, execute_command, is_gateway_mode
+from kubernetes import client
+from kubernetes import config as k8s_config
+from kubernetes.client.rest import ApiException
+
+
+def get_k8s_client():
+    """Get Kubernetes API client.
+
+    Prefers in-cluster service account auth (correct RBAC identity)
+    over kubeconfig (which may resolve to the EC2 node IAM identity).
+    """
+    in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    kubeconfig = Path.home() / ".kube" / "config"
+
+    if in_cluster.exists():
+        k8s_config.load_incluster_config()
+        print("[k8s-auth] Using in-cluster service account", file=sys.stderr)
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
+        print("[k8s-auth] Using kubeconfig (fallback)", file=sys.stderr)
+    else:
+        print(
+            "Error: Kubernetes not configured. No in-cluster token or ~/.kube/config.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return client.CoreV1Api()
+
+
+def format_pods_table(namespace: str, pod_list: list[dict]) -> None:
+    """Print pods as a human-readable table."""
+    print(f"Namespace: {namespace}")
+    print(f"Pod count: {len(pod_list)}")
+    print()
+    print(f"{'NAME':<50} {'STATUS':<12} {'READY':<8} {'RESTARTS':<10}")
+    print("-" * 80)
+    for pod in pod_list:
+        print(
+            f"{pod['name']:<50} {pod.get('status', '-'):<12} "
+            f"{pod.get('ready', '-'):<8} {pod.get('restarts', 0):<10}"
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List pods in a Kubernetes namespace")
+    parser.add_argument(
+        "-n", "--namespace", default="default", help="Kubernetes namespace"
+    )
+    parser.add_argument(
+        "--label", dest="label_selector", help="Label selector (e.g., app=myapp)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    add_cluster_id_arg(parser)
+    args = parser.parse_args()
+
+    try:
+        if is_gateway_mode(args.cluster_id):
+            params = {"namespace": args.namespace}
+            if args.label_selector:
+                params["label_selector"] = args.label_selector
+            result = execute_command(args.cluster_id, "list_pods", params)
+            pod_list = result.get("pods", [])
+        else:
+            core_v1 = get_k8s_client()
+            pods = core_v1.list_namespaced_pod(
+                namespace=args.namespace,
+                label_selector=args.label_selector,
+            )
+
+            pod_list = []
+            for pod in pods.items:
+                ready_count = sum(
+                    1 for cs in (pod.status.container_statuses or []) if cs.ready
+                )
+                total_count = len(pod.spec.containers)
+                restart_count = sum(
+                    cs.restart_count for cs in (pod.status.container_statuses or [])
+                )
+
+                pod_list.append(
+                    {
+                        "name": pod.metadata.name,
+                        "status": pod.status.phase,
+                        "ready": f"{ready_count}/{total_count}",
+                        "restarts": restart_count,
+                        "age": str(pod.metadata.creation_timestamp),
+                    }
+                )
+
+        if args.json:
+            print(json.dumps({"namespace": args.namespace, "pods": pod_list}, indent=2))
+        else:
+            format_pods_table(args.namespace, pod_list)
+
+    except ApiException as e:
+        print(f"Error: Kubernetes API error: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-neo4j/SKILL.md
+++ b/sre-agent/.claude/skills/infrastructure-neo4j/SKILL.md
@@ -1,0 +1,46 @@
+# Infrastructure Knowledge Graph (Neo4j)
+
+## When to use
+- Before starting an investigation, to understand the service topology
+- When you need to know what depends on a service (blast radius analysis)
+- When you need Kubernetes status of a service (pods, deployments, replicas)
+- When you need to understand the relationship between services
+
+## How to use
+
+### Get service topology
+```bash
+python /app/tools/neo4j_semantic_layer.py --action service-info --service <service-name>
+```
+
+### Get Kubernetes status
+```bash
+python /app/tools/neo4j_semantic_layer.py --action k8s-status --service <service-name>
+```
+
+### Get service relationships
+```bash
+python /app/tools/neo4j_semantic_layer.py --action relationships --service <service-name>
+```
+
+### Run custom Cypher query
+```bash
+python /app/tools/neo4j_semantic_layer.py --action cypher --query "MATCH (s:Service) RETURN s.name LIMIT 10"
+```
+
+## Methodology
+
+1. **Pre-investigation context**: Before analyzing logs or metrics, query the KG to understand:
+   - What the service does
+   - What depends on it (downstream impact)
+   - What it depends on (upstream causes)
+   - Current K8s health status
+
+2. **Blast radius analysis**: When a service is affected:
+   - Query all downstream dependencies
+   - Check if downstream services also show errors
+   - Report the full blast radius
+
+3. **Root cause correlation**: When multiple services are affected:
+   - Query the topology to find common upstream dependencies
+   - The shared dependency is likely the root cause

--- a/sre-agent/.claude/skills/infrastructure-neo4j/scripts/get_k8s_status.py
+++ b/sre-agent/.claude/skills/infrastructure-neo4j/scripts/get_k8s_status.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Get Kubernetes status for a service from Neo4j knowledge graph."""
+
+import json
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        )
+    ),
+)
+from tools.neo4j_semantic_layer import KubernetesGraphTools
+
+
+def main():
+    service_name = sys.argv[1] if len(sys.argv) > 1 else None
+    if not service_name:
+        print(json.dumps({"error": "Usage: get_k8s_status.py <service-name>"}))
+        sys.exit(1)
+
+    try:
+        tools = KubernetesGraphTools()
+        result = tools.get_kubernetes_status(service_name)
+        print(json.dumps({"success": True, "result": result}, indent=2, default=str))
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-neo4j/scripts/query_relationships.py
+++ b/sre-agent/.claude/skills/infrastructure-neo4j/scripts/query_relationships.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Query service relationships from Neo4j knowledge graph."""
+
+import json
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        )
+    ),
+)
+from tools.neo4j_semantic_layer import KubernetesGraphTools
+
+
+def main():
+    service_name = sys.argv[1] if len(sys.argv) > 1 else None
+    if not service_name:
+        print(json.dumps({"error": "Usage: query_relationships.py <service-name>"}))
+        sys.exit(1)
+
+    try:
+        tools = KubernetesGraphTools()
+        result = tools.get_component_relationships(service_name)
+        print(json.dumps({"success": True, "result": result}, indent=2, default=str))
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure-neo4j/scripts/query_topology.py
+++ b/sre-agent/.claude/skills/infrastructure-neo4j/scripts/query_topology.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Query service topology from Neo4j knowledge graph."""
+
+import json
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        )
+    ),
+)
+from tools.neo4j_semantic_layer import KubernetesGraphTools
+
+
+def main():
+    service_name = sys.argv[1] if len(sys.argv) > 1 else None
+    if not service_name:
+        print(json.dumps({"error": "Usage: query_topology.py <service-name>"}))
+        sys.exit(1)
+
+    try:
+        tools = KubernetesGraphTools()
+        result = tools.get_service_information(service_name)
+        print(json.dumps({"success": True, "result": result}, indent=2, default=str))
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/infrastructure/SKILL.md
+++ b/sre-agent/.claude/skills/infrastructure/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: infrastructure
+description: Infrastructure debugging for Kubernetes and AWS. Use when investigating pod crashes, deployment issues, resource problems, container failures, or cloud infrastructure issues.
+---
+
+# Infrastructure Debugging
+
+## Available Domains
+
+### Kubernetes
+For pod crashes, deployment issues, resource problems, container failures.
+Use: `/infrastructure-kubernetes`
+
+### AWS
+For EC2, ECS, Lambda, and CloudWatch issues.
+Use: `/infrastructure-aws`
+
+## Quick Reference
+
+### Kubernetes Issues
+```bash
+# List pods in namespace
+python .claude/skills/infrastructure-kubernetes/scripts/list_pods.py -n otel-demo
+
+# Get pod events (ALWAYS check first!)
+python .claude/skills/infrastructure-kubernetes/scripts/get_events.py <pod-name> -n otel-demo
+
+# Get pod logs
+python .claude/skills/infrastructure-kubernetes/scripts/get_logs.py <pod-name> -n otel-demo --tail 100
+```
+
+### Common Patterns
+
+| Symptom | First Action | Script |
+|---------|--------------|--------|
+| Pod CrashLoopBackOff | Check events | `get_events.py` |
+| Pod OOMKilled | Check resources | `get_resources.py` |
+| Pod Pending | Check events + nodes | `get_events.py` |
+| Deployment stuck | Check rollout history | `get_history.py` |

--- a/sre-agent/.claude/skills/investigate/SKILL.md
+++ b/sre-agent/.claude/skills/investigate/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: investigate
+description: Systematic incident investigation methodology. Use when investigating production issues, service degradation, errors, latency spikes, or outages. Provides 5-phase framework for evidence-based root cause analysis.
+---
+
+# 5-Phase Investigation Methodology
+
+You are an expert SRE investigator. Follow this systematic approach for all incident investigations.
+
+## Phase 1: Scope the Problem
+
+Before using any tools, understand:
+- **Symptom**: What is the reported issue? (errors, latency, downtime)
+- **Timeline**: When did it start? Is it ongoing or resolved?
+- **Impact**: Users affected, SLO breach, revenue impact?
+- **Changes**: Recent deployments, config changes, traffic patterns?
+- **Services**: Which systems are likely involved?
+
+## Phase 2: Gather Evidence (Statistics First)
+
+**CRITICAL: Get statistics before diving into raw data.**
+
+### Observability (logs, metrics, traces)
+For log/metric analysis, use the appropriate subagent:
+- Spawn `log-analyst` for deep log analysis
+- The subagent reads observability skills for query syntax
+
+Key principle: **Aggregations before samples**
+1. Get counts and distributions first
+2. Identify error patterns and temporal clusters
+3. THEN sample specific entries
+
+### Infrastructure (Kubernetes, AWS)
+For K8s/infrastructure issues:
+- Spawn `k8s-debugger` subagent
+- **Events BEFORE logs** - events explain most issues faster
+
+## Phase 3: Form Hypotheses
+
+Based on evidence, rank hypotheses:
+- **H1**: Most likely cause based on data
+- **H2**: Second most likely
+- **H3**: Alternative explanation
+
+For each hypothesis, identify:
+- What evidence supports it?
+- What evidence would refute it?
+
+## Phase 4: Test Hypotheses
+
+For each hypothesis:
+1. What specific evidence would confirm it?
+2. What specific evidence would refute it?
+3. Gather that evidence
+4. Update rankings based on findings
+
+## Phase 5: Conclude and Remediate
+
+Structure your conclusion:
+
+```
+**Root Cause**: [Specific, actionable cause]
+
+**Evidence**:
+- [Metric/log/event that supports]
+- [Correlation or change point identified]
+- [Timeline of events]
+
+**Confidence**: [High/Medium/Low - explain why]
+
+**Recommended Actions**:
+1. Immediate: [e.g., restart pod, scale up]
+2. Short-term: [follow-up fixes]
+3. Long-term: [prevention measures]
+
+**Caveats**: [What you couldn't determine]
+```
+
+## Key Principles
+
+### Intellectual Honesty
+- State confidence level clearly
+- Acknowledge insufficient evidence
+- Say "I don't know" when uncertain
+- Distinguish facts (observed) from hypotheses (inferred)
+
+### Evidence-Based Reasoning
+- Every claim must have supporting evidence
+- Quote specific data: timestamps, values, error messages
+- If you can't prove it, mark it as hypothesis
+
+### Efficiency
+- Don't repeat queries with same parameters
+- Start narrow, expand only if needed
+- Maximum 6-8 tool calls per investigation phase
+
+## When to Use Subagents
+
+| Situation | Subagent | Why |
+|-----------|----------|-----|
+| Deep log analysis (5+ queries) | `log-analyst` | Isolate log output from main context |
+| K8s pod/deployment issues | `k8s-debugger` | Specialized K8s methodology |
+| Parallel investigation | Multiple subagents | Test hypotheses simultaneously |
+| Remediation actions | `remediator` | Safety isolation for dangerous ops |

--- a/sre-agent/.claude/skills/knowledge-base/README.md
+++ b/sre-agent/.claude/skills/knowledge-base/README.md
@@ -1,0 +1,42 @@
+# Knowledge Base Skill - Confluence Integration
+
+Search runbooks, documentation, and knowledge base articles from Confluence during incident investigations.
+
+## Quick Start
+
+```bash
+# Find a runbook for a service
+python scripts/find_runbooks.py --service payment
+
+# Search for post-mortems about similar incidents
+python scripts/find_postmortems.py --service checkout --days 90
+
+# General search across documentation
+python scripts/search_pages.py --query "api timeout troubleshooting"
+
+# Read a full runbook
+python scripts/get_page.py --page-id 123456789
+```
+
+## Authentication
+
+Credentials are automatically injected by the credential proxy. Scripts work in both:
+- **Production**: Credentials injected via `CONFLUENCE_BASE_URL` proxy
+- **Local development**: Fallback to `CONFLUENCE_URL`, `CONFLUENCE_EMAIL`, `CONFLUENCE_API_TOKEN` environment variables
+
+## Integration with Incident Investigation
+
+1. **Check for runbooks first** - Before deep diving into logs/metrics
+2. **Learn from history** - Search post-mortems for similar incidents
+3. **Find architecture docs** - Understand the system before debugging
+4. **Document findings** - Use knowledge base to inform post-mortem creation
+
+## Scripts
+
+- **search_pages.py** - General text search across Confluence
+- **find_runbooks.py** - Find runbooks by service/alert with relevance scoring
+- **find_postmortems.py** - Find incident post-mortems with time filtering
+- **get_page.py** - Read full page content (HTML or plain text)
+- **search_cql.py** - Advanced search with Confluence Query Language
+
+See `SKILL.md` for detailed usage instructions and examples.

--- a/sre-agent/.claude/skills/knowledge-base/SKILL.md
+++ b/sre-agent/.claude/skills/knowledge-base/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: knowledge-base
+description: Search runbooks, documentation, and knowledge base articles from Confluence. Use when looking for incident response procedures, service documentation, post-mortems, or troubleshooting guides.
+allowed-tools: Bash(python *)
+---
+
+# Knowledge Base - Confluence Integration
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `CONFLUENCE_API_TOKEN` in environment variables - it won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+---
+
+## Why Confluence Matters During Incidents
+
+Before diving deep into technical investigation:
+- **Is there a runbook?** Find documented procedures for this service/alert
+- **Has this happened before?** Search for related post-mortems
+- **What's the architecture?** Find service documentation
+- **What's the mitigation?** Look for incident response guides
+
+## Available Scripts
+
+All scripts are in `.claude/skills/knowledge-base/scripts/`
+
+### search_pages.py - General Search
+Search across all Confluence pages for any topic.
+
+```bash
+python .claude/skills/knowledge-base/scripts/search_pages.py --query SEARCH_QUERY [--space SPACE_KEY] [--limit N]
+
+# Examples:
+python .claude/skills/knowledge-base/scripts/search_pages.py --query "payment service timeout"
+python .claude/skills/knowledge-base/scripts/search_pages.py --query "database connection" --space SRE
+python .claude/skills/knowledge-base/scripts/search_pages.py --query "api error" --limit 20
+```
+
+### find_runbooks.py - Find Runbooks
+Find runbooks for a specific service or alert. Searches for pages labeled as runbooks, playbooks, or SOPs.
+
+```bash
+python .claude/skills/knowledge-base/scripts/find_runbooks.py [--service SERVICE] [--alert ALERT_NAME] [--space SPACE_KEY] [--limit N]
+
+# Examples:
+python .claude/skills/knowledge-base/scripts/find_runbooks.py --service payment
+python .claude/skills/knowledge-base/scripts/find_runbooks.py --alert "HighErrorRate"
+python .claude/skills/knowledge-base/scripts/find_runbooks.py --service checkout --space OPS
+```
+
+### find_postmortems.py - Find Post-mortems
+Find incident post-mortems to understand historical patterns.
+
+```bash
+python .claude/skills/knowledge-base/scripts/find_postmortems.py [--service SERVICE] [--days N] [--space SPACE_KEY] [--limit N]
+
+# Examples:
+python .claude/skills/knowledge-base/scripts/find_postmortems.py --service payment
+python .claude/skills/knowledge-base/scripts/find_postmortems.py --service payment --days 180
+python .claude/skills/knowledge-base/scripts/find_postmortems.py --space SRE
+```
+
+### get_page.py - Read Full Page Content
+Get the full content of a specific Confluence page.
+
+```bash
+python .claude/skills/knowledge-base/scripts/get_page.py --page-id PAGE_ID
+python .claude/skills/knowledge-base/scripts/get_page.py --title "Page Title" --space SPACE_KEY
+
+# Examples:
+python .claude/skills/knowledge-base/scripts/get_page.py --page-id 123456789
+python .claude/skills/knowledge-base/scripts/get_page.py --title "Payment Service Runbook" --space SRE
+```
+
+### search_cql.py - Advanced CQL Search
+Use Confluence Query Language for advanced searches with filters.
+
+```bash
+python .claude/skills/knowledge-base/scripts/search_cql.py --cql "CQL_QUERY" [--limit N]
+
+# Examples:
+python .claude/skills/knowledge-base/scripts/search_cql.py --cql 'type = page AND label = "runbook"'
+python .claude/skills/knowledge-base/scripts/search_cql.py --cql 'space = "SRE" AND lastModified >= now("-30d")'
+python .claude/skills/knowledge-base/scripts/search_cql.py --cql 'text ~ "payment" AND label = "postmortem"'
+```
+
+---
+
+## Common CQL Patterns
+
+| Pattern | Example | Purpose |
+|---------|---------|---------|
+| Find by label | `type = page AND label = "runbook"` | Pages with specific labels |
+| Space filter | `space = "SRE" AND type = page` | Pages in a specific space |
+| Recent docs | `lastModified >= now("-30d")` | Recently updated pages |
+| Combined | `space = "OPS" AND label = "incident" AND text ~ "payment"` | Complex queries |
+| Post-mortems | `label = "postmortem" OR title ~ "Post-mortem"` | Incident reviews |
+
+---
+
+## Common Workflows
+
+### 1. Find Runbook for Alert
+
+```bash
+# Step 1: Search for runbook by alert name
+python find_runbooks.py --alert "HighErrorRate"
+
+# Step 2: If found, read the full runbook
+python get_page.py --page-id 123456789
+```
+
+### 2. Investigate Service Issues
+
+```bash
+# Step 1: Find service documentation
+python search_pages.py --query "payment service architecture"
+
+# Step 2: Check for runbooks
+python find_runbooks.py --service payment
+
+# Step 3: Look for historical incidents
+python find_postmortems.py --service payment --days 90
+```
+
+### 3. Learn from Past Incidents
+
+```bash
+# Step 1: Find similar post-mortems
+python find_postmortems.py --service checkout --days 180
+
+# Step 2: Read specific post-mortem
+python get_page.py --page-id 987654321
+
+# Step 3: Search for related issues
+python search_cql.py --cql 'space = "SRE" AND text ~ "checkout timeout" AND lastModified >= now("-180d")'
+```
+
+### 4. Check for Known Issues
+
+```bash
+# Search for known issues documentation
+python search_pages.py --query "known issues" --space SRE
+
+# Look for troubleshooting guides
+python search_cql.py --cql 'title ~ "troubleshooting" OR label = "troubleshooting"'
+```
+
+---
+
+## Quick Commands Reference
+
+| Goal | Command |
+|------|---------|
+| Find runbook | `find_runbooks.py --service SERVICE` |
+| Find post-mortems | `find_postmortems.py --service SERVICE` |
+| General search | `search_pages.py --query "QUERY"` |
+| Read full page | `get_page.py --page-id ID` |
+| Advanced search | `search_cql.py --cql "CQL"` |
+
+---
+
+## Best Practices
+
+### When to Use Knowledge Base
+
+1. **Start of investigation** - Check for existing runbooks before deep diving
+2. **Unknown service** - Find architecture docs to understand the system
+3. **Recurring alerts** - Look for post-mortems about similar incidents
+4. **Before remediation** - Verify documented procedures exist
+
+### Search Strategy
+
+1. **Start broad** - Use general search first (`search_pages.py`)
+2. **Narrow down** - Use specific tools (`find_runbooks.py`, `find_postmortems.py`)
+3. **Read details** - Get full page content only when needed
+4. **Check recency** - Look for recent post-mortems to find patterns
+
+### Labels to Look For
+
+Common Confluence labels in SRE/Ops teams:
+- `runbook`, `playbook`, `sop` - Operational procedures
+- `postmortem`, `post-mortem`, `incident-review` - Incident analysis
+- `architecture`, `design-doc` - System design
+- `troubleshooting`, `debugging` - Diagnostic guides
+
+---
+
+## Anti-Patterns to Avoid
+
+1. ❌ **Reading full pages first** - Start with search/find, then read details
+2. ❌ **Ignoring runbooks** - Check knowledge base before manual investigation
+3. ❌ **Not learning from history** - Post-mortems prevent repeated mistakes
+4. ❌ **Searching without space filters** - Narrow results with `--space` when possible
+
+---
+
+## Integration with Other Skills
+
+Combine knowledge base with other investigation tools:
+
+```bash
+# 1. Find runbook
+python find_runbooks.py --alert "HighMemoryUsage"
+
+# 2. Follow runbook instructions, e.g., check pod resources
+python .claude/skills/infrastructure/kubernetes/scripts/describe_pod.py payment-xxx -n otel-demo
+
+# 3. Document findings for future post-mortem
+# (Manual step - create post-mortem page after incident resolution)
+```
+
+---
+
+## Tips for Effective Searches
+
+- **Use service names** - Include the service name in queries
+- **Check multiple spaces** - Try SRE, OPS, Engineering spaces
+- **Look for patterns** - Post-mortems reveal recurring issues
+- **Verify freshness** - Recent docs are more accurate
+- **Follow links** - Runbooks often link to related documentation

--- a/sre-agent/.claude/skills/knowledge-base/scripts/confluence_client.py
+++ b/sre-agent/.claude/skills/knowledge-base/scripts/confluence_client.py
@@ -1,0 +1,277 @@
+"""Shared Confluence API client with credential proxy support.
+
+This client is designed to work with the OpenSRE credential proxy.
+Credentials are injected automatically by the proxy - scripts never see API tokens.
+
+Two modes:
+1. Proxy mode (production): Routes requests through CONFLUENCE_BASE_URL proxy
+   which injects Basic auth headers automatically
+2. Direct mode (local dev): Uses CONFLUENCE_* environment variables directly
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+def get_config() -> dict[str, Any]:
+    """Load configuration from standard locations."""
+    config = {}
+
+    # Check for config file
+    config_paths = [
+        Path.home() / ".opensre" / "config.json",
+        Path("/etc/opensre/config.json"),
+    ]
+
+    for path in config_paths:
+        if path.exists():
+            with open(path) as f:
+                config = json.load(f)
+                break
+
+    # Environment overrides
+    if os.getenv("OPENSRE_TENANT_ID"):
+        config["tenant_id"] = os.getenv("OPENSRE_TENANT_ID")
+    if os.getenv("OPENSRE_TEAM_ID"):
+        config["team_id"] = os.getenv("OPENSRE_TEAM_ID")
+
+    return config
+
+
+def get_api_url(path: str) -> str:
+    """Build the Confluence API URL.
+
+    Supports two modes:
+    1. Proxy mode (production): Uses credential-resolver's reverse proxy
+       The path /wiki/... is sent to http://credential-resolver:8002/confluence/wiki/...
+    2. Direct mode (local dev): Uses CONFLUENCE_URL with local credentials
+
+    Args:
+        path: API path (e.g., "/wiki/rest/api/content/search")
+
+    Returns:
+        Full API URL
+    """
+    # Proxy mode (production) - requests go through credential-resolver's proxy
+    # The credential-resolver has a /confluence/* endpoint that proxies to the
+    # actual Confluence instance with auth injected
+    proxy_url = os.getenv("CONFLUENCE_BASE_URL")
+    if proxy_url:
+        # CONFLUENCE_BASE_URL points to credential-resolver
+        # e.g., http://credential-resolver:8002/confluence
+        return f"{proxy_url.rstrip('/')}{path}"
+
+    # Direct mode (local dev) - requires CONFLUENCE_URL and credentials
+    url = os.getenv("CONFLUENCE_URL")
+    if url:
+        # Remove trailing /wiki if present (we add it in the path)
+        url = url.rstrip("/")
+        if url.endswith("/wiki"):
+            url = url[:-5]
+        return f"{url}{path}"
+
+    raise RuntimeError(
+        "No Confluence URL configured. Either:\n"
+        "  - Set CONFLUENCE_BASE_URL for proxy mode (production), or\n"
+        "  - Set CONFLUENCE_URL for direct mode (local development)"
+    )
+
+
+def get_headers() -> dict[str, str]:
+    """Get request headers for Confluence API.
+
+    In proxy mode: includes tenant context for credential lookup.
+    In direct mode: includes Basic auth directly.
+    """
+    config = get_config()
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    # Check if we're in direct mode (have credentials locally)
+    email = os.getenv("CONFLUENCE_EMAIL")
+    api_token = os.getenv("CONFLUENCE_API_TOKEN")
+
+    if email and api_token and not os.getenv("CONFLUENCE_BASE_URL"):
+        # Direct mode - add Basic auth
+        import base64
+
+        auth_string = f"{email}:{api_token}"
+        encoded = base64.b64encode(auth_string.encode()).decode()
+        headers["Authorization"] = f"Basic {encoded}"
+    else:
+        # Proxy mode - add JWT for authentication with credential-resolver
+        # The JWT contains tenant/team context and is validated by credential-resolver
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            # Fallback to tenant headers (for local dev without JWT)
+            headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+            headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    return headers
+
+
+def search_content(
+    cql: str,
+    limit: int = 25,
+    expand: str | None = None,
+) -> dict[str, Any]:
+    """Search Confluence using CQL (Confluence Query Language).
+
+    Args:
+        cql: CQL query string
+        limit: Maximum results to return
+        expand: Optional fields to expand (comma-separated)
+
+    Returns:
+        Search results with 'results' array
+    """
+    params = {
+        "cql": cql,
+        "limit": limit,
+    }
+    if expand:
+        params["expand"] = expand
+
+    url = get_api_url("/wiki/rest/api/content/search")
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(url, headers=get_headers(), params=params)
+        response.raise_for_status()
+        return response.json()
+
+
+def cql_search(
+    cql: str,
+    limit: int = 25,
+    expand: str | None = None,
+) -> dict[str, Any]:
+    """Search using the CQL endpoint (alternative to content/search).
+
+    Args:
+        cql: CQL query string
+        limit: Maximum results to return
+        expand: Optional fields to expand
+
+    Returns:
+        Search results
+    """
+    params = {
+        "cql": cql,
+        "limit": limit,
+    }
+    if expand:
+        params["expand"] = expand
+
+    url = get_api_url("/wiki/rest/api/search")
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(url, headers=get_headers(), params=params)
+        response.raise_for_status()
+        return response.json()
+
+
+def get_page_by_id(
+    page_id: str,
+    expand: str = "body.storage,version,space",
+) -> dict[str, Any]:
+    """Get a Confluence page by ID.
+
+    Args:
+        page_id: Page ID
+        expand: Fields to expand (comma-separated)
+
+    Returns:
+        Page data
+    """
+    url = get_api_url(f"/wiki/rest/api/content/{page_id}")
+    params = {"expand": expand}
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(url, headers=get_headers(), params=params)
+        response.raise_for_status()
+        return response.json()
+
+
+def get_page_by_title(
+    space: str,
+    title: str,
+    expand: str = "body.storage,version,space",
+) -> dict[str, Any] | None:
+    """Get a Confluence page by title.
+
+    Args:
+        space: Space key
+        title: Page title
+        expand: Fields to expand
+
+    Returns:
+        Page data or None if not found
+    """
+    url = get_api_url("/wiki/rest/api/content")
+    params = {
+        "spaceKey": space,
+        "title": title,
+        "expand": expand,
+    }
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(url, headers=get_headers(), params=params)
+        response.raise_for_status()
+        data = response.json()
+
+        results = data.get("results", [])
+        if results:
+            return results[0]
+        return None
+
+
+def format_page_result(result: dict[str, Any]) -> dict[str, Any]:
+    """Format a CQL search result for consistent output.
+
+    Args:
+        result: Raw result from CQL search
+
+    Returns:
+        Formatted page data
+    """
+    # Handle different response formats (search vs content endpoints)
+    content = result.get("content", result)
+
+    return {
+        "id": content.get("id"),
+        "title": content.get("title"),
+        "type": content.get("type"),
+        "space": content.get("space", {}).get("key") if content.get("space") else None,
+        "url": result.get("url") or content.get("_links", {}).get("webui"),
+        "excerpt": result.get("excerpt", ""),
+        "created": content.get("history", {}).get("createdDate"),
+        "updated": result.get("lastModified") or content.get("version", {}).get("when"),
+    }
+
+
+# Legacy compatibility - keep get_confluence_client for scripts that use it
+def get_confluence_client():
+    """Get Confluence client instance.
+
+    DEPRECATED: This function exists for backward compatibility.
+    New code should use the module-level functions directly:
+    - search_content()
+    - get_page_by_id()
+    - get_page_by_title()
+
+    Returns:
+        Self (this module acts as the client)
+    """
+    import sys
+
+    # Return this module as a pseudo-client
+    # Functions can be called as confluence_client.search_content(), etc.
+    return sys.modules[__name__]

--- a/sre-agent/.claude/skills/knowledge-base/scripts/find_postmortems.py
+++ b/sre-agent/.claude/skills/knowledge-base/scripts/find_postmortems.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Find post-mortem documents in Confluence.
+
+Usage:
+    python find_postmortems.py [--service SERVICE] [--days N] [--space SPACE_KEY] [--limit N]
+
+Examples:
+    python find_postmortems.py --service payment
+    python find_postmortems.py --service payment --days 180
+    python find_postmortems.py --space SRE
+"""
+
+import argparse
+import json
+import sys
+
+from confluence_client import format_page_result, search_content
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Find post-mortem documents in Confluence"
+    )
+    parser.add_argument(
+        "--service",
+        help="Service name to filter by",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=90,
+        help="Look back this many days (default: 90)",
+    )
+    parser.add_argument(
+        "--space",
+        help="Limit search to a specific space key",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum number of results (default: 20)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    try:
+        # Build CQL query
+        cql_parts = [
+            f'lastModified >= now("-{args.days}d")',
+            "type = page",
+            '(label = "postmortem" OR label = "post-mortem" OR label = "incident-review" OR title ~ "Post-mortem" OR title ~ "Postmortem" OR title ~ "Incident Review")',
+        ]
+
+        if args.service:
+            cql_parts.append(f'(title ~ "{args.service}" OR text ~ "{args.service}")')
+
+        if args.space:
+            cql_parts.append(f'space = "{args.space}"')
+
+        cql = " AND ".join(cql_parts)
+
+        # Search
+        results = search_content(cql=cql, limit=args.limit)
+
+        postmortems = []
+        for result in results.get("results", []):
+            page = format_page_result(result)
+            postmortems.append(page)
+
+        # Output
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "service": args.service,
+                        "days": args.days,
+                        "total": len(postmortems),
+                        "postmortems": postmortems,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(f"\n📋 Found {len(postmortems)} post-mortem(s)")
+            if args.service:
+                print(f"   Service: {args.service}")
+            print(f"   Last {args.days} days")
+            if args.space:
+                print(f"   Space: {args.space}")
+            print()
+
+            if len(postmortems) == 0:
+                print("   ℹ️  No post-mortems found in the specified time range.")
+                print()
+            else:
+                for i, pm in enumerate(postmortems, 1):
+                    print(f"{i}. {pm['title']}")
+                    print(f"   ID: {pm['id']}")
+                    if pm.get("space"):
+                        print(f"   Space: {pm['space']}")
+                    if pm.get("url"):
+                        print(f"   URL: {pm['url']}")
+                    if pm.get("updated"):
+                        print(f"   Last Updated: {pm['updated']}")
+                    print()
+
+    except Exception as e:
+        print(f"❌ Error: {str(e)}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/knowledge-base/scripts/find_runbooks.py
+++ b/sre-agent/.claude/skills/knowledge-base/scripts/find_runbooks.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Find runbooks in Confluence for a service or alert.
+
+Usage:
+    python find_runbooks.py [--service SERVICE] [--alert ALERT_NAME] [--space SPACE_KEY] [--limit N]
+
+Examples:
+    python find_runbooks.py --service payment
+    python find_runbooks.py --alert "HighErrorRate"
+    python find_runbooks.py --service checkout --space OPS
+"""
+
+import argparse
+import json
+import sys
+
+from confluence_client import format_page_result, search_content
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Find runbooks in Confluence for a service or alert"
+    )
+    parser.add_argument(
+        "--service",
+        help="Service name to search for",
+    )
+    parser.add_argument(
+        "--alert",
+        help="Alert name to search for",
+    )
+    parser.add_argument(
+        "--space",
+        help="Limit search to a specific space key",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="Maximum number of results (default: 10)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    if not args.service and not args.alert:
+        print("❌ Error: Must provide --service or --alert", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        # Build CQL query
+        # Look for runbook labels/titles
+        runbook_filter = '(label = "runbook" OR label = "playbook" OR label = "sop" OR title ~ "runbook" OR title ~ "playbook")'
+
+        cql_parts = [runbook_filter, "type = page"]
+
+        # Add service/alert search terms
+        search_terms = []
+        if args.service:
+            search_terms.append(
+                f'(title ~ "{args.service}" OR text ~ "{args.service}")'
+            )
+        if args.alert:
+            search_terms.append(f'(title ~ "{args.alert}" OR text ~ "{args.alert}")')
+
+        if search_terms:
+            cql_parts.append(f"({' OR '.join(search_terms)})")
+
+        if args.space:
+            cql_parts.append(f'space = "{args.space}"')
+
+        cql = " AND ".join(cql_parts)
+
+        # Search
+        results = search_content(cql=cql, limit=args.limit)
+
+        runbooks = []
+        for result in results.get("results", []):
+            page = format_page_result(result)
+            # Add relevance score
+            page["relevance"] = (
+                "high"
+                if args.service and args.service.lower() in page["title"].lower()
+                else "medium"
+            )
+            runbooks.append(page)
+
+        # Output
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "service": args.service,
+                        "alert": args.alert,
+                        "total": len(runbooks),
+                        "has_runbook": len(runbooks) > 0,
+                        "runbooks": runbooks,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            search_desc = []
+            if args.service:
+                search_desc.append(f"service: {args.service}")
+            if args.alert:
+                search_desc.append(f"alert: {args.alert}")
+
+            print(
+                f"\n📚 Found {len(runbooks)} runbook(s) for {', '.join(search_desc)}\n"
+            )
+            if args.space:
+                print(f"   Space: {args.space}\n")
+
+            if len(runbooks) == 0:
+                print(
+                    "   ℹ️  No runbooks found. Consider searching for general documentation."
+                )
+                print()
+            else:
+                for i, runbook in enumerate(runbooks, 1):
+                    relevance_emoji = "🎯" if runbook["relevance"] == "high" else "📄"
+                    print(f"{i}. {relevance_emoji} {runbook['title']}")
+                    print(f"   ID: {runbook['id']}")
+                    if runbook.get("space"):
+                        print(f"   Space: {runbook['space']}")
+                    if runbook.get("url"):
+                        print(f"   URL: {runbook['url']}")
+                    if runbook.get("updated"):
+                        print(f"   Last Updated: {runbook['updated']}")
+                    print()
+
+    except Exception as e:
+        print(f"❌ Error: {str(e)}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/knowledge-base/scripts/get_page.py
+++ b/sre-agent/.claude/skills/knowledge-base/scripts/get_page.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Get the full content of a Confluence page.
+
+Usage:
+    python get_page.py --page-id PAGE_ID
+    python get_page.py --title "Page Title" --space SPACE_KEY
+
+Examples:
+    python get_page.py --page-id 123456789
+    python get_page.py --title "Payment Service Runbook" --space SRE
+"""
+
+import argparse
+import json
+import re
+import sys
+
+from confluence_client import get_page_by_id, get_page_by_title
+
+
+def html_to_text(html: str) -> str:
+    """Convert Confluence storage format HTML to plain text.
+
+    Handles Confluence macros and CDATA sections.
+    """
+    # Extract CDATA content (Confluence macros often use CDATA)
+    cdata_pattern = r"<!\[CDATA\[(.*?)\]\]>"
+    cdata_matches = re.findall(cdata_pattern, html, re.DOTALL)
+
+    # If we found CDATA content, use that (it's usually markdown or plain text)
+    if cdata_matches:
+        return "\n\n".join(cdata_matches)
+
+    # Otherwise, strip HTML tags
+    text = re.sub(r"<[^>]+>", "", html)
+    # Clean up multiple newlines
+    text = re.sub(r"\n\s*\n\s*\n+", "\n\n", text)
+    return text.strip()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Get the full content of a Confluence page"
+    )
+    parser.add_argument(
+        "--page-id",
+        help="Page ID",
+    )
+    parser.add_argument(
+        "--title",
+        help="Page title (requires --space)",
+    )
+    parser.add_argument(
+        "--space",
+        help="Space key (required with --title)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    parser.add_argument(
+        "--raw-html",
+        action="store_true",
+        help="Show raw HTML content instead of plain text",
+    )
+    args = parser.parse_args()
+
+    if not args.page_id and not (args.title and args.space):
+        print(
+            "❌ Error: Must provide --page-id or (--title and --space)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        # Get page
+        if args.page_id:
+            page = get_page_by_id(args.page_id)
+        else:
+            # Get by title and space
+            page = get_page_by_title(space=args.space, title=args.title)
+
+        # Extract content
+        body = page.get("body", {})
+        storage = body.get("storage", {})
+        html_content = storage.get("value", "")
+
+        # Convert to text unless raw HTML requested
+        if args.raw_html:
+            content = html_content
+        else:
+            content = html_to_text(html_content)
+
+        # Construct page URL from environment or page data
+        import os
+
+        base_url = os.getenv("CONFLUENCE_BASE_URL") or os.getenv("CONFLUENCE_URL", "")
+        base_url = base_url.rstrip("/")
+        if base_url.endswith("/wiki"):
+            base_url = base_url[:-5]
+        webui = page.get("_links", {}).get("webui", "")
+        page_url = f"{base_url}/wiki{webui}" if base_url and webui else ""
+
+        # Output
+        if args.json:
+            output = {
+                "id": page.get("id"),
+                "title": page.get("title"),
+                "space": page.get("space", {}).get("key"),
+                "content": content,
+                "url": page_url,
+                "version": page.get("version", {}).get("number"),
+            }
+            print(json.dumps(output, indent=2))
+        else:
+            print(f"\n📄 {page.get('title')}")
+            print(f"   ID: {page.get('id')}")
+            if page.get("space", {}).get("key"):
+                print(f"   Space: {page.get('space', {}).get('key')}")
+            if page_url:
+                print(f"   URL: {page_url}")
+            if page.get("version", {}).get("number"):
+                print(f"   Version: {page.get('version', {}).get('number')}")
+            print("\n" + "=" * 80)
+            print(content)
+            print("=" * 80 + "\n")
+
+    except Exception as e:
+        print(f"❌ Error: {str(e)}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/knowledge-base/scripts/search_cql.py
+++ b/sre-agent/.claude/skills/knowledge-base/scripts/search_cql.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Search Confluence using CQL (Confluence Query Language).
+
+More powerful than text search - supports filtering by space, type,
+labels, dates, etc. Useful for finding runbooks, post-mortems, and
+incident documentation.
+
+Common CQL patterns:
+- Find runbooks: 'type = page AND label = "runbook"'
+- Find post-mortems: 'type = page AND (label = "postmortem" OR title ~ "Post-mortem")'
+- Find by space: 'space = "OPS" AND type = page'
+- Find recent: 'lastModified >= now("-30d") AND type = page'
+- Combined: 'space = "SRE" AND label = "incident" AND lastModified >= now("-90d")'
+
+Usage:
+    python search_cql.py --cql "CQL_QUERY" [--limit N]
+
+Examples:
+    python search_cql.py --cql 'type = page AND label = "runbook"'
+    python search_cql.py --cql 'space = "SRE" AND lastModified >= now("-30d")'
+    python search_cql.py --cql 'text ~ "payment" AND label = "postmortem"'
+"""
+
+import argparse
+import json
+import sys
+
+from confluence_client import format_page_result, search_content
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Search Confluence using CQL (Confluence Query Language)"
+    )
+    parser.add_argument(
+        "--cql",
+        required=True,
+        help="CQL query string",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=25,
+        help="Maximum number of results (default: 25)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    try:
+        # Search
+        results = search_content(cql=args.cql, limit=args.limit)
+
+        pages = []
+        for result in results.get("results", []):
+            page = format_page_result(result)
+            pages.append(page)
+
+        total_size = results.get("totalSize", len(pages))
+
+        # Output
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "cql": args.cql,
+                        "total_results": total_size,
+                        "returned_results": len(pages),
+                        "pages": pages,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print("\n🔍 CQL Search Results")
+            print(f"   Query: {args.cql}")
+            print(f"   Found: {total_size} total, showing {len(pages)}\n")
+
+            if len(pages) == 0:
+                print("   ℹ️  No results found.")
+                print()
+            else:
+                for i, page in enumerate(pages, 1):
+                    print(f"{i}. {page['title']}")
+                    print(f"   ID: {page['id']}")
+                    print(f"   Type: {page.get('type', 'page')}")
+                    if page.get("space"):
+                        print(f"   Space: {page['space']}")
+                    if page.get("url"):
+                        print(f"   URL: {page['url']}")
+                    if page.get("updated"):
+                        print(f"   Last Updated: {page['updated']}")
+                    print()
+
+    except Exception as e:
+        print(f"❌ Error: {str(e)}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/knowledge-base/scripts/search_pages.py
+++ b/sre-agent/.claude/skills/knowledge-base/scripts/search_pages.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Search for pages in Confluence.
+
+Usage:
+    python search_pages.py --query SEARCH_QUERY [--space SPACE_KEY] [--limit N]
+
+Examples:
+    python search_pages.py --query "payment service timeout"
+    python search_pages.py --query "database connection" --space SRE
+    python search_pages.py --query "api error" --limit 20
+"""
+
+import argparse
+import json
+import sys
+
+from confluence_client import format_page_result, search_content
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search for pages in Confluence")
+    parser.add_argument(
+        "--query",
+        required=True,
+        help="Search query",
+    )
+    parser.add_argument(
+        "--space",
+        help="Limit search to a specific space key",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="Maximum number of results (default: 10)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    try:
+        # Build CQL query
+        cql_parts = [f'text ~ "{args.query}"', "type = page"]
+        if args.space:
+            cql_parts.append(f'space = "{args.space}"')
+
+        cql = " AND ".join(cql_parts)
+
+        # Search
+        results = search_content(cql=cql, limit=args.limit)
+
+        pages = []
+        for result in results.get("results", []):
+            page = format_page_result(result)
+            pages.append(page)
+
+        # Output
+        if args.json:
+            print(
+                json.dumps(
+                    {"query": args.query, "total": len(pages), "pages": pages}, indent=2
+                )
+            )
+        else:
+            print(f"\n🔍 Found {len(pages)} page(s) for query: {args.query}\n")
+            if args.space:
+                print(f"   Space: {args.space}\n")
+
+            for i, page in enumerate(pages, 1):
+                print(f"{i}. {page['title']}")
+                print(f"   ID: {page['id']}")
+                if page.get("space"):
+                    print(f"   Space: {page['space']}")
+                if page.get("url"):
+                    print(f"   URL: {page['url']}")
+                if page.get("updated"):
+                    print(f"   Last Updated: {page['updated']}")
+                print()
+
+    except Exception as e:
+        print(f"❌ Error: {str(e)}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/knowledge-raptor/SKILL.md
+++ b/sre-agent/.claude/skills/knowledge-raptor/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: knowledge-raptor
+description: Search the RAPTOR knowledge base for runbooks, past incidents, service dependencies, and accumulated team knowledge. Use BEFORE Confluence when investigating incidents — this contains curated, structured knowledge that the system has learned from past investigations.
+allowed-tools: Bash(python *)
+---
+
+# Knowledge Base - RAPTOR Integration
+
+## Authentication
+
+**No credentials needed.** The RAPTOR service is an internal Kubernetes service. Requests go directly via ClusterIP — no proxy, no tokens. Just run the scripts.
+
+---
+
+## Why RAPTOR Matters During Incidents
+
+The RAPTOR knowledge base contains **learned knowledge** from past investigations, taught runbooks, service dependency graphs, and incident patterns. Check it **before** Confluence:
+
+- **Is there a known fix?** Search for runbooks matching the symptoms
+- **Has this happened before?** Find similar past incidents and their resolutions
+- **What's the blast radius?** Query the service dependency graph
+- **What should I know?** Search for relevant team knowledge
+
+## Available Scripts
+
+All scripts are in `.claude/skills/knowledge-raptor/scripts/`
+
+### search.py - General Knowledge Search
+
+Search across all knowledge (runbooks, docs, past learnings) using semantic search.
+
+```bash
+python .claude/skills/knowledge-raptor/scripts/search.py --query SEARCH_QUERY [--tree TREE] [--top-k N]
+
+# Examples:
+python .claude/skills/knowledge-raptor/scripts/search.py --query "how to debug OOMKilled pods"
+python .claude/skills/knowledge-raptor/scripts/search.py --query "database connection pool exhaustion" --top-k 10
+python .claude/skills/knowledge-raptor/scripts/search.py --query "Redis cache eviction" --tree mega_ultra_v2
+```
+
+### search_incident.py - Incident-Aware Search
+
+Find runbooks and past incidents matching specific symptoms. Optimized for incident investigation.
+
+```bash
+python .claude/skills/knowledge-raptor/scripts/search_incident.py --symptoms DESCRIPTION [--service SERVICE] [--top-k N]
+
+# Examples:
+python .claude/skills/knowledge-raptor/scripts/search_incident.py --symptoms "pods keep crashing with OOMKilled"
+python .claude/skills/knowledge-raptor/scripts/search_incident.py --symptoms "high latency on API endpoints" --service payment-gateway
+python .claude/skills/knowledge-raptor/scripts/search_incident.py --symptoms "503 errors, connection timeouts" --service auth-service --top-k 10
+```
+
+### query_graph.py - Service Dependency Graph
+
+Query the knowledge graph for service dependencies, ownership, blast radius, and related runbooks.
+
+```bash
+python .claude/skills/knowledge-raptor/scripts/query_graph.py --entity ENTITY --query-type TYPE [--max-hops N]
+
+# Query types: dependencies, dependents, owner, runbooks, incidents, blast_radius
+
+# Examples:
+python .claude/skills/knowledge-raptor/scripts/query_graph.py --entity payment-gateway --query-type blast_radius
+python .claude/skills/knowledge-raptor/scripts/query_graph.py --entity redis-cache --query-type dependents
+python .claude/skills/knowledge-raptor/scripts/query_graph.py --entity auth-service --query-type owner
+python .claude/skills/knowledge-raptor/scripts/query_graph.py --entity postgres-primary --query-type dependencies --max-hops 3
+```
+
+### find_similar.py - Find Similar Past Incidents
+
+Find past incidents with similar symptoms to identify patterns and known resolutions.
+
+```bash
+python .claude/skills/knowledge-raptor/scripts/find_similar.py --symptoms DESCRIPTION [--service SERVICE] [--limit N]
+
+# Examples:
+python .claude/skills/knowledge-raptor/scripts/find_similar.py --symptoms "connection timeouts to database"
+python .claude/skills/knowledge-raptor/scripts/find_similar.py --symptoms "high memory usage, pods restarting" --service checkout-service
+python .claude/skills/knowledge-raptor/scripts/find_similar.py --symptoms "kafka consumer lag increasing" --limit 10
+```
+
+### teach.py - Teach New Knowledge
+
+Teach the knowledge base something new learned during an investigation. The system detects duplicates and contradictions automatically.
+
+```bash
+python .claude/skills/knowledge-raptor/scripts/teach.py --content KNOWLEDGE [--type TYPE] [--entities ENTITY1,ENTITY2] [--confidence N] [--source SOURCE] [--context CONTEXT]
+
+# Knowledge types: procedural, factual, temporal, relational, contextual, policy, social, meta
+
+# Examples:
+python .claude/skills/knowledge-raptor/scripts/teach.py \
+  --content "When payment-gateway shows OOMKilled, check the Redis connection pool first — stale connections accumulate during traffic spikes" \
+  --type procedural \
+  --entities payment-gateway,redis-cache \
+  --source "incident_INC-2024-0456"
+
+python .claude/skills/knowledge-raptor/scripts/teach.py \
+  --content "The auth-service fallback to database sessions adds ~200ms latency per request when Redis is down" \
+  --type factual \
+  --entities auth-service,redis-cache \
+  --confidence 0.9
+```
+
+---
+
+## Common Workflows
+
+### 1. Investigate an Incident
+
+```bash
+# Step 1: Search for matching runbooks and past incidents
+python .claude/skills/knowledge-raptor/scripts/search_incident.py --symptoms "503 errors, high latency" --service payment-gateway
+
+# Step 2: Check blast radius
+python .claude/skills/knowledge-raptor/scripts/query_graph.py --entity payment-gateway --query-type blast_radius
+
+# Step 3: Find similar past incidents
+python .claude/skills/knowledge-raptor/scripts/find_similar.py --symptoms "503 errors on payment service"
+
+# Step 4: After resolving, teach what you learned
+python .claude/skills/knowledge-raptor/scripts/teach.py \
+  --content "payment-gateway 503s were caused by connection pool exhaustion after Redis failover" \
+  --type procedural \
+  --entities payment-gateway,redis-cache
+```
+
+### 2. Understand Service Dependencies
+
+```bash
+# What does this service depend on?
+python .claude/skills/knowledge-raptor/scripts/query_graph.py --entity checkout-service --query-type dependencies
+
+# Who owns it?
+python .claude/skills/knowledge-raptor/scripts/query_graph.py --entity checkout-service --query-type owner
+
+# What breaks if it goes down?
+python .claude/skills/knowledge-raptor/scripts/query_graph.py --entity checkout-service --query-type blast_radius
+```
+
+### 3. Learn from History
+
+```bash
+# Search for past learnings about a topic
+python .claude/skills/knowledge-raptor/scripts/search.py --query "kafka consumer rebalance storms"
+
+# Find similar incidents
+python .claude/skills/knowledge-raptor/scripts/find_similar.py --symptoms "kafka consumer group rebalancing frequently"
+```
+
+---
+
+## Quick Commands Reference
+
+| Goal | Command |
+|------|---------|
+| Find runbook | `search_incident.py --symptoms "..." --service SVC` |
+| General search | `search.py --query "..."` |
+| Service dependencies | `query_graph.py --entity SVC --query-type dependencies` |
+| Blast radius | `query_graph.py --entity SVC --query-type blast_radius` |
+| Who owns service | `query_graph.py --entity SVC --query-type owner` |
+| Past incidents | `find_similar.py --symptoms "..."` |
+| Teach knowledge | `teach.py --content "..." --type procedural` |
+
+---
+
+## Best Practices
+
+### When to Use RAPTOR vs Confluence
+
+1. **Start with RAPTOR** — it has structured, learned knowledge from past investigations
+2. **Fall back to Confluence** — for detailed documentation, architecture docs, or team wikis
+3. **Teach back to RAPTOR** — after resolving, teach what you learned so future investigations benefit
+
+### Investigation Flow
+
+1. **Start with incident search** — match symptoms to known patterns
+2. **Check dependencies** — understand the blast radius before making changes
+3. **Search broadly** — if incident search doesn't match, try general search
+4. **Look at history** — find similar past incidents for resolution patterns
+5. **Teach what you learn** — close the loop for future investigators

--- a/sre-agent/.claude/skills/knowledge-raptor/scripts/find_similar.py
+++ b/sre-agent/.claude/skills/knowledge-raptor/scripts/find_similar.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Find similar past incidents in the knowledge base.
+
+Usage:
+    python find_similar.py --symptoms DESCRIPTION [--service SERVICE] [--limit N]
+
+Examples:
+    python find_similar.py --symptoms "connection timeouts to database"
+    python find_similar.py --symptoms "high memory usage" --service checkout-service
+"""
+
+import argparse
+import json
+import sys
+
+from raptor_client import raptor_post
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Find similar past incidents")
+    parser.add_argument(
+        "--symptoms",
+        required=True,
+        help="Description of the symptoms to match",
+    )
+    parser.add_argument(
+        "--service",
+        default="",
+        help="Filter by service name (optional)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=5,
+        help="Maximum results (default: 5)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    try:
+        payload = {
+            "symptoms": args.symptoms,
+            "service": args.service,
+            "limit": args.limit,
+        }
+
+        data = raptor_post("/api/v1/similar-incidents", payload)
+
+        if args.json:
+            print(json.dumps(data, indent=2))
+        else:
+            incidents = data.get("similar_incidents", [])
+            total = data.get("total_found", len(incidents))
+
+            print(f"\nSimilar incidents for: {args.symptoms}")
+            if args.service:
+                print(f"Service filter: {args.service}")
+            print(f"Found: {total}\n")
+
+            if not incidents:
+                print("No similar incidents found.")
+            else:
+                for i, inc in enumerate(incidents, 1):
+                    similarity = inc.get("similarity", 0)
+                    inc_id = inc.get("incident_id", "unknown")
+                    date = inc.get("date", "")
+                    symptoms = inc.get("symptoms", "")
+                    root_cause = inc.get("root_cause", "")
+                    resolution = inc.get("resolution", "")
+                    services = inc.get("services_affected", [])
+
+                    print(f"{i}. [{similarity:.2f}] {inc_id}")
+                    if date:
+                        print(f"   Date: {date}")
+                    if services:
+                        print(f"   Services: {', '.join(services)}")
+                    if symptoms:
+                        print(f"   Symptoms: {symptoms[:200]}")
+                    if root_cause:
+                        print(f"   Root cause: {root_cause[:200]}")
+                    if resolution:
+                        print(f"   Resolution: {resolution[:200]}")
+                    print()
+
+            hint = data.get("hint")
+            if hint:
+                print(f"Hint: {hint}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/knowledge-raptor/scripts/query_graph.py
+++ b/sre-agent/.claude/skills/knowledge-raptor/scripts/query_graph.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Query the service dependency graph in the knowledge base.
+
+Usage:
+    python query_graph.py --entity ENTITY --query-type TYPE [--max-hops N]
+
+Query types: dependencies, dependents, owner, runbooks, incidents, blast_radius
+
+Examples:
+    python query_graph.py --entity payment-gateway --query-type blast_radius
+    python query_graph.py --entity redis-cache --query-type dependents
+    python query_graph.py --entity auth-service --query-type owner
+"""
+
+import argparse
+import json
+import sys
+
+from raptor_client import raptor_post
+
+QUERY_TYPES = [
+    "dependencies",
+    "dependents",
+    "owner",
+    "runbooks",
+    "incidents",
+    "blast_radius",
+]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Query the service dependency graph")
+    parser.add_argument(
+        "--entity",
+        required=True,
+        help="Service or entity name to query",
+    )
+    parser.add_argument(
+        "--query-type",
+        required=True,
+        choices=QUERY_TYPES,
+        help="Type of graph query",
+    )
+    parser.add_argument(
+        "--max-hops",
+        type=int,
+        default=2,
+        help="Maximum hops in graph traversal (1-5, default: 2)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    try:
+        payload = {
+            "entity_name": args.entity,
+            "query_type": args.query_type,
+            "max_hops": args.max_hops,
+        }
+
+        data = raptor_post("/api/v1/graph/query", payload)
+
+        if args.json:
+            print(json.dumps(data, indent=2))
+        else:
+            print(f"\nGraph query: {args.entity} -> {args.query_type}\n")
+
+            if args.query_type == "dependencies":
+                deps = data.get("dependencies", [])
+                if deps:
+                    print(f"Dependencies ({len(deps)}):")
+                    for dep in deps:
+                        print(f"  - {dep}")
+                else:
+                    print("No dependencies found.")
+
+            elif args.query_type == "dependents":
+                deps = data.get("dependents", [])
+                if deps:
+                    print(f"Dependents ({len(deps)}):")
+                    for dep in deps:
+                        print(f"  - {dep}")
+                else:
+                    print("No dependents found.")
+
+            elif args.query_type == "owner":
+                owner = data.get("owner", {})
+                if owner:
+                    print(f"Owner: {owner.get('team', 'unknown')}")
+                    if owner.get("entity_id"):
+                        print(f"Entity ID: {owner['entity_id']}")
+                else:
+                    print("No owner information found.")
+
+            elif args.query_type == "runbooks":
+                runbooks = data.get("runbooks", [])
+                if runbooks:
+                    print(f"Runbooks ({len(runbooks)}):")
+                    for rb in runbooks:
+                        rb_id = rb.get("runbook_id", "unknown")
+                        props = rb.get("properties", {})
+                        print(f"  - {rb_id}")
+                        if props:
+                            for k, v in props.items():
+                                print(f"    {k}: {v}")
+                else:
+                    print("No runbooks found.")
+
+            elif args.query_type == "incidents":
+                incidents = data.get("incidents", [])
+                if incidents:
+                    print(f"Incidents ({len(incidents)}):")
+                    for inc in incidents:
+                        inc_id = inc.get("incident_id", "unknown")
+                        props = inc.get("properties", {})
+                        print(f"  - {inc_id}")
+                        if props:
+                            for k, v in props.items():
+                                print(f"    {k}: {v}")
+                else:
+                    print("No incidents found.")
+
+            elif args.query_type == "blast_radius":
+                blast = data.get("blast_radius", {})
+                affected = data.get("affected_services", [])
+                if blast or affected:
+                    if blast.get("direct_dependents"):
+                        print(f"Direct dependents: {blast['direct_dependents']}")
+                    if blast.get("total_affected"):
+                        print(f"Total affected: {blast['total_affected']}")
+                    if affected:
+                        print(f"\nAffected services ({len(affected)}):")
+                        for svc in affected:
+                            print(f"  - {svc}")
+                else:
+                    print("No blast radius information found.")
+
+            hint = data.get("hint")
+            if hint:
+                print(f"\nHint: {hint}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/knowledge-raptor/scripts/raptor_client.py
+++ b/sre-agent/.claude/skills/knowledge-raptor/scripts/raptor_client.py
@@ -1,0 +1,69 @@
+"""Shared RAPTOR knowledge base client.
+
+The RAPTOR service is an internal K8s service — no authentication required.
+Requests go directly to the service ClusterIP (no Envoy proxy needed).
+
+Configuration:
+    RAPTOR_URL: Base URL of the RAPTOR/ultimate_rag service.
+        Production: http://opensre-rag.<namespace>.svc.cluster.local:8000
+        Local dev:  http://localhost:8000
+"""
+
+import os
+from typing import Any
+
+import httpx
+
+RAPTOR_URL = os.getenv("RAPTOR_URL", "http://localhost:8000")
+
+
+def raptor_post(path: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Send a POST request to the RAPTOR API.
+
+    Args:
+        path: API path (e.g., "/api/v1/search")
+        payload: JSON request body
+
+    Returns:
+        Parsed JSON response
+
+    Raises:
+        httpx.HTTPStatusError: On non-2xx response
+        RuntimeError: If RAPTOR service is unreachable
+    """
+    url = f"{RAPTOR_URL.rstrip('/')}{path}"
+
+    try:
+        with httpx.Client(timeout=30.0) as client:
+            response = client.post(url, json=payload)
+            response.raise_for_status()
+            return response.json()
+    except httpx.ConnectError:
+        raise RuntimeError(
+            f"Cannot connect to RAPTOR service at {RAPTOR_URL}.\n"
+            "Ensure the service is running and RAPTOR_URL is set correctly."
+        )
+
+
+def raptor_get(path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Send a GET request to the RAPTOR API.
+
+    Args:
+        path: API path (e.g., "/health")
+        params: Optional query parameters
+
+    Returns:
+        Parsed JSON response
+    """
+    url = f"{RAPTOR_URL.rstrip('/')}{path}"
+
+    try:
+        with httpx.Client(timeout=30.0) as client:
+            response = client.get(url, params=params)
+            response.raise_for_status()
+            return response.json()
+    except httpx.ConnectError:
+        raise RuntimeError(
+            f"Cannot connect to RAPTOR service at {RAPTOR_URL}.\n"
+            "Ensure the service is running and RAPTOR_URL is set correctly."
+        )

--- a/sre-agent/.claude/skills/knowledge-raptor/scripts/search.py
+++ b/sre-agent/.claude/skills/knowledge-raptor/scripts/search.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Search the RAPTOR knowledge base for relevant information.
+
+Usage:
+    python search.py --query SEARCH_QUERY [--tree TREE] [--top-k N]
+
+Examples:
+    python search.py --query "how to debug OOMKilled pods"
+    python search.py --query "database connection pool" --top-k 10
+"""
+
+import argparse
+import json
+import sys
+
+from raptor_client import raptor_post
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search the RAPTOR knowledge base")
+    parser.add_argument(
+        "--query",
+        required=True,
+        help="Natural language search query",
+    )
+    parser.add_argument(
+        "--tree",
+        help="Knowledge tree to search (default: server default)",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=5,
+        help="Number of results to return (default: 5)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    try:
+        payload = {
+            "query": args.query,
+            "top_k": args.top_k,
+            "include_summaries": True,
+        }
+        if args.tree:
+            payload["tree"] = args.tree
+
+        data = raptor_post("/api/v1/search", payload)
+
+        results = data.get("results", [])
+
+        if args.json:
+            print(json.dumps(data, indent=2))
+        else:
+            print(f"\nFound {len(results)} result(s) for: {args.query}\n")
+
+            for i, result in enumerate(results, 1):
+                score = result.get("score", 0)
+                text = result.get("text", "")
+                layer = result.get("layer", 0)
+                is_summary = result.get("is_summary", False)
+
+                label = " [summary]" if is_summary else ""
+                print(f"{i}. [{score:.2f}] (layer {layer}){label}")
+                # Show first 300 chars, preserve readability
+                preview = text[:300].replace("\n", " ")
+                if len(text) > 300:
+                    preview += "..."
+                print(f"   {preview}")
+                print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/knowledge-raptor/scripts/search_incident.py
+++ b/sre-agent/.claude/skills/knowledge-raptor/scripts/search_incident.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Incident-aware search: find runbooks and past incidents matching symptoms.
+
+Usage:
+    python search_incident.py --symptoms DESCRIPTION [--service SERVICE] [--top-k N]
+
+Examples:
+    python search_incident.py --symptoms "pods keep crashing with OOMKilled"
+    python search_incident.py --symptoms "503 errors" --service payment-gateway
+"""
+
+import argparse
+import json
+import sys
+
+from raptor_client import raptor_post
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Find runbooks and past incidents matching symptoms"
+    )
+    parser.add_argument(
+        "--symptoms",
+        required=True,
+        help="Description of the symptoms/issue",
+    )
+    parser.add_argument(
+        "--service",
+        default="",
+        help="Affected service name (optional but recommended)",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=5,
+        help="Number of results per category (default: 5)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    try:
+        payload = {
+            "symptoms": args.symptoms,
+            "affected_service": args.service,
+            "include_runbooks": True,
+            "include_past_incidents": True,
+            "top_k": args.top_k,
+        }
+
+        data = raptor_post("/api/v1/incident-search", payload)
+
+        if args.json:
+            print(json.dumps(data, indent=2))
+        else:
+            service_label = f" (service: {args.service})" if args.service else ""
+            print(f"\nIncident search for: {args.symptoms}{service_label}\n")
+
+            # Runbooks
+            runbooks = data.get("runbooks", [])
+            if runbooks:
+                print(f"--- Runbooks ({len(runbooks)}) ---\n")
+                for i, rb in enumerate(runbooks, 1):
+                    title = rb.get("title", "Untitled")
+                    relevance = rb.get("relevance", 0)
+                    text = rb.get("text", "")
+                    print(f"{i}. [{relevance:.2f}] {title}")
+                    preview = text[:200].replace("\n", " ")
+                    if len(text) > 200:
+                        preview += "..."
+                    print(f"   {preview}")
+                    print()
+
+            # Past incidents
+            incidents = data.get("past_incidents", [])
+            if incidents:
+                print(f"--- Past Incidents ({len(incidents)}) ---\n")
+                for i, inc in enumerate(incidents, 1):
+                    inc_id = inc.get("incident_id", "unknown")
+                    relevance = inc.get("relevance", 0)
+                    summary = inc.get("summary", "")
+                    resolution = inc.get("resolution", "")
+                    print(f"{i}. [{relevance:.2f}] {inc_id}")
+                    if summary:
+                        preview = summary[:200].replace("\n", " ")
+                        print(f"   Summary: {preview}")
+                    if resolution:
+                        preview = resolution[:200].replace("\n", " ")
+                        print(f"   Resolution: {preview}")
+                    print()
+
+            # Service context
+            context = data.get("service_context", [])
+            if context:
+                print(f"--- Service Context ({len(context)}) ---\n")
+                for i, ctx in enumerate(context, 1):
+                    text = ctx.get("text", "")
+                    relevance = ctx.get("relevance", 0)
+                    print(f"{i}. [{relevance:.2f}]")
+                    preview = text[:200].replace("\n", " ")
+                    if len(text) > 200:
+                        preview += "..."
+                    print(f"   {preview}")
+                    print()
+
+            if not runbooks and not incidents and not context:
+                print("No matching runbooks or past incidents found.")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/knowledge-raptor/scripts/teach.py
+++ b/sre-agent/.claude/skills/knowledge-raptor/scripts/teach.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Teach the knowledge base something new learned during an investigation.
+
+The system automatically detects duplicates and contradictions.
+
+Usage:
+    python teach.py --content KNOWLEDGE [--type TYPE] [--entities E1,E2] [--confidence N]
+
+Examples:
+    python teach.py --content "When payment-gateway shows OOMKilled, check Redis connection pool first"
+    python teach.py --content "auth-service falls back to DB sessions when Redis is down (+200ms)" \
+        --type factual --entities auth-service,redis-cache --confidence 0.9
+"""
+
+import argparse
+import json
+import sys
+
+from raptor_client import raptor_post
+
+KNOWLEDGE_TYPES = [
+    "procedural",
+    "factual",
+    "temporal",
+    "relational",
+    "contextual",
+    "policy",
+    "social",
+    "meta",
+]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Teach the knowledge base new knowledge"
+    )
+    parser.add_argument(
+        "--content",
+        required=True,
+        help="Knowledge to teach (minimum 20 characters)",
+    )
+    parser.add_argument(
+        "--type",
+        default="procedural",
+        choices=KNOWLEDGE_TYPES,
+        help="Knowledge type (default: procedural)",
+    )
+    parser.add_argument(
+        "--entities",
+        default="",
+        help="Comma-separated related entities (e.g., payment-gateway,redis-cache)",
+    )
+    parser.add_argument(
+        "--confidence",
+        type=float,
+        default=0.7,
+        help="Confidence score 0-1 (default: 0.7)",
+    )
+    parser.add_argument(
+        "--source",
+        default="agent_investigation",
+        help="Source of the knowledge (default: agent_investigation)",
+    )
+    parser.add_argument(
+        "--context",
+        default="",
+        help="Task context (e.g., incident ID, investigation thread)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    if len(args.content) < 20:
+        print("Error: Content must be at least 20 characters.", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        entities = [e.strip() for e in args.entities.split(",") if e.strip()]
+
+        payload = {
+            "content": args.content,
+            "knowledge_type": args.type,
+            "source": args.source,
+            "confidence": args.confidence,
+            "related_entities": entities,
+            "learned_from": args.source,
+            "task_context": args.context,
+        }
+
+        data = raptor_post("/api/v1/teach", payload)
+
+        if args.json:
+            print(json.dumps(data, indent=2))
+        else:
+            status = data.get("status", "unknown")
+            node_id = data.get("node_id")
+            message = data.get("message", "")
+
+            status_icons = {
+                "created": "Created",
+                "merged": "Merged with existing",
+                "duplicate": "Duplicate detected",
+                "pending_review": "Pending review",
+                "contradiction": "Contradiction detected",
+            }
+
+            label = status_icons.get(status, status)
+            print(f"\nTeach result: {label}")
+            if node_id:
+                print(f"Node ID: {node_id}")
+            if message:
+                print(f"Message: {message}")
+            print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/metrics-analysis/SKILL.md
+++ b/sre-agent/.claude/skills/metrics-analysis/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: metrics-analysis
+description: Prometheus/Grafana metrics analysis and PromQL queries. Use when investigating latency, error rates, resource usage, or any time-series metrics.
+allowed-tools: Bash(python *)
+---
+
+# Metrics Analysis
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `GRAFANA_API_KEY` or `PROMETHEUS_URL` in environment variables - they won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+---
+
+## Core Principle: USE & RED Methods
+
+**USE Method** (for infrastructure):
+- **U**tilization - How busy is the resource?
+- **S**aturation - How much work is queued?
+- **E**rrors - Are there error events?
+
+**RED Method** (for services):
+- **R**ate - Requests per second
+- **E**rrors - Error rate
+- **D**uration - Latency distribution
+
+## Available Scripts
+
+All scripts are in `.claude/skills/metrics-analysis/scripts/`
+
+### query_prometheus.py - Execute PromQL Queries
+```bash
+python .claude/skills/metrics-analysis/scripts/query_prometheus.py --query PROMQL [--time-range MINUTES] [--step STEP]
+
+# Examples:
+python .claude/skills/metrics-analysis/scripts/query_prometheus.py --query "up"
+python .claude/skills/metrics-analysis/scripts/query_prometheus.py --query "rate(http_requests_total[5m])" --time-range 60
+python .claude/skills/metrics-analysis/scripts/query_prometheus.py --query "histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))"
+```
+
+### list_dashboards.py - Find Grafana Dashboards
+```bash
+python .claude/skills/metrics-analysis/scripts/list_dashboards.py [--query SEARCH_TERM]
+
+# Examples:
+python .claude/skills/metrics-analysis/scripts/list_dashboards.py
+python .claude/skills/metrics-analysis/scripts/list_dashboards.py --query "api"
+```
+
+### get_alerts.py - Check Firing Alerts
+```bash
+python .claude/skills/metrics-analysis/scripts/get_alerts.py [--state STATE]
+
+# Examples:
+python .claude/skills/metrics-analysis/scripts/get_alerts.py
+python .claude/skills/metrics-analysis/scripts/get_alerts.py --state alerting
+```
+
+---
+
+## PromQL Quick Reference
+
+### Basic Queries
+
+```promql
+# Instant vector - current value
+http_requests_total{service="api"}
+
+# Range vector - values over time (for rate calculations)
+http_requests_total{service="api"}[5m]
+
+# Rate of increase per second
+rate(http_requests_total{service="api"}[5m])
+```
+
+### Common Operators
+
+```promql
+# Rate (counter → gauge, per second)
+rate(http_requests_total[5m])
+
+# Increase (total increase over time range)
+increase(http_requests_total[1h])
+
+# Average over time
+avg_over_time(cpu_usage[5m])
+
+# Histogram quantile (p95, p99)
+histogram_quantile(0.95, rate(http_request_duration_bucket[5m]))
+```
+
+### Aggregations
+
+```promql
+# Sum across all instances
+sum(rate(http_requests_total[5m]))
+
+# Group by label
+sum by (service) (rate(http_requests_total[5m]))
+
+# Average by label
+avg by (instance) (cpu_usage)
+
+# Top 5 by value
+topk(5, sum by (service) (rate(http_requests_total[5m])))
+```
+
+### Label Matching
+
+```promql
+# Exact match
+http_requests_total{status="500"}
+
+# Regex match
+http_requests_total{status=~"5.."}
+
+# Not equal
+http_requests_total{status!="200"}
+
+# Multiple labels
+http_requests_total{service="api", status=~"5.."}
+```
+
+---
+
+## Investigation Workflows
+
+### 1. Latency Investigation
+
+```bash
+# Step 1: Check overall latency trend
+python query_prometheus.py --query 'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{service="api"}[5m]))' --time-range 60
+
+# Step 2: Compare p50 vs p99
+python query_prometheus.py --query 'histogram_quantile(0.50, rate(http_request_duration_seconds_bucket{service="api"}[5m]))'
+
+# Step 3: Break down by endpoint
+python query_prometheus.py --query 'histogram_quantile(0.95, sum by (endpoint) (rate(http_request_duration_seconds_bucket{service="api"}[5m])))'
+```
+
+### 2. Error Rate Investigation
+
+```bash
+# Step 1: Overall error rate
+python query_prometheus.py --query 'sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total[5m]))'
+
+# Step 2: Errors by status code
+python query_prometheus.py --query 'sum by (status) (rate(http_requests_total{status=~"[45].."}[5m]))'
+
+# Step 3: Errors by service
+python query_prometheus.py --query 'sum by (service) (rate(http_requests_total{status=~"5.."}[5m]))'
+```
+
+### 3. Resource Investigation (CPU/Memory)
+
+```bash
+# CPU usage
+python query_prometheus.py --query 'avg by (instance) (rate(container_cpu_usage_seconds_total{pod=~"api-.*"}[5m]))'
+
+# Memory usage percentage
+python query_prometheus.py --query 'container_memory_usage_bytes{pod=~"api-.*"} / container_spec_memory_limit_bytes{pod=~"api-.*"}'
+```
+
+---
+
+## Quick Commands Reference
+
+| Goal | Command |
+|------|---------|
+| Request rate | `query_prometheus.py --query "sum(rate(http_requests_total[5m]))"` |
+| Error rate | `query_prometheus.py --query "sum(rate(http_requests_total{status=~'5..'}[5m]))"` |
+| P95 latency | `query_prometheus.py --query "histogram_quantile(0.95, ...)"` |
+| CPU usage | `query_prometheus.py --query "rate(container_cpu_usage_seconds_total[5m])"` |
+| Find dashboards | `list_dashboards.py --query "api"` |
+| Check alerts | `get_alerts.py --state alerting` |
+
+---
+
+## Common Metric Patterns
+
+### Request Metrics
+```promql
+http_requests_total                    # Counter
+http_request_duration_seconds_bucket   # Histogram
+http_requests_in_flight               # Gauge
+```
+
+### Kubernetes Metrics
+```promql
+container_cpu_usage_seconds_total
+container_memory_usage_bytes
+kube_pod_container_status_restarts_total
+kube_pod_status_phase
+```
+
+---
+
+## Anti-Patterns to Avoid
+
+1. ❌ **Using `rate()` without range vector** - Always include `[5m]` or similar
+2. ❌ **Comparing counters directly** - Use `rate()` or `increase()` first
+3. ❌ **Wrong quantile math** - `histogram_quantile` requires `_bucket` metrics
+4. ❌ **Missing label filters** - Queries without filters return all series
+5. ❌ **Too-short time ranges** - Use at least 2x your scrape interval for `rate()`

--- a/sre-agent/.claude/skills/metrics-analysis/scripts/__init__.py
+++ b/sre-agent/.claude/skills/metrics-analysis/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Prometheus/Grafana metrics analysis scripts

--- a/sre-agent/.claude/skills/metrics-analysis/scripts/get_alerts.py
+++ b/sre-agent/.claude/skills/metrics-analysis/scripts/get_alerts.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Get Grafana alerts and their current state.
+
+Usage:
+    python get_alerts.py [--state STATE]
+
+Examples:
+    python get_alerts.py
+    python get_alerts.py --state alerting
+    python get_alerts.py --state pending
+"""
+
+import argparse
+import json
+import sys
+
+from grafana_client import get_alerts
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Grafana alerts")
+    parser.add_argument(
+        "--state",
+        choices=["alerting", "pending", "ok", "paused", "no_data"],
+        help="Filter by alert state",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    try:
+        alerts = get_alerts(state=args.state)
+
+        if args.json:
+            print(json.dumps(alerts, indent=2))
+        else:
+            print("=" * 60)
+            print("GRAFANA ALERTS")
+            if args.state:
+                print(f"Filter: state={args.state}")
+            print("=" * 60)
+            print(f"Found: {len(alerts)} alerts")
+            print()
+
+            # Group by state
+            by_state = {}
+            for alert in alerts:
+                state = alert.get("state", "unknown")
+                if state not in by_state:
+                    by_state[state] = []
+                by_state[state].append(alert)
+
+            for state, state_alerts in sorted(by_state.items()):
+                state_icon = {
+                    "alerting": "🔴",
+                    "pending": "🟡",
+                    "ok": "🟢",
+                    "paused": "⏸️",
+                    "no_data": "⚪",
+                }.get(state, "❓")
+
+                print(f"{state_icon} {state.upper()} ({len(state_alerts)})")
+                print("-" * 40)
+                for alert in state_alerts:
+                    name = alert.get("name", "Unnamed")
+                    dashboard = alert.get("dashboardSlug", "")
+                    panel = alert.get("panelId", "")
+                    print(f"  • {name}")
+                    if dashboard:
+                        print(f"    Dashboard: {dashboard}, Panel: {panel}")
+                print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/metrics-analysis/scripts/grafana_client.py
+++ b/sre-agent/.claude/skills/metrics-analysis/scripts/grafana_client.py
@@ -1,0 +1,381 @@
+"""Shared Grafana/Prometheus API client with credential proxy support.
+
+This client is designed to work with the OpenSRE credential proxy.
+Credentials are injected automatically - scripts should NOT check for
+GRAFANA_API_KEY in environment variables.
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+def get_config() -> dict[str, Any]:
+    """Load configuration from standard locations."""
+    config = {}
+
+    # Check for config file
+    config_paths = [
+        Path.home() / ".opensre" / "config.json",
+        Path("/etc/opensre/config.json"),
+    ]
+
+    for path in config_paths:
+        if path.exists():
+            with open(path) as f:
+                config = json.load(f)
+                break
+
+    # Environment overrides
+    if os.getenv("TENANT_ID"):
+        config["tenant_id"] = os.getenv("TENANT_ID")
+    if os.getenv("TEAM_ID"):
+        config["team_id"] = os.getenv("TEAM_ID")
+
+    return config
+
+
+def get_grafana_url(endpoint: str) -> str:
+    """Get the Grafana API URL for an endpoint.
+
+    In production, this routes through the credential proxy.
+    """
+    base_url = os.getenv("GRAFANA_BASE_URL") or os.getenv("GRAFANA_URL")
+    if not base_url:
+        raise RuntimeError(
+            "GRAFANA_BASE_URL or GRAFANA_URL not set. "
+            "Agent must run through credential proxy."
+        )
+
+    return f"{base_url.rstrip('/')}{endpoint}"
+
+
+def get_prometheus_url(endpoint: str) -> str:
+    """Get the Prometheus API URL for an endpoint.
+
+    In production, this routes through the credential proxy.
+    """
+    base_url = os.getenv("PROMETHEUS_BASE_URL") or os.getenv("PROMETHEUS_URL")
+    if not base_url:
+        raise RuntimeError(
+            "PROMETHEUS_BASE_URL or PROMETHEUS_URL not set. "
+            "Agent must run through credential proxy."
+        )
+
+    return f"{base_url.rstrip('/')}{endpoint}"
+
+
+def get_grafana_headers() -> dict[str, str]:
+    """Get headers for Grafana API requests.
+
+    Supports multiple auth methods:
+    1. Service Account token (Bearer) - GRAFANA_API_KEY or GRAFANA_TOKEN
+    2. Basic auth - GRAFANA_API_KEY="user:pass" or GRAFANA_USER + GRAFANA_PASSWORD
+    3. Proxy mode - tenant context headers
+
+    Environment variables:
+        GRAFANA_API_KEY: Service account token (glsa_xxx) or "user:pass"
+        GRAFANA_TOKEN: Service account token (alternative)
+        GRAFANA_USER + GRAFANA_PASSWORD: Basic auth credentials
+    """
+    config = get_config()
+    import base64
+
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    # Priority 1: API key / Service Account token
+    api_key = os.getenv("GRAFANA_API_KEY") or os.getenv("GRAFANA_TOKEN")
+    if api_key:
+        if ":" in api_key:
+            # Basic auth format (user:pass)
+            encoded = base64.b64encode(api_key.encode()).decode()
+            headers["Authorization"] = f"Basic {encoded}"
+        else:
+            # Bearer token (service account)
+            headers["Authorization"] = f"Bearer {api_key}"
+        return headers
+
+    # Priority 2: Explicit user/password
+    user = os.getenv("GRAFANA_USER")
+    password = os.getenv("GRAFANA_PASSWORD")
+    if user and password:
+        encoded = base64.b64encode(f"{user}:{password}".encode()).decode()
+        headers["Authorization"] = f"Basic {encoded}"
+        return headers
+
+    # Priority 3: Proxy mode - add JWT for authentication with credential-resolver
+    # The JWT contains tenant/team context and is validated by credential-resolver
+    sandbox_jwt = os.getenv("SANDBOX_JWT")
+    if sandbox_jwt:
+        headers["X-Sandbox-JWT"] = sandbox_jwt
+    else:
+        # Fallback to tenant headers (for local dev without JWT)
+        headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+        headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    return headers
+
+
+def get_prometheus_headers() -> dict[str, str]:
+    """Get headers for Prometheus API requests.
+
+    Supports multiple auth methods:
+    1. Bearer token - PROMETHEUS_TOKEN
+    2. Basic auth - PROMETHEUS_USER + PROMETHEUS_PASSWORD
+    3. Falls back to Grafana auth (for Grafana datasource proxy)
+
+    Environment variables:
+        PROMETHEUS_TOKEN: Bearer token
+        PROMETHEUS_USER + PROMETHEUS_PASSWORD: Basic auth
+    """
+    import base64
+
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    # Priority 1: Bearer token
+    token = os.getenv("PROMETHEUS_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+        return headers
+
+    # Priority 2: Basic auth
+    user = os.getenv("PROMETHEUS_USER")
+    password = os.getenv("PROMETHEUS_PASSWORD")
+    if user and password:
+        encoded = base64.b64encode(f"{user}:{password}".encode()).decode()
+        headers["Authorization"] = f"Basic {encoded}"
+        return headers
+
+    # Priority 3: Fall back to Grafana auth (for datasource proxy pattern)
+    return get_grafana_headers()
+
+
+def get_headers() -> dict[str, str]:
+    """Get headers for API requests (backward compatible).
+
+    Uses Grafana headers by default.
+    """
+    return get_grafana_headers()
+
+
+def query_prometheus(
+    query: str,
+    time_seconds: int | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """Execute an instant PromQL query.
+
+    Args:
+        query: PromQL query string
+        time_seconds: Evaluation timestamp (Unix seconds), default now
+        timeout: Query timeout in seconds
+
+    Returns:
+        Prometheus query result
+    """
+    url = get_prometheus_url("/api/v1/query")
+
+    params = {"query": query, "timeout": f"{timeout}s"}
+    if time_seconds:
+        params["time"] = str(time_seconds)
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.get(url, headers=get_prometheus_headers(), params=params)
+
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"Prometheus API error {response.status_code}: {response.text}"
+            )
+
+        return response.json()
+
+
+def query_prometheus_range(
+    query: str,
+    start_seconds: int,
+    end_seconds: int,
+    step: str = "1m",
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """Execute a range PromQL query.
+
+    Args:
+        query: PromQL query string
+        start_seconds: Start timestamp (Unix seconds)
+        end_seconds: End timestamp (Unix seconds)
+        step: Query step (e.g., "1m", "5m", "1h")
+        timeout: Query timeout in seconds
+
+    Returns:
+        Prometheus query result with time series
+    """
+    url = get_prometheus_url("/api/v1/query_range")
+
+    params = {
+        "query": query,
+        "start": str(start_seconds),
+        "end": str(end_seconds),
+        "step": step,
+        "timeout": f"{timeout}s",
+    }
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.get(url, headers=get_prometheus_headers(), params=params)
+
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"Prometheus API error {response.status_code}: {response.text}"
+            )
+
+        return response.json()
+
+
+def list_dashboards(query: str | None = None) -> list[dict[str, Any]]:
+    """List Grafana dashboards.
+
+    Args:
+        query: Optional search query
+
+    Returns:
+        List of dashboard objects
+    """
+    url = get_grafana_url("/api/search")
+
+    params = {"type": "dash-db"}
+    if query:
+        params["query"] = query
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.get(url, headers=get_headers(), params=params)
+
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"Grafana API error {response.status_code}: {response.text}"
+            )
+
+        return response.json()
+
+
+def get_dashboard(uid: str) -> dict[str, Any]:
+    """Get a Grafana dashboard by UID.
+
+    Args:
+        uid: Dashboard UID
+
+    Returns:
+        Dashboard object with panels
+    """
+    url = get_grafana_url(f"/api/dashboards/uid/{uid}")
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.get(url, headers=get_headers())
+
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"Grafana API error {response.status_code}: {response.text}"
+            )
+
+        return response.json()
+
+
+def get_alerts(state: str | None = None) -> list[dict[str, Any]]:
+    """Get Grafana alerts.
+
+    Args:
+        state: Filter by state (alerting, pending, ok, etc.)
+
+    Returns:
+        List of alert objects
+    """
+    url = get_grafana_url("/api/alerts")
+
+    params = {}
+    if state:
+        params["state"] = state
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.get(url, headers=get_headers(), params=params)
+
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"Grafana API error {response.status_code}: {response.text}"
+            )
+
+        return response.json()
+
+
+def get_annotations(
+    from_seconds: int | None = None,
+    to_seconds: int | None = None,
+    tags: list[str] | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Get Grafana annotations (deployment markers, etc.).
+
+    Args:
+        from_seconds: Start timestamp (Unix milliseconds)
+        to_seconds: End timestamp (Unix milliseconds)
+        tags: Filter by tags
+        limit: Maximum results
+
+    Returns:
+        List of annotation objects
+    """
+    url = get_grafana_url("/api/annotations")
+
+    params = {"limit": limit}
+    if from_seconds:
+        params["from"] = str(from_seconds * 1000)  # Convert to milliseconds
+    if to_seconds:
+        params["to"] = str(to_seconds * 1000)
+    if tags:
+        params["tags"] = ",".join(tags)
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.get(url, headers=get_headers(), params=params)
+
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"Grafana API error {response.status_code}: {response.text}"
+            )
+
+        return response.json()
+
+
+def format_metric_result(result: dict[str, Any]) -> str:
+    """Format a Prometheus query result for display."""
+    status = result.get("status", "unknown")
+    data = result.get("data", {})
+    result_type = data.get("resultType", "unknown")
+    results = data.get("result", [])
+
+    output = f"Status: {status}\n"
+    output += f"Result type: {result_type}\n"
+    output += f"Series count: {len(results)}\n\n"
+
+    for r in results[:20]:  # Limit display
+        metric = r.get("metric", {})
+        labels = ", ".join(f"{k}={v}" for k, v in metric.items())
+
+        if result_type == "vector":
+            value = r.get("value", [None, None])
+            output += f"  {{{labels}}}: {value[1]}\n"
+        elif result_type == "matrix":
+            values = r.get("values", [])
+            output += f"  {{{labels}}}: {len(values)} samples\n"
+            if values:
+                output += f"    Latest: {values[-1][1]}\n"
+
+    if len(results) > 20:
+        output += f"\n  ... and {len(results) - 20} more series"
+
+    return output

--- a/sre-agent/.claude/skills/metrics-analysis/scripts/list_dashboards.py
+++ b/sre-agent/.claude/skills/metrics-analysis/scripts/list_dashboards.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""List Grafana dashboards.
+
+Usage:
+    python list_dashboards.py [--query SEARCH_TERM]
+
+Examples:
+    python list_dashboards.py
+    python list_dashboards.py --query "api"
+    python list_dashboards.py --query "kubernetes"
+"""
+
+import argparse
+import json
+import sys
+
+from grafana_client import list_dashboards
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Grafana dashboards")
+    parser.add_argument(
+        "--query",
+        help="Search query to filter dashboards",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    try:
+        dashboards = list_dashboards(query=args.query)
+
+        if args.json:
+            print(json.dumps(dashboards, indent=2))
+        else:
+            print("=" * 60)
+            print("GRAFANA DASHBOARDS")
+            if args.query:
+                print(f"Search: {args.query}")
+            print("=" * 60)
+            print(f"Found: {len(dashboards)} dashboards")
+            print()
+
+            if not dashboards:
+                print("No dashboards found.")
+            else:
+                for d in dashboards:
+                    uid = d.get("uid", "")
+                    title = d.get("title", "Untitled")
+                    folder = d.get("folderTitle", "General")
+                    url = d.get("url", "")
+                    print(f"  [{uid}] {title}")
+                    print(f"      Folder: {folder}")
+                    print(f"      URL: {url}")
+                    print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/metrics-analysis/scripts/query_prometheus.py
+++ b/sre-agent/.claude/skills/metrics-analysis/scripts/query_prometheus.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Execute PromQL queries against Prometheus.
+
+Usage:
+    python query_prometheus.py --query PROMQL [--time-range MINUTES] [--step STEP]
+
+Examples:
+    python query_prometheus.py --query "up"
+    python query_prometheus.py --query "rate(http_requests_total[5m])" --time-range 60
+    python query_prometheus.py --query "histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))"
+"""
+
+import argparse
+import json
+import sys
+import time
+
+from grafana_client import (
+    format_metric_result,
+    query_prometheus,
+    query_prometheus_range,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Execute PromQL queries against Prometheus"
+    )
+    parser.add_argument(
+        "--query",
+        required=True,
+        help="PromQL query string",
+    )
+    parser.add_argument(
+        "--time-range",
+        type=int,
+        help="Time range in minutes (enables range query)",
+    )
+    parser.add_argument(
+        "--step",
+        default="1m",
+        help="Query step for range queries (default: 1m)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    try:
+        now = int(time.time())
+
+        if args.time_range:
+            # Range query
+            start = now - (args.time_range * 60)
+            result = query_prometheus_range(
+                query=args.query,
+                start_seconds=start,
+                end_seconds=now,
+                step=args.step,
+            )
+        else:
+            # Instant query
+            result = query_prometheus(query=args.query)
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print("=" * 60)
+            print("PROMETHEUS QUERY RESULT")
+            print("=" * 60)
+            print(f"Query: {args.query}")
+            if args.time_range:
+                print(f"Time range: {args.time_range} minutes")
+                print(f"Step: {args.step}")
+            print()
+            print(format_metric_result(result))
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/metrics-victoriametrics/SKILL.md
+++ b/sre-agent/.claude/skills/metrics-victoriametrics/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: metrics-victoriametrics
+description: VictoriaMetrics metrics analysis using MetricsQL. Use when querying time-series metrics stored in VictoriaMetrics. Supports PromQL and MetricsQL extensions.
+allowed-tools: Bash(python *)
+---
+
+# VictoriaMetrics Metrics Analysis
+
+Query and analyze time-series metrics from VictoriaMetrics using MetricsQL (PromQL-compatible with extensions).
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `VICTORIAMETRICS_TOKEN` in environment variables - they won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+---
+
+## MANDATORY: Context-Efficient Investigation
+
+**NEVER dump all series or run unbounded range queries.** Always follow this pattern:
+
+```
+GET STATISTICS → INSTANT QUERY → RANGE QUERY (only if needed)
+```
+
+1. **Statistics First** — Know how many series exist, what metrics/jobs are active
+2. **Instant Query** — Get current values (single point, compact output)
+3. **Range Query** — Only when you need trend over time, and ALWAYS with `topk()` to cap output
+
+## Available Scripts
+
+All scripts are in `.claude/skills/metrics-victoriametrics/scripts/`
+
+### get_statistics.py — ALWAYS START HERE
+Discover what metrics exist and their cardinality.
+```bash
+python .claude/skills/metrics-victoriametrics/scripts/get_statistics.py --query '{job="api"}'
+python .claude/skills/metrics-victoriametrics/scripts/get_statistics.py --query '{namespace="production"}' --time-range 120
+python .claude/skills/metrics-victoriametrics/scripts/get_statistics.py --query '{}' --json
+```
+
+Output includes:
+- Active series count
+- Top 10 metric names by series count
+- Top 5 jobs
+- Compact summary (~20 lines)
+
+### query_metrics.py — Targeted Queries
+Execute MetricsQL queries with output limits.
+```bash
+# Instant query (default - single value per series, compact)
+python .claude/skills/metrics-victoriametrics/scripts/query_metrics.py --query 'up{job="api"}'
+python .claude/skills/metrics-victoriametrics/scripts/query_metrics.py --query 'rate(http_requests_total{service="payment"}[5m])'
+
+# Range query (use sparingly - shows latest value per series, not all datapoints)
+python .claude/skills/metrics-victoriametrics/scripts/query_metrics.py --query 'rate(http_requests_total[5m])' --type range --time-range 60
+
+# Limit output
+python .claude/skills/metrics-victoriametrics/scripts/query_metrics.py --query 'topk(5, rate(http_requests_total[5m]))' --limit 10 --json
+```
+
+### list_labels.py — Metadata Discovery
+Discover available labels and values.
+```bash
+python .claude/skills/metrics-victoriametrics/scripts/list_labels.py
+python .claude/skills/metrics-victoriametrics/scripts/list_labels.py --label job
+python .claude/skills/metrics-victoriametrics/scripts/list_labels.py --label namespace --match '{job="api"}' --json
+```
+
+---
+
+## MetricsQL Quick Reference
+
+MetricsQL is fully PromQL-compatible with additional extensions.
+
+### Basic Queries
+```metricsql
+# Instant vector
+http_requests_total{service="api"}
+
+# Rate of increase per second
+rate(http_requests_total{service="api"}[5m])
+
+# Histogram quantile
+histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))
+```
+
+### Aggregations
+```metricsql
+sum by (service) (rate(http_requests_total[5m]))
+avg by (instance) (cpu_usage)
+topk(5, sum by (service) (rate(http_requests_total[5m])))
+bottomk(3, avg_over_time(cpu_usage[1h]))
+```
+
+### MetricsQL Extensions (beyond PromQL)
+
+#### WITH Templates — Reusable Filters
+```metricsql
+WITH (
+  commonFilters = {job="api", env="prod"},
+  errorRate(m) = rate(m{status=~"5.."}[5m]) / rate(m[5m])
+)
+errorRate(http_requests_total{commonFilters})
+```
+
+#### Rollup Functions
+```metricsql
+rollup(metric[5m])              # Returns min, max, avg in one query
+rollup_rate(counter[5m])        # Rate with proper counter reset handling
+rollup_increase(counter[5m])    # Increase with counter reset handling
+```
+
+#### Label Manipulation
+```metricsql
+label_set(metric, "env", "prod")       # Set label value
+label_del(metric, "instance")          # Remove label
+label_copy(metric, "pod", "instance")  # Copy label
+label_move(metric, "old", "new")       # Rename label
+label_join(metric, "dst", ",", "a", "b")  # Join labels
+```
+
+#### Range & Time Functions
+```metricsql
+range_median(metric[1h])         # Median over range
+range_first(metric[1h])         # First value in range
+range_last(metric[1h])          # Last value in range
+running_avg(metric[1h])         # Running average
+```
+
+### Label Matching
+```metricsql
+{status="500"}           # Exact match
+{status=~"5.."}          # Regex match
+{status!="200"}          # Not equal
+{service="api", status=~"5.."}   # Multiple labels
+```
+
+---
+
+## Investigation Workflows
+
+### Error Rate Investigation
+```bash
+# Step 1: Get statistics
+python get_statistics.py --query '{job="api"}'
+
+# Step 2: Current error rate
+python query_metrics.py --query 'sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total[5m]))'
+
+# Step 3: Error rate by service (top 5 only)
+python query_metrics.py --query 'topk(5, sum by (service) (rate(http_requests_total{status=~"5.."}[5m])))'
+```
+
+### Latency Investigation
+```bash
+python query_metrics.py --query 'histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{service="api"}[5m])))'
+```
+
+### Resource Investigation
+```bash
+python query_metrics.py --query 'topk(5, rate(container_cpu_usage_seconds_total{namespace="prod"}[5m]))'
+python query_metrics.py --query 'topk(5, container_memory_usage_bytes{namespace="prod"} / container_spec_memory_limit_bytes{namespace="prod"})'
+```
+
+---
+
+## Anti-Patterns to Avoid
+
+1. **NEVER run unbounded `query_range`** — Always use `topk()` or filter by specific labels
+2. **NEVER skip `get_statistics.py`** — Know your cardinality before querying
+3. **NEVER use `rate()` without range vector** — Always include `[5m]` or similar
+4. **NEVER compare counters directly** — Use `rate()` or `increase()` first
+5. **Avoid short steps in range queries** — Use `step` >= 2x scrape interval

--- a/sre-agent/.claude/skills/metrics-victoriametrics/scripts/get_statistics.py
+++ b/sre-agent/.claude/skills/metrics-victoriametrics/scripts/get_statistics.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Get metric statistics from VictoriaMetrics — THE MANDATORY FIRST STEP.
+
+Uses server-side MetricsQL aggregation to return a compact summary of
+what metrics exist, their cardinality, and top metric names/jobs.
+Never dumps raw series data.
+
+Usage:
+    python get_statistics.py --query '{job="api"}'
+    python get_statistics.py --query '{namespace="production"}' --time-range 120
+
+Examples:
+    python get_statistics.py --query '{}'
+    python get_statistics.py --query '{job=~".*api.*"}' --json
+"""
+
+import argparse
+import json
+import sys
+
+from victoriametrics_client import query_instant
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Get metric statistics from VictoriaMetrics (ALWAYS call first)"
+    )
+    parser.add_argument(
+        "--query",
+        "-q",
+        default="{}",
+        help="MetricsQL series selector (default: {} = all)",
+    )
+    parser.add_argument(
+        "--time-range",
+        type=int,
+        default=60,
+        help="Time range in minutes (default: 60)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        selector = args.query
+
+        # 1. Count active series
+        count_result = query_instant(f"count({selector})")
+        series_count = 0
+        count_data = count_result.get("data", {}).get("result", [])
+        if count_data:
+            series_count = int(float(count_data[0].get("value", [0, "0"])[1]))
+
+        # 2. Top metric names by series count
+        top_metrics_result = query_instant(f"topk(10, count by (__name__)({selector}))")
+        top_metrics = []
+        for item in top_metrics_result.get("data", {}).get("result", []):
+            name = item.get("metric", {}).get("__name__", "unknown")
+            count = int(float(item.get("value", [0, "0"])[1]))
+            top_metrics.append({"name": name, "series_count": count})
+
+        # 3. Top jobs
+        top_jobs_result = query_instant(f"topk(5, count by (job)({selector}))")
+        top_jobs = []
+        for item in top_jobs_result.get("data", {}).get("result", []):
+            job = item.get("metric", {}).get("job", "unknown")
+            count = int(float(item.get("value", [0, "0"])[1]))
+            top_jobs.append({"job": job, "series_count": count})
+
+        result = {
+            "selector": selector,
+            "active_series": series_count,
+            "top_metrics": top_metrics,
+            "top_jobs": top_jobs,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print("=" * 50)
+            print("VICTORIAMETRICS STATISTICS")
+            print("=" * 50)
+            print(f"Selector: {selector}")
+            print(f"Active series: {series_count:,}")
+            print()
+
+            if top_metrics:
+                print("Top Metric Names (by series count):")
+                for m in top_metrics:
+                    print(f"  {m['name']}: {m['series_count']:,}")
+                print()
+
+            if top_jobs:
+                print("Top Jobs:")
+                for j in top_jobs:
+                    print(f"  {j['job']}: {j['series_count']:,}")
+                print()
+
+            if series_count == 0:
+                print("No active series found for this selector.")
+            elif series_count > 10000:
+                print(
+                    f"High cardinality ({series_count:,} series). "
+                    "Use specific label filters to narrow down."
+                )
+            else:
+                print(f"Cardinality OK ({series_count:,} series).")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/metrics-victoriametrics/scripts/list_labels.py
+++ b/sre-agent/.claude/skills/metrics-victoriametrics/scripts/list_labels.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Discover available labels and values in VictoriaMetrics.
+
+Lightweight metadata query — returns compact lists, not raw series data.
+
+Usage:
+    python list_labels.py                           # List all label names
+    python list_labels.py --label job               # List values for 'job'
+    python list_labels.py --label namespace --match '{job="api"}'  # Scoped values
+
+Examples:
+    python list_labels.py
+    python list_labels.py --label service --limit 20 --json
+"""
+
+import argparse
+import json
+import sys
+
+from victoriametrics_client import get_label_values, get_labels
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Discover labels and values in VictoriaMetrics"
+    )
+    parser.add_argument(
+        "--label", help="Get values for this specific label (omit to list all labels)"
+    )
+    parser.add_argument(
+        "--match", help="Series selector to scope results (e.g., '{job=\"api\"}')"
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Max values to display (default: 50)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        if args.label:
+            # Get values for a specific label
+            values = get_label_values(args.label, match=args.match)
+            total = len(values)
+            values = values[: args.limit]
+
+            if args.json:
+                output = {
+                    "label": args.label,
+                    "values": values,
+                    "count": len(values),
+                    "total": total,
+                }
+                if args.match:
+                    output["match"] = args.match
+                print(json.dumps(output, indent=2))
+            else:
+                scope = f" (scoped to {args.match})" if args.match else ""
+                print(f"Values for label '{args.label}'{scope}:")
+                print(f"  Total: {total}")
+                print()
+                for v in values:
+                    print(f"  {v}")
+                if total > args.limit:
+                    print(f"\n  ... showing {args.limit} of {total} values")
+        else:
+            # List all label names
+            labels = get_labels()
+
+            if args.json:
+                print(json.dumps({"labels": labels, "count": len(labels)}, indent=2))
+            else:
+                print(f"Available labels ({len(labels)}):")
+                print()
+                for label in labels:
+                    print(f"  {label}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/metrics-victoriametrics/scripts/query_metrics.py
+++ b/sre-agent/.claude/skills/metrics-victoriametrics/scripts/query_metrics.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Execute MetricsQL queries against VictoriaMetrics.
+
+Context-efficient: defaults to instant queries (single value per series),
+caps output to --limit series, and shows only latest values for range queries.
+
+Usage:
+    python query_metrics.py --query METRICSQL [--type instant|range] [--limit N]
+
+Examples:
+    python query_metrics.py --query 'up{job="api"}'
+    python query_metrics.py --query 'topk(5, rate(http_requests_total[5m]))' --type range
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+from victoriametrics_client import (
+    format_metric_result,
+    query_instant,
+    query_range,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Execute MetricsQL queries against VictoriaMetrics"
+    )
+    parser.add_argument("--query", "-q", required=True, help="MetricsQL/PromQL query")
+    parser.add_argument(
+        "--type",
+        choices=["instant", "range"],
+        default="instant",
+        help="Query type (default: instant — compact single-value output)",
+    )
+    parser.add_argument(
+        "--time-range",
+        type=int,
+        default=60,
+        help="Time range in minutes for range queries (default: 60)",
+    )
+    parser.add_argument(
+        "--step", default="5m", help="Step for range queries (default: 5m)"
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Max series to display (default: 20)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        if args.type == "instant":
+            result = query_instant(args.query)
+        else:
+            now = datetime.now(timezone.utc)
+            start = now - timedelta(minutes=args.time_range)
+            result = query_range(args.query, start=start, end=now, step=args.step)
+
+        data = result.get("data", {})
+        results = data.get("result", [])
+
+        if args.json:
+            # For JSON, include all results but still cap
+            output = {
+                "query": args.query,
+                "type": args.type,
+                "result_count": len(results),
+                "results": results[: args.limit],
+            }
+            if len(results) > args.limit:
+                output["truncated"] = True
+                output["total_series"] = len(results)
+            print(json.dumps(output, indent=2))
+        else:
+            print(f"Query: {args.query}")
+            print(f"Type: {args.type}")
+            print(f"Results: {len(results)} series")
+            print()
+
+            if not results:
+                print("No results found.")
+            else:
+                print(format_metric_result(result, max_series=args.limit))
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/metrics-victoriametrics/scripts/victoriametrics_client.py
+++ b/sre-agent/.claude/skills/metrics-victoriametrics/scripts/victoriametrics_client.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Shared VictoriaMetrics client with proxy support.
+
+This module provides the VictoriaMetrics client that works through the credential proxy.
+Credentials are injected transparently by the proxy layer.
+
+VictoriaMetrics is Prometheus-compatible and supports MetricsQL extensions.
+"""
+
+import base64
+import os
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import httpx
+
+
+def get_config() -> dict[str, str | None]:
+    """Get VictoriaMetrics configuration from environment.
+
+    Credentials are injected by the credential-proxy based on tenant context.
+    """
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+    }
+
+
+def get_api_url(endpoint: str) -> str:
+    """Build the VictoriaMetrics API URL.
+
+    Supports two modes:
+    1. Proxy mode (production): Uses VICTORIAMETRICS_BASE_URL
+    2. Direct mode (testing): Uses VICTORIAMETRICS_URL
+    """
+    # Proxy mode (production)
+    base_url = os.getenv("VICTORIAMETRICS_BASE_URL")
+    if base_url:
+        return f"{base_url.rstrip('/')}{endpoint}"
+
+    # Direct mode (testing)
+    direct_url = os.getenv("VICTORIAMETRICS_URL")
+    if direct_url:
+        return f"{direct_url.rstrip('/')}{endpoint}"
+
+    raise RuntimeError(
+        "Either VICTORIAMETRICS_BASE_URL (proxy mode) or VICTORIAMETRICS_URL (direct mode) must be set."
+    )
+
+
+def get_headers() -> dict[str, str]:
+    """Get VictoriaMetrics API headers.
+
+    Supports multiple auth methods:
+    1. Bearer token - VICTORIAMETRICS_TOKEN
+    2. Basic auth - VICTORIAMETRICS_USER + VICTORIAMETRICS_PASSWORD
+    3. Proxy mode - JWT for credential-resolver auth
+    """
+    config = get_config()
+
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    # Priority 1: Bearer token
+    token = os.getenv("VICTORIAMETRICS_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+        return headers
+
+    # Priority 2: Basic auth
+    user = os.getenv("VICTORIAMETRICS_USER")
+    password = os.getenv("VICTORIAMETRICS_PASSWORD")
+    if user and password:
+        encoded = base64.b64encode(f"{user}:{password}".encode()).decode()
+        headers["Authorization"] = f"Basic {encoded}"
+        return headers
+
+    # Priority 3: Proxy mode - use JWT for credential-resolver auth
+    if os.getenv("VICTORIAMETRICS_BASE_URL"):
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            # Fallback for local dev
+            headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+            headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    return headers
+
+
+def query_instant(query: str, time: datetime | None = None) -> dict:
+    """Execute an instant MetricsQL query.
+
+    Args:
+        query: MetricsQL/PromQL query string
+        time: Evaluation time (default: now)
+
+    Returns:
+        Query response with vector data
+    """
+    params = {"query": query}
+
+    if time is not None:
+        params["time"] = str(int(time.timestamp()))
+
+    url = get_api_url(f"/api/v1/query?{urlencode(params)}")
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+        return response.json()
+
+
+def query_range(
+    query: str,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    step: str = "5m",
+) -> dict:
+    """Execute a range MetricsQL query.
+
+    Args:
+        query: MetricsQL/PromQL query string
+        start: Start time (default: 1 hour ago)
+        end: End time (default: now)
+        step: Query resolution step (default: 5m)
+
+    Returns:
+        Query response with matrix data
+    """
+    now = datetime.now(timezone.utc)
+    if end is None:
+        end = now
+    if start is None:
+        start = now - timedelta(hours=1)
+
+    params = {
+        "query": query,
+        "start": str(int(start.timestamp())),
+        "end": str(int(end.timestamp())),
+        "step": step,
+    }
+
+    url = get_api_url(f"/api/v1/query_range?{urlencode(params)}")
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+        return response.json()
+
+
+def get_labels(start: datetime | None = None, end: datetime | None = None) -> list[str]:
+    """Get all label names.
+
+    Args:
+        start: Start time (default: 6 hours ago)
+        end: End time (default: now)
+
+    Returns:
+        List of label names
+    """
+    now = datetime.now(timezone.utc)
+    if end is None:
+        end = now
+    if start is None:
+        start = now - timedelta(hours=6)
+
+    params = {
+        "start": str(int(start.timestamp())),
+        "end": str(int(end.timestamp())),
+    }
+
+    url = get_api_url(f"/api/v1/labels?{urlencode(params)}")
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+        data = response.json()
+        return data.get("data", [])
+
+
+def get_label_values(
+    label: str,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    match: str | None = None,
+) -> list[str]:
+    """Get values for a specific label.
+
+    Args:
+        label: Label name
+        start: Start time (default: 6 hours ago)
+        end: End time (default: now)
+        match: Optional series selector to scope results
+
+    Returns:
+        List of label values
+    """
+    now = datetime.now(timezone.utc)
+    if end is None:
+        end = now
+    if start is None:
+        start = now - timedelta(hours=6)
+
+    params = {
+        "start": str(int(start.timestamp())),
+        "end": str(int(end.timestamp())),
+    }
+    if match:
+        params["match[]"] = match
+
+    url = get_api_url(f"/api/v1/label/{label}/values?{urlencode(params)}")
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+        data = response.json()
+        return data.get("data", [])
+
+
+def get_series(
+    match: list[str],
+    start: datetime | None = None,
+    end: datetime | None = None,
+    limit: int = 100,
+) -> list[dict]:
+    """Get series matching selectors.
+
+    Args:
+        match: List of series selectors (e.g., ['{job="api"}'])
+        start: Start time (default: 1 hour ago)
+        end: End time (default: now)
+        limit: Max series to return
+
+    Returns:
+        List of label sets
+    """
+    now = datetime.now(timezone.utc)
+    if end is None:
+        end = now
+    if start is None:
+        start = now - timedelta(hours=1)
+
+    params = [
+        ("start", str(int(start.timestamp()))),
+        ("end", str(int(end.timestamp()))),
+        ("limit", str(limit)),
+    ]
+    for m in match:
+        params.append(("match[]", m))
+
+    url = get_api_url(f"/api/v1/series?{urlencode(params)}")
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+        data = response.json()
+        return data.get("data", [])
+
+
+def format_metric_result(result: dict, max_series: int = 20) -> str:
+    """Format a query result for human-readable display.
+
+    Caps output to max_series to avoid flooding the context window.
+
+    Args:
+        result: API response dict
+        max_series: Maximum number of series to display
+
+    Returns:
+        Formatted string
+    """
+    data = result.get("data", {})
+    result_type = data.get("resultType", "vector")
+    results = data.get("result", [])
+
+    if not results:
+        return "No results found."
+
+    lines = []
+    total = len(results)
+
+    for item in results[:max_series]:
+        metric = item.get("metric", {})
+        name = metric.get("__name__", "")
+        labels = {k: v for k, v in metric.items() if k != "__name__"}
+        label_str = ", ".join(f'{k}="{v}"' for k, v in labels.items())
+
+        if result_type == "vector":
+            # Instant query: [timestamp, value]
+            value = item.get("value", [None, "N/A"])
+            lines.append(f"  {name}{{{label_str}}}: {value[1]}")
+        elif result_type == "matrix":
+            # Range query: show only latest value to keep output compact
+            values = item.get("values", [])
+            if values:
+                latest = values[-1]
+                lines.append(
+                    f"  {name}{{{label_str}}}: {latest[1]} (latest, {len(values)} points)"
+                )
+            else:
+                lines.append(f"  {name}{{{label_str}}}: (no data)")
+
+    if total > max_series:
+        lines.append(f"\n  ... showing {max_series} of {total} series")
+
+    return "\n".join(lines)

--- a/sre-agent/.claude/skills/observability-coralogix/SKILL.md
+++ b/sre-agent/.claude/skills/observability-coralogix/SKILL.md
@@ -1,0 +1,407 @@
+---
+name: observability-coralogix
+description: Coralogix log analysis with DataPrime query language. Use when querying Coralogix logs, metrics, or traces. Provides syntax reference and intelligent investigation scripts.
+---
+
+# Coralogix Analysis
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `CORALOGIX_API_KEY` or other API keys in environment variables - they won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `CORALOGIX_DOMAIN` - Team hostname (e.g., `myteam.app.cx498.coralogix.com`)
+- `CORALOGIX_REGION` - Region code (e.g., `us2`, `eu1`) - fallback if domain not set
+
+**Region mapping** (the scripts auto-detect based on domain):
+- US1: `*.app.coralogix.us` → `api.us1.coralogix.com`
+- US2: `*.app.cx498.coralogix.com` → `api.us2.coralogix.com`
+- EU1: `*.coralogix.com` → `api.eu1.coralogix.com`
+- EU2: `*.app.eu2.coralogix.com` → `api.eu2.coralogix.com`
+- AP1: `*.app.coralogix.in` → `api.ap1.coralogix.com`
+- AP2: `*.app.coralogixsg.com` → `api.ap2.coralogix.com`
+
+---
+
+## MANDATORY: Statistics-First Investigation
+
+**NEVER dump raw logs.** Always follow this pattern:
+
+```
+STATISTICS → SAMPLE → SIGNATURES → CORRELATE
+```
+
+1. **Statistics First** - Know volume, error rate, and top patterns before sampling
+2. **Strategic Sampling** - Choose the right strategy based on statistics
+3. **Pattern Extraction** - Cluster similar errors to find root causes
+4. **Context Correlation** - Investigate around anomaly timestamps
+
+## Available Scripts
+
+All scripts are in `.claude/skills/observability-coralogix/scripts/`
+
+### PRIMARY INVESTIGATION SCRIPTS
+
+#### get_statistics.py - ALWAYS START HERE
+Comprehensive statistics with pattern extraction and anomaly detection.
+```bash
+python .claude/skills/observability-coralogix/scripts/get_statistics.py [--service SERVICE] [--app APP] [--time-range MINUTES]
+
+# Examples:
+python .claude/skills/observability-coralogix/scripts/get_statistics.py --time-range 60
+python .claude/skills/observability-coralogix/scripts/get_statistics.py --service payment --app otel-demo
+```
+
+Output includes:
+- Total count, error count, error rate percentage
+- Severity distribution
+- **Top error patterns** (crucial for quick triage)
+- Time bucket anomalies (spike/drop detection via z-score)
+- Top services by log volume
+- Actionable recommendation
+
+#### sample_logs.py - Strategic Sampling
+Choose the right sampling strategy based on statistics.
+```bash
+python .claude/skills/observability-coralogix/scripts/sample_logs.py --strategy STRATEGY [--service SERVICE] [--app APP]
+
+# Strategies:
+#   errors_only   - Only ERROR/CRITICAL logs (default for incidents)
+#   around_anomaly - Logs within time window of specific timestamp
+#   first_last    - First N/2 + last N/2 logs (timeline view)
+#   random        - Random sample across time range
+#   all           - All severity levels (use sparingly)
+
+# Examples:
+python .claude/skills/observability-coralogix/scripts/sample_logs.py --strategy errors_only --service payment
+python .claude/skills/observability-coralogix/scripts/sample_logs.py --strategy around_anomaly --timestamp "2026-01-27T05:00:00Z" --window 60
+python .claude/skills/observability-coralogix/scripts/sample_logs.py --strategy first_last --service checkout --limit 50
+```
+
+#### extract_signatures.py - Pattern Clustering
+Normalize and cluster log messages to see unique issue patterns.
+```bash
+python .claude/skills/observability-coralogix/scripts/extract_signatures.py --service SERVICE [--severity SEVERITY] [--max-signatures N]
+
+# Examples:
+python .claude/skills/observability-coralogix/scripts/extract_signatures.py --service payment --severity ERROR
+python .claude/skills/observability-coralogix/scripts/extract_signatures.py --app otel-demo --max-signatures 30
+```
+
+Normalizes variable parts (UUIDs, IPs, timestamps, numbers) to find:
+- Dominant error patterns (> 50% = single root cause likely)
+- Diverse errors (many patterns = multiple issues)
+- Affected services per pattern
+
+### UTILITY SCRIPTS
+
+#### list_services.py - Service Discovery
+```bash
+python .claude/skills/observability-coralogix/scripts/list_services.py [--time-range MINUTES]
+```
+
+#### get_health.py - Quick Health Check
+```bash
+python .claude/skills/observability-coralogix/scripts/get_health.py <service> [--time-range MINUTES]
+```
+
+#### get_errors.py - Quick Error Fetch
+```bash
+python .claude/skills/observability-coralogix/scripts/get_errors.py <service> [--app APPLICATION] [--time-range MINUTES]
+```
+
+#### query_logs.py - Raw DataPrime Queries
+For custom queries not covered by other scripts.
+```bash
+python .claude/skills/observability-coralogix/scripts/query_logs.py "<dataprime_query>" [--time-range MINUTES] [--limit N]
+```
+
+## DataPrime Syntax Quick Reference
+
+### Filters
+```dataprime
+# Equality (use == not =)
+$l.subsystemname == 'api-server'
+
+# Severity - use ENUM values (no quotes!)
+# Valid: VERBOSE, DEBUG, INFO, WARNING, ERROR, CRITICAL
+$m.severity == ERROR
+$m.severity == WARNING || $m.severity == ERROR
+
+# Text search (case-insensitive) - use ~~ not 'contains'
+$d ~~ 'timeout'
+$d ~~ 'connection refused'
+
+# Combine filters with &&
+$l.subsystemname == 'payment' && $m.severity == ERROR
+```
+
+### Aggregations
+```dataprime
+# Count
+| aggregate count() as total
+
+# Group by field
+| groupby $l.subsystemname aggregate count() as cnt
+
+# Time bucketing
+| timebucket 5m aggregate count() as cnt
+
+# Multiple aggregations
+| groupby $l.subsystemname aggregate count() as cnt, avg($d.duration) as avg_duration
+
+# Order and limit
+| orderby cnt desc | limit 20
+```
+
+### Common Fields
+- `$l.applicationname` - Application/environment name (e.g., "otel-demo")
+- `$l.subsystemname` - Service name (e.g., "payment", "checkout")
+- `$m.severity` - Log level enum: VERBOSE, DEBUG, INFO, WARNING, ERROR, CRITICAL
+- `$m.timestamp` - Event timestamp
+- `$d` - Log message/data (use ~~ for text search)
+
+## Common Query Patterns
+
+### 1. List all services with log counts
+```dataprime
+source logs | groupby $l.subsystemname aggregate count() as cnt | orderby cnt desc | limit 30
+```
+
+### 2. Error count by service
+```dataprime
+source logs | filter $m.severity == ERROR | groupby $l.subsystemname aggregate count() as errors | orderby errors desc
+```
+
+### 3. Error rate over time
+```dataprime
+source logs | filter $m.severity == ERROR | groupby $m.timestamp / 5m as bucket aggregate count() as errors | orderby bucket asc
+```
+
+### 4. Errors for specific service
+```dataprime
+source logs | filter $l.subsystemname == 'payment' | filter $m.severity == ERROR | limit 50
+```
+
+### 5. Search for specific error message
+```dataprime
+source logs | filter $d ~~ 'connection refused' | limit 20
+```
+
+## Advanced DataPrime Patterns
+
+### Bracket Notation for Special Fields
+K8s fields often have dots in names. Use bracket notation:
+```dataprime
+# Wrong - treats as nested path
+$d.kubernetes.namespace
+
+# Correct - literal field name with dot
+$d['kubernetes.namespace']
+$d['resource.attributes.k8s_pod_name']
+```
+
+### Time-Based Comparisons
+Compare logs before/after a time threshold:
+```dataprime
+# Count logs in last hour vs older
+source logs | countby if($m.timestamp > now() - 1h, 'last_hour', 'older')
+
+# Find logs older than 5 minutes
+source logs | filter $m.timestamp < now() - 5m
+```
+
+### K8s Container Restarts
+Find unstable containers:
+```dataprime
+source logs
+| choose resource.attributes.k8s_container_restart_count:number as restarts,
+         resource.attributes.k8s_container_name as container,
+         resource.attributes.k8s_deployment_name as deployment
+| filter restarts > 0
+| groupby deployment aggregate max(restarts) as max_restarts
+| orderby max_restarts desc
+```
+
+### Peak Error Window
+Find the 10-minute window with most errors:
+```dataprime
+source logs
+| filter $m.severity == ERROR
+| groupby $m.timestamp / 10m as bucket aggregate count() as cnt
+| orderby cnt desc
+| limit 5
+```
+
+### Fuzzy Search All Fields
+When you don't know which field contains the value:
+```dataprime
+# Search all fields for text
+source logs | filter $d ~~ 'connection refused'
+
+# Or use wildfind
+source logs | wildfind 'timeout'
+```
+
+## Anti-Patterns to Avoid
+
+1. ❌ **NEVER skip statistics** - `get_statistics.py` is MANDATORY first step
+2. ❌ **Unbounded queries** - Always specify time ranges and limits
+3. ❌ **Quoting severity values** - Use enum: `ERROR` not `'ERROR'`
+4. ❌ **Using 'contains'** - Use ~~ operator for text search
+5. ❌ **Missing application filter** - For multi-tenant, filter by $l.applicationname
+6. ❌ **Fetching all logs** - Use sampling strategies, not `limit 10000`
+7. ❌ **Ignoring anomaly timestamps** - Use `around_anomaly` to investigate spikes
+8. ❌ **Reading logs without patterns** - Always extract signatures for RCA
+9. ❌ **Dot notation for K8s fields** - Use bracket notation: `$d['k8s.pod.name']`
+
+## Investigation Workflow
+
+### Standard Incident Investigation
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. STATISTICS FIRST (mandatory)                              │
+│    python get_statistics.py --service <service>              │
+│    → Know volume, error rate, top patterns, anomalies        │
+└─────────────────────────────────────────────────────────────┘
+                             │
+                             ▼
+                     Dominant Issue?
+               ┌─────────────┴─────────────┐
+               │                           │
+      YES (>80% one pattern)               NO (mixed errors)
+               │                           │
+               ▼                           ▼
+┌─────────────────────────────┐  ┌───────────────────────────────────────────┐
+│ 2. FAST PATH                │  │ 2. DEEP DIVE                              │
+│    Sample errors directly   │  │    python extract_signatures.py           │
+│    python sample_logs.py    │  │    python sample_logs.py --strategy ...   │
+│    → Verify hypothesis      │  │    → Cluster and analyze patterns         │
+└─────────────────────────────┘  └───────────────────────────────────────────┘
+```
+
+### Example: Payment Service Investigation
+
+```bash
+# Step 1: Statistics first - ALWAYS
+python .claude/skills/observability-coralogix/scripts/get_statistics.py --service payment --time-range 60
+# Output: 15,432 logs, 847 errors (5.5%), top pattern: "Connection timeout to downstream"
+
+# IF dominant pattern found:
+# Step 2: Verify with samples
+python .claude/skills/observability-coralogix/scripts/sample_logs.py --strategy errors_only --service payment --limit 10
+```
+
+### Quick Commands Reference
+
+| Goal | Command |
+|------|---------|
+| Start investigation | `get_statistics.py --service X` |
+| See error variety | `extract_signatures.py --service X` |
+| Sample errors only | `sample_logs.py --strategy errors_only --service X` |
+| Investigate spike | `sample_logs.py --strategy around_anomaly --timestamp T` |
+| Timeline view | `sample_logs.py --strategy first_last --service X` |
+| List all services | `list_services.py` |
+| Custom query | `query_logs.py "source logs | ..."` |
+
+---
+
+## Trace Investigation
+
+Use traces to understand **request flow** and **latency** across services.
+
+### When to Use Traces vs Logs
+
+| Use Case | Tool |
+|----------|------|
+| "What errors happened?" | Logs (`get_statistics.py`) |
+| "Why is this request slow?" | Traces (`get_slow_spans.py`) |
+| "Where did the request fail?" | Traces (`get_traces.py`) |
+| "What's the service dependency?" | Traces (operation analysis) |
+
+### Trace Scripts
+
+#### get_traces.py - Find Spans
+```bash
+# Get spans for a service
+python .claude/skills/observability-coralogix/scripts/get_traces.py --service checkout --time-range 30
+
+# Get all spans for a trace ID
+python .claude/skills/observability-coralogix/scripts/get_traces.py --trace-id abc123def456
+
+# Filter by operation
+python .claude/skills/observability-coralogix/scripts/get_traces.py --operation "/api/checkout" --service checkout
+```
+
+#### get_slow_spans.py - Latency Analysis
+```bash
+# Find spans slower than 500ms
+python .claude/skills/observability-coralogix/scripts/get_slow_spans.py --min-duration 500
+
+# Find slow spans in specific service
+python .claude/skills/observability-coralogix/scripts/get_slow_spans.py --min-duration 200 --service checkout
+
+# Get latency statistics by service (recommended first step)
+python .claude/skills/observability-coralogix/scripts/get_slow_spans.py --stats
+```
+
+### DataPrime Spans Syntax
+
+Spans use `source spans` but with **different field names** than logs:
+
+```dataprime
+# List spans for a service (use serviceName, not $l.subsystemname)
+source spans | filter serviceName == 'checkout' | limit 50
+
+# Find slow spans (duration in MICROSECONDS)
+source spans | filter duration > 500000 | orderby duration desc | limit 20
+
+# Get all spans for a trace (use top-level traceID)
+source spans | filter traceID == 'abc123def456...' | limit 100
+
+# Latency statistics by service
+source spans | groupby serviceName aggregate avg(duration) as avg_dur, max(duration) as max_dur | orderby avg_dur desc
+```
+
+### Span Fields Reference (different from logs!)
+- `operationName` - Operation name (e.g., `HTTP GET /checkout`)
+- `serviceName` - Service name (equivalent to logs' `$l.subsystemname`)
+- `applicationName` - Application name
+- `duration` - Span duration in **microseconds**
+- `traceID` - Trace identifier (32-char hex)
+- `spanID` - Span identifier
+- `parentId` - Parent span ID (for trace tree)
+- `tags` - Span metadata (e.g., `http.status_code`, `rpc.method`)
+- `process.tags` - Resource attributes (e.g., `k8s.pod.name`)
+
+### Trace Investigation Workflow
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. CHECK LATENCY STATS                                       │
+│    python get_slow_spans.py --stats                          │
+│    → See which services have high latency                    │
+└─────────────────────────────────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 2. FIND SLOW SPANS                                           │
+│    python get_slow_spans.py --min-duration 500 --service X   │
+│    → Get specific slow spans with trace IDs                  │
+└─────────────────────────────────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 3. TRACE FULL REQUEST                                        │
+│    python get_traces.py --trace-id <id>                      │
+│    → See all spans in the slow request                       │
+└─────────────────────────────────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 4. CORRELATE WITH LOGS                                       │
+│    python sample_logs.py --strategy around_anomaly           │
+│    → Get logs around the same timestamp                      │
+└─────────────────────────────────────────────────────────────┘
+```

--- a/sre-agent/.claude/skills/observability-coralogix/scripts/__init__.py
+++ b/sre-agent/.claude/skills/observability-coralogix/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Coralogix scripts package

--- a/sre-agent/.claude/skills/observability-coralogix/scripts/coralogix_client.py
+++ b/sre-agent/.claude/skills/observability-coralogix/scripts/coralogix_client.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Shared Coralogix API client with correct endpoint mapping.
+
+This module provides the correct API URL construction for Coralogix DataPrime queries.
+
+Region/Domain mapping (from Coralogix docs):
+- US1: api.us1.coralogix.com (team hostname: *.app.coralogix.us)
+- US2: api.us2.coralogix.com (team hostname: *.app.cx498.coralogix.com)
+- EU1: api.eu1.coralogix.com (team hostname: *.coralogix.com)
+- EU2: api.eu2.coralogix.com (team hostname: *.app.eu2.coralogix.com)
+- AP1: api.ap1.coralogix.com (team hostname: *.app.coralogix.in)
+- AP2: api.ap2.coralogix.com (team hostname: *.app.coralogixsg.com)
+- AP3: api.ap3.coralogix.com (team hostname: *.app.ap3.coralogix.com)
+"""
+
+import json
+import os
+import re
+from datetime import datetime, timedelta
+from typing import Any
+
+import httpx
+
+# Mapping from team hostname patterns to API domains
+HOSTNAME_TO_DOMAIN = {
+    r"\.app\.coralogix\.us$": "us1.coralogix.com",
+    r"\.app\.cx498\.coralogix\.com$": "us2.coralogix.com",
+    r"\.coralogix\.com$": "eu1.coralogix.com",  # Default EU1 (must be after cx498)
+    r"\.app\.eu2\.coralogix\.com$": "eu2.coralogix.com",
+    r"\.app\.coralogix\.in$": "ap1.coralogix.com",
+    r"\.app\.coralogixsg\.com$": "ap2.coralogix.com",
+    r"\.app\.ap3\.coralogix\.com$": "ap3.coralogix.com",
+}
+
+# Direct region code to domain mapping
+REGION_TO_DOMAIN = {
+    "us1": "us1.coralogix.com",
+    "us2": "us2.coralogix.com",
+    "cx498": "us2.coralogix.com",  # cx498 is US2
+    "eu1": "eu1.coralogix.com",
+    "eu2": "eu2.coralogix.com",
+    "ap1": "ap1.coralogix.com",
+    "ap2": "ap2.coralogix.com",
+    "ap3": "ap3.coralogix.com",
+}
+
+
+def get_config() -> dict[str, str | None]:
+    """Get Coralogix configuration from environment.
+
+    Credentials are injected by the credential-proxy based on tenant context.
+
+    Environment variables:
+        OPENSRE_TENANT_ID - Tenant ID for credential lookup
+        OPENSRE_TEAM_ID - Team ID for credential lookup
+        CORALOGIX_DOMAIN - Team hostname (e.g., myteam.app.cx498.coralogix.com)
+        CORALOGIX_REGION - Region code (e.g., us2, eu1)
+    """
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+        "domain": os.getenv("CORALOGIX_DOMAIN"),
+        "region": os.getenv("CORALOGIX_REGION"),
+    }
+
+
+def resolve_api_domain(config: dict[str, str | None]) -> str:
+    """Resolve the correct API domain from configuration.
+
+    Priority:
+    1. Extract from CORALOGIX_DOMAIN (team hostname)
+    2. Map from CORALOGIX_REGION
+    3. Default to US2 (cx498)
+    """
+    domain = config.get("domain")
+
+    if domain:
+        # Try to match against known hostname patterns
+        # Order matters: check more specific patterns first
+        for pattern, api_domain in [
+            (r"\.app\.cx498\.coralogix\.com", "us2.coralogix.com"),
+            (r"\.app\.coralogix\.us", "us1.coralogix.com"),
+            (r"\.app\.eu2\.coralogix\.com", "eu2.coralogix.com"),
+            (r"\.app\.coralogix\.in", "ap1.coralogix.com"),
+            (r"\.app\.coralogixsg\.com", "ap2.coralogix.com"),
+            (r"\.app\.ap3\.coralogix\.com", "ap3.coralogix.com"),
+            (r"\.coralogix\.com", "eu1.coralogix.com"),  # Generic .coralogix.com = EU1
+        ]:
+            if re.search(pattern, domain):
+                return api_domain
+
+        # If domain looks like an API domain already (api.X.coralogix.com)
+        match = re.search(r"api\.([a-z0-9]+)\.coralogix\.com", domain)
+        if match:
+            return f"{match.group(1)}.coralogix.com"
+
+    # Try region mapping
+    region = config.get("region")
+    if region:
+        region_lower = region.lower()
+        if region_lower in REGION_TO_DOMAIN:
+            return REGION_TO_DOMAIN[region_lower]
+
+    # Default to US2
+    return "us2.coralogix.com"
+
+
+def get_api_url(endpoint: str) -> str:
+    """Build the Coralogix API URL.
+
+    Supports two modes:
+    1. Proxy mode (production): Uses CORALOGIX_BASE_URL
+    2. Direct mode (testing): Uses CORALOGIX_DOMAIN or CORALOGIX_REGION
+
+    Args:
+        endpoint: API path (e.g., "/api/v1/dataprime/query")
+
+    Returns:
+        Full API URL
+    """
+    # Proxy mode (production)
+    base_url = os.getenv("CORALOGIX_BASE_URL")
+    if base_url:
+        return f"{base_url.rstrip('/')}{endpoint}"
+
+    # Direct mode (testing) - requires CORALOGIX_API_KEY
+    if os.getenv("CORALOGIX_API_KEY"):
+        config = get_config()
+        api_domain = resolve_api_domain(config)
+        return f"https://ng-api-http.{api_domain}{endpoint}"
+
+    raise RuntimeError(
+        "Either CORALOGIX_BASE_URL (proxy mode) or CORALOGIX_API_KEY (direct mode) must be set."
+    )
+
+
+def get_headers() -> dict[str, str]:
+    """Get Coralogix API headers.
+
+    In proxy mode: includes tenant context for credential lookup.
+    In direct mode: includes Bearer token directly.
+    """
+    config = get_config()
+    headers = {
+        "Content-Type": "application/json",
+    }
+
+    # Direct mode - add API key as Bearer token
+    api_key = os.getenv("CORALOGIX_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    else:
+        # Proxy mode - use JWT for credential-resolver auth
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            # Fallback for local dev
+            headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+            headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    return headers
+
+
+def parse_result(result: dict[str, Any]) -> dict[str, Any]:
+    """Parse a single result, handling userData JSON strings.
+
+    Coralogix returns aggregation results in userData as a JSON string.
+    This function parses that and merges it into a flat dict.
+    """
+    parsed = {}
+
+    # Copy metadata and labels if present
+    for item in result.get("metadata", []):
+        if isinstance(item, dict) and "key" in item and "value" in item:
+            parsed[item["key"]] = item["value"]
+
+    for item in result.get("labels", []):
+        if isinstance(item, dict) and "key" in item and "value" in item:
+            parsed[item["key"]] = item["value"]
+
+    # Parse userData - this is where aggregation results live
+    user_data = result.get("userData")
+    if user_data:
+        if isinstance(user_data, str):
+            try:
+                user_data = json.loads(user_data)
+            except json.JSONDecodeError:
+                pass
+        if isinstance(user_data, dict):
+            parsed.update(user_data)
+
+    # If we didn't find anything, return original
+    return parsed if parsed else result
+
+
+def execute_query(
+    query: str,
+    time_range_minutes: int = 60,
+    limit: int = 100,
+    tier: str = "TIER_FREQUENT_SEARCH",
+) -> list[dict[str, Any]]:
+    """Execute a DataPrime query and return results.
+
+    Args:
+        query: DataPrime query string
+        time_range_minutes: Time range to query (default: 60 minutes)
+        limit: Maximum results to return (default: 100)
+        tier: Storage tier (TIER_FREQUENT_SEARCH or TIER_ARCHIVE)
+
+    Returns:
+        List of result dictionaries
+
+    Raises:
+        httpx.HTTPStatusError: On API errors
+    """
+    end_time = datetime.utcnow()
+    start_time = end_time - timedelta(minutes=time_range_minutes)
+
+    url = get_api_url("/api/v1/dataprime/query")
+
+    payload = {
+        "query": query,
+        "metadata": {
+            "startDate": start_time.isoformat() + "Z",
+            "endDate": end_time.isoformat() + "Z",
+            "tier": tier,
+        },
+        "limit": limit,
+    }
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.post(url, headers=get_headers(), json=payload)
+        response.raise_for_status()
+
+        # Parse NDJSON response (newline-delimited JSON)
+        all_results = []
+        for line in response.text.strip().split("\n"):
+            if line.strip():
+                try:
+                    obj = json.loads(line)
+                    if "result" in obj and "results" in obj["result"]:
+                        # Parse each result to handle userData JSON strings
+                        for raw_result in obj["result"]["results"]:
+                            all_results.append(parse_result(raw_result))
+                except json.JSONDecodeError:
+                    continue
+
+        return all_results
+
+
+def format_log_entry(result: dict[str, Any], max_body_length: int = 300) -> str:
+    """Format a log entry result for display with clear structure.
+
+    Args:
+        result: Log entry dictionary from query results
+        max_body_length: Maximum length for log body (truncated if longer)
+
+    Returns:
+        Multi-line formatted string with severity, timestamp, service, message, and context
+    """
+    # Handle different response formats
+    timestamp = result.get("timestamp", result.get("@timestamp", ""))
+
+    # Severity can be in different locations
+    severity_raw = (
+        result.get("severity")
+        or result.get("$m.severity")
+        or result.get("severityText")
+        or "3"
+    )
+
+    # Map numeric severity to human-readable names
+    severity_map = {
+        "1": "DEBUG",
+        "2": "VERBOSE",
+        "3": "INFO",
+        "4": "WARNING",
+        "5": "ERROR",
+        "6": "CRITICAL",
+    }
+    severity = severity_map.get(str(severity_raw), str(severity_raw).upper())
+
+    # Subsystem/service name
+    subsystem = (
+        result.get("subsystemname")
+        or result.get("$l.subsystemname")
+        or result.get("subsystemName")
+        or "unknown"
+    )
+
+    # Log body/message - handle multiple formats
+    body = ""
+    # OTEL format: nested in logRecord.body
+    log_record = result.get("logRecord", {})
+    if isinstance(log_record, dict):
+        body = log_record.get("body", "")
+    # Direct body field
+    if not body:
+        body = (
+            result.get("body")
+            or result.get("$d")
+            or result.get("message")
+            or result.get("userData", "")
+        )
+    # Handle nested dict in body
+    if isinstance(body, dict):
+        body = body.get("logRecord", {}).get("body", str(body))
+    # Structured logs without body - create pattern from key fields
+    if not body:
+        parts = []
+        for key in [
+            "limit_event_type",
+            "limit_name",
+            "error_type",
+            "error_code",
+            "exception",
+            "error",
+        ]:
+            if key in result:
+                parts.append(f"{key}={result[key]}")
+        body = " ".join(parts) if parts else str(result)[:100]
+
+    # Truncate message if needed
+    body_str = str(body)
+    if len(body_str) > max_body_length:
+        body_str = body_str[:max_body_length] + "..."
+
+    # Format timestamp to be more readable
+    if "T" in str(timestamp):
+        # ISO format: "2026-01-27T06:09:39.657474697" -> "2026-01-27 06:09:39"
+        ts = str(timestamp).split(".")[0].replace("T", " ")
+    else:
+        ts = str(timestamp)
+
+    # Build multi-line output
+    lines = [f"[{severity}] {ts} | {subsystem}", f"  {body_str}"]
+
+    # Add optional context from OTEL resource attributes
+    resource = result.get("resource", {})
+    if isinstance(resource, dict):
+        attrs = resource.get("attributes", {})
+        context_parts = []
+
+        # K8s pod name
+        pod = attrs.get("k8s.pod.name", "")
+        if pod:
+            context_parts.append(f"pod={pod}")
+
+        # K8s node name (short form)
+        node = attrs.get("k8s.node.name", "")
+        if node:
+            # Shorten AWS node names: "ip-10-0-40-187.us-west-2.compute.internal" -> "ip-10-0-40-187"
+            node_short = node.split(".")[0] if "." in node else node
+            context_parts.append(f"node={node_short}")
+
+        # Namespace (if not already obvious)
+        namespace = attrs.get("k8s.namespace.name", "")
+        if namespace and namespace != subsystem:
+            context_parts.append(f"ns={namespace}")
+
+        if context_parts:
+            lines.append(f"  Context: {', '.join(context_parts)}")
+
+    return "\n".join(lines)

--- a/sre-agent/.claude/skills/observability-coralogix/scripts/extract_signatures.py
+++ b/sre-agent/.claude/skills/observability-coralogix/scripts/extract_signatures.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Extract and cluster log signatures for root cause analysis.
+
+This tool normalizes log messages by replacing variable parts with placeholders,
+then clusters similar messages to show the VARIETY of issues without reading
+every log entry.
+
+Normalization replaces:
+- UUIDs → {uuid}
+- Numbers → {num}
+- IP addresses → {ip}
+- Timestamps → {ts}
+- Hex strings → {hex}
+- URLs → {url}
+
+Usage:
+    python extract_signatures.py --service payment --time-range 60
+    python extract_signatures.py --app otel-demo --severity ERROR
+    python extract_signatures.py --service checkout --max-signatures 30
+
+Environment:
+    CORALOGIX_API_KEY - Required
+    CORALOGIX_DOMAIN - Team hostname
+"""
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+
+from coralogix_client import execute_query
+
+
+def normalize_message(msg: str) -> str:
+    """Normalize a log message by replacing variable parts with placeholders."""
+    if not msg:
+        return "empty"
+
+    normalized = str(msg)
+
+    # URLs (do this early before other patterns match parts of URLs)
+    normalized = re.sub(r"https?://[^\s]+", "{url}", normalized)
+
+    # UUIDs
+    normalized = re.sub(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        "{uuid}",
+        normalized,
+        flags=re.I,
+    )
+
+    # Long hex strings (like trace IDs, span IDs)
+    normalized = re.sub(r"\b[0-9a-f]{16,}\b", "{hex}", normalized, flags=re.I)
+
+    # IP addresses
+    normalized = re.sub(r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b", "{ip}", normalized)
+
+    # Timestamps in various formats
+    normalized = re.sub(
+        r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d+)?Z?", "{ts}", normalized
+    )
+    normalized = re.sub(r"\d{2}/\w{3}/\d{4}:\d{2}:\d{2}:\d{2}", "{ts}", normalized)
+
+    # Duration/latency values (e.g., 123ms, 4.5s)
+    normalized = re.sub(
+        r"\b\d+(\.\d+)?(ms|s|sec|seconds|milliseconds)\b",
+        "{duration}",
+        normalized,
+        flags=re.I,
+    )
+
+    # File paths with line numbers
+    normalized = re.sub(r":[0-9]+:[0-9]+", ":{line}", normalized)
+
+    # Numbers (do this last)
+    normalized = re.sub(r"\b\d+\b", "{num}", normalized)
+
+    # Collapse multiple whitespace
+    normalized = re.sub(r"\s+", " ", normalized)
+
+    return normalized.strip()[:120]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Extract and cluster log signatures for RCA"
+    )
+    parser.add_argument("--service", help="Service name (subsystemname)")
+    parser.add_argument("--app", help="Application name (applicationname)")
+    parser.add_argument(
+        "--time-range", type=int, default=60, help="Time range in minutes (default: 60)"
+    )
+    parser.add_argument(
+        "--severity", default="ERROR", help="Severity filter (default: ERROR)"
+    )
+    parser.add_argument(
+        "--max-signatures",
+        type=int,
+        default=20,
+        help="Max signatures to return (default: 20)",
+    )
+    parser.add_argument(
+        "--sample-size",
+        type=int,
+        default=500,
+        help="Logs to sample for analysis (default: 500)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Build query
+        query = "source logs"
+
+        if args.app:
+            query += f" | filter $l.applicationname == '{args.app}'"
+        if args.service:
+            query += f" | filter $l.subsystemname == '{args.service}'"
+
+        # Apply severity filter
+        severity = args.severity.upper()
+        if severity == "ERROR":
+            query += " | filter $m.severity == ERROR || $m.severity == CRITICAL"
+        elif severity == "WARNING":
+            query += " | filter $m.severity == WARNING || $m.severity == ERROR || $m.severity == CRITICAL"
+        elif severity == "ALL":
+            pass  # No filter
+        else:
+            query += f" | filter $m.severity == {severity}"
+
+        query += f" | limit {args.sample_size}"
+
+        # Fetch logs
+        results = execute_query(query, args.time_range, limit=args.sample_size)
+
+        if not results:
+            if args.json:
+                print(json.dumps({"signatures": [], "message": "No logs found"}))
+            else:
+                print("No logs found matching criteria.")
+            return
+
+        # Extract and normalize signatures
+        signature_counts = Counter()
+        signature_examples = {}
+        signature_services = {}
+        signature_first_seen = {}
+        signature_last_seen = {}
+
+        for log in results:
+            # Get the message body - handle multiple formats
+            body = ""
+            # OTEL format: nested in logRecord.body
+            log_record = log.get("logRecord", {})
+            if isinstance(log_record, dict):
+                body = log_record.get("body", "")
+            # Direct body field
+            if not body:
+                body = log.get("body", log.get("message", ""))
+            # Structured logs - create pattern from fields
+            if not body:
+                parts = []
+                for key in [
+                    "limit_event_type",
+                    "limit_name",
+                    "error_type",
+                    "error_code",
+                    "exception",
+                ]:
+                    if key in log:
+                        parts.append(f"{key}={log[key]}")
+                body = " ".join(parts) if parts else ""
+
+            msg = str(body)
+            sig = normalize_message(msg)
+
+            signature_counts[sig] += 1
+
+            if sig not in signature_examples:
+                signature_examples[sig] = msg[:300]
+                signature_first_seen[sig] = log.get("timestamp", "")
+                signature_services[sig] = set()
+
+            signature_last_seen[sig] = log.get("timestamp", "")
+
+            service = log.get("subsystemname", log.get("service", ""))
+            if service:
+                signature_services[sig].add(service)
+
+        # Build signature list
+        total_analyzed = len(results)
+        signatures = []
+
+        for i, (pattern, count) in enumerate(
+            signature_counts.most_common(args.max_signatures)
+        ):
+            signatures.append(
+                {
+                    "id": i + 1,
+                    "pattern": pattern,
+                    "count": count,
+                    "percentage": round(count / total_analyzed * 100, 1),
+                    "first_seen": signature_first_seen.get(pattern, ""),
+                    "last_seen": signature_last_seen.get(pattern, ""),
+                    "sample_message": signature_examples.get(pattern, ""),
+                    "affected_services": list(signature_services.get(pattern, set())),
+                }
+            )
+
+        # Generate insights
+        if signatures:
+            top_pattern = signatures[0]
+            if top_pattern["percentage"] > 50:
+                insight = f"DOMINANT ISSUE: {top_pattern['percentage']}% of errors share one pattern. Focus on: {top_pattern['pattern'][:50]}..."
+            elif len(signatures) <= 3:
+                insight = f"FEW UNIQUE ISSUES: Only {len(signatures)} distinct error patterns. Good candidates for targeted fixes."
+            else:
+                insight = f"DIVERSE ISSUES: {len(signatures)} unique patterns. Top pattern accounts for {top_pattern['percentage']}% of errors."
+        else:
+            insight = "No error patterns found."
+
+        result = {
+            "time_range_minutes": args.time_range,
+            "service": args.service,
+            "application": args.app,
+            "severity_filter": args.severity,
+            "total_logs_analyzed": total_analyzed,
+            "unique_signatures": len(signatures),
+            "signatures": signatures,
+            "insight": insight,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print("🔬 Log Signature Analysis")
+            print(f"Time range: Last {args.time_range} minutes")
+            print(f"Severity: {args.severity}")
+            if args.service:
+                print(f"Service: {args.service}")
+            print(f"Analyzed: {total_analyzed} logs")
+            print("=" * 60)
+
+            print(f"\n💡 INSIGHT: {insight}")
+
+            print(f"\n📊 SIGNATURES ({len(signatures)} unique patterns)")
+            print("-" * 60)
+
+            for sig in signatures:
+                # Color code by percentage
+                if sig["percentage"] > 30:
+                    emoji = "🔴"
+                elif sig["percentage"] > 10:
+                    emoji = "🟠"
+                else:
+                    emoji = "🟡"
+
+                print(
+                    f"\n{emoji} #{sig['id']} - {sig['count']} occurrences ({sig['percentage']}%)"
+                )
+                print(f"   Pattern: {sig['pattern']}")
+                if sig["affected_services"]:
+                    print(f"   Services: {', '.join(sig['affected_services'])}")
+                print(f"   Sample: {sig['sample_message'][:100]}...")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-coralogix/scripts/get_errors.py
+++ b/sre-agent/.claude/skills/observability-coralogix/scripts/get_errors.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Get error logs for a service from Coralogix.
+
+Simplified interface - builds correct DataPrime query automatically.
+
+Usage:
+    python get_errors.py <service> [--app APPLICATION] [--time-range MINUTES] [--limit N]
+
+Examples:
+    python get_errors.py payment --app otel-demo
+    python get_errors.py checkout --time-range 30 --limit 100
+
+Environment:
+    CORALOGIX_API_KEY - Required
+    CORALOGIX_DOMAIN - Team hostname (e.g., myteam.app.cx498.coralogix.com)
+    CORALOGIX_REGION - Region code (e.g., us2, eu1)
+"""
+
+import argparse
+import json
+import sys
+
+from coralogix_client import execute_query, format_log_entry
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Get error logs for a service from Coralogix"
+    )
+    parser.add_argument("service", help="Service name (e.g., payment, checkout)")
+    parser.add_argument(
+        "--app", default="otel-demo", help="Application name (default: otel-demo)"
+    )
+    parser.add_argument(
+        "--time-range", type=int, default=60, help="Time range in minutes (default: 60)"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=50, help="Result limit (default: 50)"
+    )
+    parser.add_argument(
+        "--include-warnings", action="store_true", help="Include WARNING severity"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    # Build DataPrime query
+    query = "source logs"
+    query += f" | filter $l.applicationname == '{args.app}'"
+    query += f" | filter $l.subsystemname == '{args.service}'"
+
+    if args.include_warnings:
+        query += " | filter $m.severity == WARNING || $m.severity == ERROR || $m.severity == CRITICAL"
+    else:
+        query += " | filter $m.severity == ERROR || $m.severity == CRITICAL"
+
+    query += f" | limit {args.limit}"
+
+    try:
+        results = execute_query(
+            query=query,
+            time_range_minutes=args.time_range,
+            limit=args.limit,
+        )
+
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "service": args.service,
+                        "application": args.app,
+                        "time_range": f"Last {args.time_range} minutes",
+                        "error_count": len(results),
+                        "errors": results[: args.limit],
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(f"Service: {args.service}")
+            print(f"Application: {args.app}")
+            print(f"Time range: Last {args.time_range} minutes")
+            print(f"Errors found: {len(results)}")
+            print("-" * 60)
+
+            if not results:
+                print("No errors found for this service.")
+            else:
+                for result in results[: args.limit]:
+                    severity = (
+                        result.get("severity") or result.get("$m.severity") or "ERROR"
+                    )
+                    severity_icon = "🔴" if severity == "CRITICAL" else "🟠"
+                    print(f"{severity_icon} {format_log_entry(result)}")
+                    print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-coralogix/scripts/get_health.py
+++ b/sre-agent/.claude/skills/observability-coralogix/scripts/get_health.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Get health summary for a service from Coralogix.
+
+Usage:
+    python get_health.py <service> [--app APPLICATION] [--time-range MINUTES]
+
+Examples:
+    python get_health.py payment
+    python get_health.py checkout --app otel-demo --time-range 30
+
+Environment:
+    CORALOGIX_API_KEY - Required
+    CORALOGIX_DOMAIN - Team hostname (e.g., myteam.app.cx498.coralogix.com)
+    CORALOGIX_REGION - Region code (e.g., us2, eu1)
+"""
+
+import argparse
+import json
+import sys
+
+from coralogix_client import execute_query
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get service health from Coralogix")
+    parser.add_argument("service", help="Service name")
+    parser.add_argument(
+        "--app", default="otel-demo", help="Application name (default: otel-demo)"
+    )
+    parser.add_argument(
+        "--time-range", type=int, default=60, help="Time range in minutes (default: 60)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Get total log count
+        total_query = f"source logs | filter $l.applicationname == '{args.app}' | filter $l.subsystemname == '{args.service}' | aggregate count() as total"
+        total_results = execute_query(total_query, args.time_range)
+        total_count = total_results[0].get("total", 0) if total_results else 0
+
+        # Get error count
+        error_query = f"source logs | filter $l.applicationname == '{args.app}' | filter $l.subsystemname == '{args.service}' | filter $m.severity == ERROR || $m.severity == CRITICAL | aggregate count() as errors"
+        error_results = execute_query(error_query, args.time_range)
+        error_count = error_results[0].get("errors", 0) if error_results else 0
+
+        # Get warning count
+        warning_query = f"source logs | filter $l.applicationname == '{args.app}' | filter $l.subsystemname == '{args.service}' | filter $m.severity == WARNING | aggregate count() as warnings"
+        warning_results = execute_query(warning_query, args.time_range)
+        warning_count = warning_results[0].get("warnings", 0) if warning_results else 0
+
+        # Calculate error rate
+        error_rate = (error_count / total_count * 100) if total_count > 0 else 0
+
+        # Determine health status
+        if error_count == 0:
+            status = "healthy"
+            status_icon = "🟢"
+        elif error_count < 10 or error_rate < 1:
+            status = "degraded"
+            status_icon = "🟡"
+        elif error_count < 50 or error_rate < 5:
+            status = "warning"
+            status_icon = "🟠"
+        else:
+            status = "critical"
+            status_icon = "🔴"
+
+        result = {
+            "service": args.service,
+            "application": args.app,
+            "time_range": f"Last {args.time_range} minutes",
+            "status": status,
+            "total_logs": total_count,
+            "error_count": error_count,
+            "warning_count": warning_count,
+            "error_rate_percent": round(error_rate, 2),
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"{status_icon} Service Health: {args.service}")
+            print(f"Application: {args.app}")
+            print(f"Time range: Last {args.time_range} minutes")
+            print("-" * 40)
+            print(f"Status: {status.upper()}")
+            print(f"Total logs: {total_count}")
+            print(f"Errors: {error_count} ({error_rate:.2f}%)")
+            print(f"Warnings: {warning_count}")
+
+            if status == "critical":
+                print()
+                print("⚠️  CRITICAL: High error rate detected!")
+                print("   Run get_errors.py to see specific errors.")
+            elif status == "warning":
+                print()
+                print("⚠️  WARNING: Elevated error rate.")
+                print("   Consider investigating recent errors.")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-coralogix/scripts/get_slow_spans.py
+++ b/sre-agent/.claude/skills/observability-coralogix/scripts/get_slow_spans.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Find slow spans (latency analysis) from Coralogix.
+
+Use this to identify performance bottlenecks and slow operations.
+
+Usage:
+    python get_slow_spans.py --min-duration 500 --service checkout
+    python get_slow_spans.py --min-duration 1000 --time-range 30
+
+Examples:
+    # Find spans slower than 500ms
+    python get_slow_spans.py --min-duration 500
+
+    # Find slow spans in checkout service
+    python get_slow_spans.py --min-duration 200 --service checkout
+
+    # Get latency statistics by service
+    python get_slow_spans.py --stats
+
+Environment:
+    CORALOGIX_API_KEY - Required
+    CORALOGIX_DOMAIN - Team hostname
+"""
+
+import argparse
+import json
+import sys
+
+from coralogix_client import execute_query
+
+
+def format_slow_span(span: dict) -> str:
+    """Format a slow span for readable output."""
+    operation = span.get("operationName", "unknown")
+    service = span.get("serviceName", span.get("subsystemName", "unknown"))
+    duration = span.get("duration", 0)
+
+    # Duration is in microseconds - convert to ms
+    duration_ms = duration / 1000
+
+    # Color code by latency
+    if duration_ms > 1000:
+        icon = "🔴"  # > 1s
+    elif duration_ms > 500:
+        icon = "🟠"  # > 500ms
+    elif duration_ms > 200:
+        icon = "🟡"  # > 200ms
+    else:
+        icon = "🟢"
+
+    # Format timestamp (spans have startTime in epoch microseconds)
+    start_time = span.get("startTime", span.get("timestamp", ""))
+    if isinstance(start_time, (int, float)) and start_time > 1_000_000_000_000:
+        # Microseconds epoch - convert to datetime
+        from datetime import datetime
+
+        ts = datetime.fromtimestamp(start_time / 1_000_000).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+    elif "T" in str(start_time):
+        ts = str(start_time).split(".")[0].replace("T", " ")
+    else:
+        ts = str(start_time)
+
+    # Get trace ID from references or direct field
+    trace_id = ""
+    refs = span.get("references", [])
+    if refs and isinstance(refs, list) and len(refs) > 0:
+        trace_id = refs[0].get("traceID", "")[:16]
+    if not trace_id:
+        trace_id = span.get("traceId", span.get("traceID", ""))
+        if trace_id:
+            trace_id = trace_id[:16]
+
+    lines = [
+        f"{icon} {duration_ms:.1f}ms | {operation} | {service}",
+        f"  Time: {ts}",
+    ]
+
+    if trace_id:
+        lines.append(f"  Trace: {trace_id}...")
+
+    # Add pod context if available
+    process = span.get("process", {})
+    if isinstance(process, dict):
+        tags = process.get("tags", {})
+        pod = tags.get("k8s.pod.name", "")
+        if pod:
+            lines.append(f"  Pod: {pod}")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Find slow spans (latency analysis)")
+    parser.add_argument(
+        "--min-duration",
+        type=int,
+        default=500,
+        help="Minimum duration in milliseconds (default: 500)",
+    )
+    parser.add_argument("--service", help="Service name filter")
+    parser.add_argument("--app", help="Application name filter")
+    parser.add_argument("--operation", help="Operation name filter")
+    parser.add_argument(
+        "--time-range", type=int, default=60, help="Time range in minutes (default: 60)"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=50, help="Maximum spans to return (default: 50)"
+    )
+    parser.add_argument(
+        "--stats", action="store_true", help="Show latency statistics by service"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        if args.stats:
+            # Get latency statistics grouped by service
+            # Note: Spans use serviceName, applicationName (not $l. prefix like logs)
+            query = "source spans"
+            if args.app:
+                query += f" | filter applicationName == '{args.app}'"
+            if args.service:
+                query += f" | filter serviceName == '{args.service}'"
+
+            # Group by service, calculate avg/max duration (duration is in microseconds)
+            query += " | groupby serviceName aggregate count() as span_count, avg(duration) as avg_duration, max(duration) as max_duration"
+            query += " | orderby avg_duration desc | limit 20"
+
+            results = execute_query(query, args.time_range, limit=20)
+
+            if args.json:
+                print(
+                    json.dumps(
+                        {
+                            "time_range_minutes": args.time_range,
+                            "service_stats": results,
+                        },
+                        indent=2,
+                    )
+                )
+            else:
+                print("📊 Latency Statistics by Service")
+                print(f"Time range: Last {args.time_range} minutes")
+                print("=" * 70)
+                print(f"{'SERVICE':<25} {'COUNT':>10} {'AVG':>12} {'MAX':>12}")
+                print("-" * 70)
+
+                for r in results:
+                    service = r.get("serviceName", "unknown")
+                    count = r.get("span_count", 0)
+                    avg_dur = r.get("avg_duration", 0)
+                    max_dur = r.get("max_duration", 0)
+
+                    # Duration is in microseconds - convert to ms
+                    avg_ms = avg_dur / 1000
+                    max_ms = max_dur / 1000
+
+                    print(
+                        f"{service:<25} {count:>10} {avg_ms:>10.1f}ms {max_ms:>10.1f}ms"
+                    )
+
+            return
+
+        # Build query for slow spans
+        # Note: Spans use serviceName, applicationName, operationName, duration (not $l./$m. prefix)
+        query = "source spans"
+
+        if args.app:
+            query += f" | filter applicationName == '{args.app}'"
+        if args.service:
+            query += f" | filter serviceName == '{args.service}'"
+        if args.operation:
+            query += f" | filter operationName ~~ '{args.operation}'"
+
+        # Filter by duration (duration is in microseconds)
+        duration_us = args.min_duration * 1000  # Convert ms to µs
+        query += f" | filter duration > {duration_us}"
+
+        # Order by duration descending
+        query += " | orderby duration desc"
+        query += f" | limit {args.limit}"
+
+        results = execute_query(query, args.time_range, limit=args.limit)
+
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "min_duration_ms": args.min_duration,
+                        "service": args.service,
+                        "time_range_minutes": args.time_range,
+                        "slow_span_count": len(results),
+                        "spans": results,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(f"🐢 Slow Spans (>{args.min_duration}ms)")
+            if args.service:
+                print(f"Service: {args.service}")
+            print(f"Time range: Last {args.time_range} minutes")
+            print(f"Found: {len(results)} slow spans")
+            print("=" * 60)
+
+            if not results:
+                print(f"\nNo spans slower than {args.min_duration}ms found.")
+                print("Try lowering --min-duration or increasing --time-range")
+            else:
+                for span in results[:20]:
+                    print(format_slow_span(span))
+                    print()
+
+                if len(results) > 20:
+                    print(f"... and {len(results) - 20} more slow spans")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-coralogix/scripts/get_statistics.py
+++ b/sre-agent/.claude/skills/observability-coralogix/scripts/get_statistics.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Get comprehensive log statistics - THE MANDATORY FIRST STEP.
+
+This should ALWAYS be called before fetching raw logs. It provides:
+- Total count and error rate (to decide if sampling is needed)
+- Severity distribution
+- Top error patterns (crucial for quick triage)
+- Time buckets for anomaly/spike detection
+- Actionable recommendations
+
+Usage:
+    python get_statistics.py [--service SERVICE] [--app APPLICATION] [--time-range MINUTES]
+
+Examples:
+    python get_statistics.py --time-range 60
+    python get_statistics.py --service payment --app otel-demo
+    python get_statistics.py --service checkout --time-range 30
+
+Environment:
+    CORALOGIX_API_KEY - Required
+    CORALOGIX_DOMAIN - Team hostname
+"""
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from datetime import datetime
+
+from coralogix_client import execute_query
+
+
+def detect_anomalies(time_buckets: list[dict], threshold_z: float = 2.0) -> list[dict]:
+    """Detect anomalies in time series data using z-score.
+
+    Args:
+        time_buckets: List of {timestamp, count} dicts
+        threshold_z: Z-score threshold for anomaly (default 2.0)
+
+    Returns:
+        List of anomalies with timestamp, count, z_score, type
+    """
+    if len(time_buckets) < 3:
+        return []
+
+    counts = [b.get("count", 0) for b in time_buckets]
+    mean = sum(counts) / len(counts)
+    variance = sum((x - mean) ** 2 for x in counts) / len(counts)
+    std_dev = variance**0.5 if variance > 0 else 1
+
+    anomalies = []
+    for bucket in time_buckets:
+        count = bucket.get("count", 0)
+        z_score = (count - mean) / std_dev if std_dev > 0 else 0
+
+        if abs(z_score) > threshold_z:
+            anomalies.append(
+                {
+                    "timestamp": bucket.get("timestamp"),
+                    "count": count,
+                    "z_score": round(z_score, 2),
+                    "type": "spike" if z_score > 0 else "drop",
+                    "description": f"{'Unusually high' if z_score > 0 else 'Unusually low'} ({count} vs avg {round(mean)})",
+                }
+            )
+
+    return anomalies
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Get comprehensive log statistics (ALWAYS call first)"
+    )
+    parser.add_argument("--service", help="Service name (subsystemname)")
+    parser.add_argument("--app", help="Application name (applicationname)")
+    parser.add_argument(
+        "--time-range", type=int, default=60, help="Time range in minutes (default: 60)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # 1. Get severity distribution
+        severity_query = "source logs"
+        if args.app:
+            severity_query += f" | filter $l.applicationname == '{args.app}'"
+        if args.service:
+            severity_query += f" | filter $l.subsystemname == '{args.service}'"
+        severity_query += " | groupby $m.severity aggregate count() as cnt"
+
+        severity_results = execute_query(severity_query, args.time_range, limit=20)
+
+        # Parse severity distribution
+        severity_dist = {}
+        total_count = 0
+        error_count = 0
+        warning_count = 0
+
+        # Coralogix returns severity as "Info", "Error", etc.
+        error_severities = {"error", "critical", "5", "6"}
+        warning_severities = {"warning", "warn", "4"}
+
+        for r in severity_results:
+            sev = str(r.get("severity", "UNKNOWN"))
+            cnt = int(r.get("cnt", 0))
+            severity_dist[sev] = cnt
+            total_count += cnt
+            if sev.lower() in error_severities:
+                error_count += cnt
+            elif sev.lower() in warning_severities:
+                warning_count += cnt
+
+        # 2. Get top error patterns (crucial for triage)
+        # Fetch error samples and extract patterns client-side (more reliable than groupby on body)
+        pattern_query = (
+            "source logs | filter $m.severity == ERROR || $m.severity == CRITICAL"
+        )
+        if args.app:
+            pattern_query = f"source logs | filter $l.applicationname == '{args.app}' | filter $m.severity == ERROR || $m.severity == CRITICAL"
+        if args.service:
+            if args.app:
+                pattern_query += f" | filter $l.subsystemname == '{args.service}'"
+            else:
+                pattern_query = f"source logs | filter $l.subsystemname == '{args.service}' | filter $m.severity == ERROR || $m.severity == CRITICAL"
+        pattern_query += " | limit 100"
+
+        pattern_results = execute_query(pattern_query, args.time_range, limit=100)
+
+        # Extract patterns client-side by normalizing and counting
+        pattern_counts = Counter()
+
+        for r in pattern_results:
+            # Try multiple locations for the log body
+            body = ""
+            # OTEL logs: nested in logRecord.body
+            log_record = r.get("logRecord", {})
+            if isinstance(log_record, dict):
+                body = log_record.get("body", "")
+            # Direct body field
+            if not body:
+                body = r.get("body", r.get("message", ""))
+            # Structured logs without body - create pattern from key fields
+            if not body:
+                # Use key fields that describe the error
+                parts = []
+                for key in [
+                    "limit_event_type",
+                    "limit_name",
+                    "error_type",
+                    "error_code",
+                    "exception",
+                ]:
+                    if key in r:
+                        parts.append(f"{key}={r[key]}")
+                body = " ".join(parts) if parts else str(r)[:100]
+
+            body = str(body)
+            # Normalize: replace numbers, UUIDs, IPs with placeholders
+            normalized = re.sub(
+                r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+                "{uuid}",
+                body,
+                flags=re.I,
+            )
+            normalized = re.sub(r"\b\d+\b", "{num}", normalized)
+            normalized = re.sub(
+                r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b", "{ip}", normalized
+            )
+            pattern_counts[normalized[:100]] += 1
+
+        top_patterns = [
+            {"pattern": p, "count": c} for p, c in pattern_counts.most_common(10)
+        ]
+
+        # 3. Get time buckets for anomaly detection (5-minute buckets)
+        # Use DataPrime timestamp division for bucketing: $m.timestamp / 5.toInterval('m')
+        time_query = "source logs"
+        if args.app:
+            time_query += f" | filter $l.applicationname == '{args.app}'"
+        if args.service:
+            time_query += f" | filter $l.subsystemname == '{args.service}'"
+        time_query += " | create bucket from $m.timestamp / 5.toInterval('m') | groupby bucket aggregate count() as cnt | orderby bucket asc"
+
+        time_results = execute_query(time_query, args.time_range, limit=100)
+
+        time_buckets = []
+        for r in time_results:
+            # bucket is a nanosecond timestamp
+            bucket_ns = r.get("bucket", 0)
+            # Convert nanoseconds to ISO timestamp
+            if bucket_ns:
+                ts = datetime.fromtimestamp(bucket_ns / 1_000_000_000)
+                time_buckets.append(
+                    {"timestamp": ts.isoformat(), "count": r.get("cnt", 0)}
+                )
+            else:
+                time_buckets.append(
+                    {"timestamp": str(bucket_ns), "count": r.get("cnt", 0)}
+                )
+
+        # Detect anomalies
+        anomalies = detect_anomalies(time_buckets)
+
+        # 4. Get top services (if not filtering by service)
+        top_services = []
+        if not args.service:
+            service_query = "source logs"
+            if args.app:
+                service_query += f" | filter $l.applicationname == '{args.app}'"
+            service_query += " | groupby $l.subsystemname aggregate count() as cnt | orderby cnt desc | limit 10"
+
+            service_results = execute_query(service_query, args.time_range, limit=10)
+            for r in service_results:
+                top_services.append(
+                    {
+                        "service": r.get("subsystemname", "unknown"),
+                        "count": r.get("cnt", 0),
+                    }
+                )
+
+        # Calculate error rate
+        error_rate = round(error_count / total_count * 100, 2) if total_count > 0 else 0
+
+        # Generate recommendation
+        if total_count > 100000:
+            recommendation = f"HIGH volume ({total_count:,} logs). Use narrow time range and sampling with limit."
+        elif total_count > 10000:
+            recommendation = (
+                f"MODERATE volume ({total_count:,} logs). Sampling recommended."
+            )
+        elif error_count > 100:
+            recommendation = f"ELEVATED errors ({error_count} errors, {error_rate}% rate). Investigate top patterns."
+        elif error_count > 0:
+            recommendation = f"LOW error rate ({error_count} errors, {error_rate}%). Check top patterns for root cause."
+        else:
+            recommendation = (
+                f"HEALTHY ({total_count:,} logs, no errors). Monitor for changes."
+            )
+
+        result = {
+            "time_range_minutes": args.time_range,
+            "service": args.service,
+            "application": args.app,
+            "total_count": total_count,
+            "error_count": error_count,
+            "warning_count": warning_count,
+            "error_rate_percent": error_rate,
+            "severity_distribution": severity_dist,
+            "top_error_patterns": top_patterns,
+            "top_services": top_services,
+            "anomalies_detected": len(anomalies),
+            "anomalies": anomalies[:5],  # Top 5 anomalies
+            "recommendation": recommendation,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            # Determine status
+            if error_count == 0:
+                status_icon = "🟢"
+                status = "HEALTHY"
+            elif error_rate < 1:
+                status_icon = "🟡"
+                status = "DEGRADED"
+            elif error_rate < 5:
+                status_icon = "🟠"
+                status = "WARNING"
+            else:
+                status_icon = "🔴"
+                status = "CRITICAL"
+
+            print(f"{status_icon} Log Statistics - {status}")
+            print(f"Time range: Last {args.time_range} minutes")
+            if args.service:
+                print(f"Service: {args.service}")
+            if args.app:
+                print(f"Application: {args.app}")
+            print("=" * 60)
+
+            print("\n📊 VOLUME")
+            print(f"   Total logs: {total_count:,}")
+            print(f"   Errors: {error_count:,} ({error_rate}%)")
+            print(f"   Warnings: {warning_count:,}")
+
+            if severity_dist:
+                print("\n📈 SEVERITY DISTRIBUTION")
+                for sev, cnt in sorted(severity_dist.items(), key=lambda x: -x[1]):
+                    pct = round(cnt / total_count * 100, 1) if total_count > 0 else 0
+                    print(f"   {sev}: {cnt:,} ({pct}%)")
+
+            if top_patterns:
+                print("\n🔥 TOP ERROR PATTERNS")
+                for i, p in enumerate(top_patterns[:5], 1):
+                    print(f"   {i}. [{p['count']}x] {p['pattern'][:60]}...")
+
+            if top_services:
+                print("\n🏷️  TOP SERVICES")
+                for s in top_services[:5]:
+                    print(f"   {s['service']}: {s['count']:,} logs")
+
+            if anomalies:
+                print(f"\n⚠️  ANOMALIES DETECTED: {len(anomalies)}")
+                for a in anomalies[:3]:
+                    print(
+                        f"   {a['type'].upper()}: {a['description']} at {a['timestamp']}"
+                    )
+
+            print("\n💡 RECOMMENDATION")
+            print(f"   {recommendation}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-coralogix/scripts/get_traces.py
+++ b/sre-agent/.claude/skills/observability-coralogix/scripts/get_traces.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Get distributed traces/spans from Coralogix.
+
+Use this to understand request flow, identify slow operations, and trace errors.
+
+Usage:
+    python get_traces.py --service checkout --time-range 30
+    python get_traces.py --operation "/api/checkout" --limit 20
+    python get_traces.py --trace-id abc123def456
+
+Examples:
+    # List recent spans for a service
+    python get_traces.py --service payment --time-range 15
+
+    # Find a specific trace
+    python get_traces.py --trace-id abc123def456
+
+    # Find spans for an operation
+    python get_traces.py --operation "HTTP GET" --service checkout
+
+Environment:
+    CORALOGIX_API_KEY - Required
+    CORALOGIX_DOMAIN - Team hostname
+"""
+
+import argparse
+import json
+import sys
+
+from coralogix_client import execute_query
+
+
+def format_span(span: dict, include_context: bool = True) -> str:
+    """Format a span for readable output."""
+    from datetime import datetime
+
+    # Extract key fields (spans use serviceName, operationName directly)
+    operation = span.get("operationName", "unknown")
+    service = span.get("serviceName", span.get("subsystemName", "unknown"))
+    duration = span.get("duration", 0)
+
+    # Duration is in microseconds - convert to ms
+    duration_ms = duration / 1000
+    if duration_ms >= 1:
+        duration_str = f"{duration_ms:.1f}ms"
+    else:
+        duration_str = f"{duration}µs"
+
+    # Get IDs from references or direct fields
+    trace_id = ""
+    span_id = span.get("spanID", "")[:8] if span.get("spanID") else ""
+    refs = span.get("references", [])
+    if refs and isinstance(refs, list) and len(refs) > 0:
+        trace_id = refs[0].get("traceID", "")[:16]
+
+    # Status - check tags for error status
+    tags = span.get("tags", {})
+    is_error = tags.get("error", False) or tags.get("otel.status_code") == "ERROR"
+    status_icon = "❌" if is_error else "✓"
+
+    # Format timestamp (spans have startTime in epoch microseconds)
+    start_time = span.get("startTime", span.get("timestamp", ""))
+    if isinstance(start_time, (int, float)) and start_time > 1_000_000_000_000:
+        ts = datetime.fromtimestamp(start_time / 1_000_000).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+    elif "T" in str(start_time):
+        ts = str(start_time).split(".")[0].replace("T", " ")
+    else:
+        ts = str(start_time)
+
+    lines = [
+        f"{status_icon} [{duration_str}] {operation} | {service}",
+        f"  Time: {ts}",
+    ]
+
+    if trace_id or span_id:
+        lines.append(f"  IDs: trace={trace_id}... span={span_id}...")
+
+    if include_context:
+        # Add pod context from process.tags
+        process = span.get("process", {})
+        if isinstance(process, dict):
+            proc_tags = process.get("tags", {})
+            pod = proc_tags.get("k8s.pod.name", "")
+            if pod:
+                lines.append(f"  Pod: {pod}")
+
+        # Add span tags (filter to interesting ones)
+        if isinstance(tags, dict) and tags:
+            interesting_keys = [
+                "http.method",
+                "http.status_code",
+                "http.url",
+                "db.system",
+                "rpc.method",
+            ]
+            tag_items = [(k, v) for k, v in tags.items() if k in interesting_keys][:3]
+            if tag_items:
+                tag_str = ", ".join(f"{k}={v}" for k, v in tag_items)
+                lines.append(f"  Tags: {tag_str}")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Get distributed traces/spans from Coralogix"
+    )
+    parser.add_argument("--service", help="Service name (subsystemname)")
+    parser.add_argument("--app", help="Application name (applicationname)")
+    parser.add_argument("--operation", help="Operation/span name filter")
+    parser.add_argument("--trace-id", help="Get all spans for a specific trace ID")
+    parser.add_argument(
+        "--time-range", type=int, default=60, help="Time range in minutes (default: 60)"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=50, help="Maximum spans to return (default: 50)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Build DataPrime query
+        # Note: Spans use serviceName, applicationName, operationName (not $l. prefix like logs)
+        query = "source spans"
+
+        if args.trace_id:
+            # Get all spans for a specific trace
+            # Use top-level traceID field (full 32-char hex string)
+            query += f" | filter traceID == '{args.trace_id}'"
+        else:
+            if args.app:
+                query += f" | filter applicationName == '{args.app}'"
+            if args.service:
+                query += f" | filter serviceName == '{args.service}'"
+            if args.operation:
+                query += f" | filter operationName ~~ '{args.operation}'"
+
+        query += f" | limit {args.limit}"
+
+        results = execute_query(query, args.time_range, limit=args.limit)
+
+        # When viewing a specific trace, sort by startTime to show request flow
+        if args.trace_id and results:
+            results.sort(key=lambda s: s.get("startTime", 0))
+
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "service": args.service,
+                        "operation": args.operation,
+                        "trace_id": args.trace_id,
+                        "time_range_minutes": args.time_range,
+                        "span_count": len(results),
+                        "spans": results,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print("🔍 Trace Search")
+            if args.trace_id:
+                print(f"Trace ID: {args.trace_id}")
+            if args.service:
+                print(f"Service: {args.service}")
+            if args.operation:
+                print(f"Operation: {args.operation}")
+            print(f"Time range: Last {args.time_range} minutes")
+            print(f"Spans found: {len(results)}")
+            print("=" * 60)
+
+            if not results:
+                print("\nNo spans found matching criteria.")
+            else:
+                for span in results[:20]:
+                    print(format_span(span))
+                    print()
+
+                if len(results) > 20:
+                    print(f"... and {len(results) - 20} more spans")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-coralogix/scripts/list_services.py
+++ b/sre-agent/.claude/skills/observability-coralogix/scripts/list_services.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""List all services (subsystems) in Coralogix.
+
+Usage:
+    python list_services.py [--time-range MINUTES] [--app APPLICATION]
+
+Examples:
+    python list_services.py
+    python list_services.py --time-range 120 --app otel-demo
+
+Environment:
+    CORALOGIX_API_KEY - Required
+    CORALOGIX_DOMAIN - Team hostname (e.g., myteam.app.cx498.coralogix.com)
+    CORALOGIX_REGION - Region code (e.g., us2, eu1)
+"""
+
+import argparse
+import json
+import sys
+
+from coralogix_client import execute_query
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List services in Coralogix")
+    parser.add_argument(
+        "--time-range", type=int, default=60, help="Time range in minutes (default: 60)"
+    )
+    parser.add_argument("--app", help="Filter by application name")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    # Build DataPrime query
+    query = "source logs"
+    if args.app:
+        query += f" | filter $l.applicationname == '{args.app}'"
+    query += " | groupby $l.subsystemname aggregate count() as log_count | orderby log_count desc | limit 50"
+
+    try:
+        results = execute_query(
+            query=query,
+            time_range_minutes=args.time_range,
+            limit=50,
+        )
+
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "time_range": f"Last {args.time_range} minutes",
+                        "application": args.app,
+                        "service_count": len(results),
+                        "services": results,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(f"Time range: Last {args.time_range} minutes")
+            if args.app:
+                print(f"Application: {args.app}")
+            print(f"Services found: {len(results)}")
+            print("-" * 60)
+            print(f"{'SERVICE':<40} {'LOG COUNT':<15}")
+            print("-" * 60)
+
+            for result in results:
+                service = (
+                    result.get("subsystemname")
+                    or result.get("$l.subsystemname")
+                    or "unknown"
+                )
+                count = result.get("log_count", 0)
+                print(f"{service:<40} {count:<15}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-coralogix/scripts/query_logs.py
+++ b/sre-agent/.claude/skills/observability-coralogix/scripts/query_logs.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Execute DataPrime queries against Coralogix.
+
+Usage:
+    python query_logs.py "<dataprime_query>" [--time-range MINUTES] [--limit N]
+
+Examples:
+    # List services
+    python query_logs.py "source logs | groupby \$l.subsystemname aggregate count() as cnt | orderby cnt desc | limit 20"
+
+    # Get errors
+    python query_logs.py "source logs | filter \$m.severity == ERROR | limit 50"
+
+Environment:
+    CORALOGIX_API_KEY - Required
+    CORALOGIX_DOMAIN - Team hostname (e.g., myteam.app.cx498.coralogix.com)
+    CORALOGIX_REGION - Region code (e.g., us2, eu1)
+"""
+
+import argparse
+import json
+import sys
+
+# Import from shared client module
+from coralogix_client import execute_query, format_log_entry
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Execute DataPrime query against Coralogix"
+    )
+    parser.add_argument("query", help="DataPrime query string")
+    parser.add_argument(
+        "--time-range", type=int, default=60, help="Time range in minutes (default: 60)"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=100, help="Result limit (default: 100)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        results = execute_query(
+            query=args.query,
+            time_range_minutes=args.time_range,
+            limit=args.limit,
+        )
+
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "query": args.query,
+                        "time_range": f"Last {args.time_range} minutes",
+                        "result_count": len(results),
+                        "results": results[: args.limit],
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(f"Query: {args.query}")
+            print(f"Time range: Last {args.time_range} minutes")
+            print(f"Results: {len(results)}")
+            print("-" * 60)
+
+            for result in results[: args.limit]:
+                # Format depends on query type
+                if isinstance(result, dict):
+                    # Check if aggregation result
+                    if any(
+                        k in result
+                        for k in ("cnt", "count", "errors", "total", "warnings")
+                    ):
+                        # Group by result - print key-value pairs
+                        for k, v in result.items():
+                            print(f"  {k}: {v}")
+                        print()
+                    else:
+                        # Log entry
+                        print(format_log_entry(result))
+                else:
+                    print(result)
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-coralogix/scripts/sample_logs.py
+++ b/sre-agent/.claude/skills/observability-coralogix/scripts/sample_logs.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Sample logs using intelligent strategies - NEVER fetch all logs.
+
+Strategies:
+- errors_only: Only ERROR/CRITICAL logs (default for incidents)
+- around_anomaly: Logs within window of specific timestamp
+- first_last: First N/2 and last N/2 logs (timeline view)
+- random: Random sample across time range
+- all: All severity levels (use with caution)
+
+Usage:
+    python sample_logs.py --strategy errors_only --service payment
+    python sample_logs.py --strategy around_anomaly --timestamp "2026-01-27T05:00:00Z" --window 60
+    python sample_logs.py --strategy first_last --service checkout --limit 50
+
+Environment:
+    CORALOGIX_API_KEY - Required
+    CORALOGIX_DOMAIN - Team hostname
+"""
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from datetime import datetime, timedelta
+
+import httpx
+from coralogix_client import execute_query, format_log_entry, get_api_url, get_headers
+
+
+def extract_log_body(log: dict) -> str:
+    """Extract the body/message from a log entry.
+
+    Handles multiple log formats:
+    - OTEL logs with nested logRecord.body
+    - Direct body field
+    - Structured logs without body (creates pattern from fields)
+    """
+    # Try nested logRecord.body (OTEL format)
+    log_record = log.get("logRecord", {})
+    if isinstance(log_record, dict):
+        body = log_record.get("body", "")
+        if body:
+            return str(body)
+
+    # Try direct body or message fields
+    body = log.get("body", log.get("message", ""))
+    if body:
+        return str(body)
+
+    # Structured logs - create pattern from key fields
+    parts = []
+    for key in [
+        "limit_event_type",
+        "limit_name",
+        "error_type",
+        "error_code",
+        "exception",
+        "error",
+    ]:
+        if key in log:
+            parts.append(f"{key}={log[key]}")
+    if parts:
+        return " ".join(parts)
+
+    return ""
+
+
+def extract_pattern_summary(logs: list[dict], top_n: int = 5) -> list[dict]:
+    """Extract top patterns from log messages.
+
+    Normalizes messages by replacing variable parts with placeholders,
+    then counts frequency of each normalized pattern.
+    """
+
+    def normalize_message(msg: str) -> str:
+        if not msg:
+            return "empty"
+
+        normalized = msg
+        # UUIDs
+        normalized = re.sub(
+            r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+            "{uuid}",
+            normalized,
+            flags=re.I,
+        )
+        # Numbers
+        normalized = re.sub(r"\b\d+\b", "{num}", normalized)
+        # IP addresses
+        normalized = re.sub(
+            r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b", "{ip}", normalized
+        )
+        # Timestamps
+        normalized = re.sub(
+            r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}", "{ts}", normalized
+        )
+        # Hex strings
+        normalized = re.sub(r"\b[0-9a-f]{16,}\b", "{hex}", normalized, flags=re.I)
+
+        return normalized[:80]
+
+    pattern_counts = Counter()
+    for log in logs:
+        msg = extract_log_body(log)
+        pattern = normalize_message(msg)
+        pattern_counts[pattern] += 1
+
+    return (
+        [
+            {"pattern": p, "count": c, "percentage": round(c / len(logs) * 100, 1)}
+            for p, c in pattern_counts.most_common(top_n)
+        ]
+        if logs
+        else []
+    )
+
+
+def sample_around_anomaly(
+    timestamp: str,
+    window_seconds: int,
+    service: str | None,
+    app: str | None,
+    limit: int,
+) -> dict:
+    """Sample logs around a specific timestamp."""
+    try:
+        ts = datetime.fromisoformat(timestamp.replace("Z", ""))
+    except ValueError:
+        return {
+            "error": f"Invalid timestamp format: {timestamp}. Use ISO format like 2026-01-27T05:00:00Z"
+        }
+
+    window_start = ts - timedelta(seconds=window_seconds)
+    window_end = ts + timedelta(seconds=window_seconds)
+
+    # Build query
+    query = "source logs"
+    if app:
+        query += f" | filter $l.applicationname == '{app}'"
+    if service:
+        query += f" | filter $l.subsystemname == '{service}'"
+    query += f" | limit {limit}"
+
+    # Custom time range
+    url = get_api_url("/api/v1/dataprime/query")
+    payload = {
+        "query": query,
+        "metadata": {
+            "startDate": window_start.isoformat() + "Z",
+            "endDate": window_end.isoformat() + "Z",
+            "tier": "TIER_FREQUENT_SEARCH",
+        },
+        "limit": limit,
+    }
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.post(url, headers=get_headers(), json=payload)
+        response.raise_for_status()
+
+        results = []
+        for line in response.text.strip().split("\n"):
+            if line.strip():
+                try:
+                    obj = json.loads(line)
+                    if "result" in obj and "results" in obj["result"]:
+                        for item in obj["result"]["results"]:
+                            # Parse userData
+                            user_data = item.get("userData", {})
+                            if isinstance(user_data, str):
+                                try:
+                                    user_data = json.loads(user_data)
+                                except json.JSONDecodeError:
+                                    user_data = {"body": user_data}
+                            results.append(user_data)
+                except json.JSONDecodeError:
+                    continue
+
+    # Categorize logs
+    logs_before = []
+    logs_at = []
+    logs_after = []
+
+    for log in results:
+        log_ts_str = log.get("timestamp", "")
+        try:
+            log_ts = datetime.fromisoformat(log_ts_str.replace("Z", ""))
+            if log_ts < ts - timedelta(seconds=2):
+                logs_before.append(log)
+            elif log_ts > ts + timedelta(seconds=2):
+                logs_after.append(log)
+            else:
+                logs_at.append(log)
+        except (ValueError, TypeError):
+            logs_at.append(log)
+
+    return {
+        "strategy": "around_anomaly",
+        "target_timestamp": timestamp,
+        "window_seconds": window_seconds,
+        "window": {
+            "start": window_start.isoformat() + "Z",
+            "end": window_end.isoformat() + "Z",
+        },
+        "logs_before": logs_before[-10:],  # Last 10 before
+        "logs_at": logs_at[:10],  # Up to 10 at target
+        "logs_after": logs_after[:10],  # First 10 after
+        "total_in_window": len(results),
+        "summary": f"{len(logs_before)} before, {len(logs_at)} at event, {len(logs_after)} after",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Sample logs using intelligent strategies"
+    )
+    parser.add_argument(
+        "--strategy",
+        choices=["errors_only", "around_anomaly", "first_last", "random", "all"],
+        default="errors_only",
+        help="Sampling strategy (default: errors_only)",
+    )
+    parser.add_argument("--service", help="Service name (subsystemname)")
+    parser.add_argument("--app", help="Application name (applicationname)")
+    parser.add_argument(
+        "--time-range", type=int, default=60, help="Time range in minutes (default: 60)"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=50, help="Maximum logs to return (default: 50)"
+    )
+    parser.add_argument(
+        "--timestamp", help="[around_anomaly] Target timestamp (ISO format)"
+    )
+    parser.add_argument(
+        "--window",
+        type=int,
+        default=60,
+        help="[around_anomaly] Window seconds (default: 60)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Handle around_anomaly specially
+        if args.strategy == "around_anomaly":
+            if not args.timestamp:
+                print(
+                    "Error: --timestamp required for around_anomaly strategy",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+            result = sample_around_anomaly(
+                args.timestamp, args.window, args.service, args.app, args.limit
+            )
+
+            if args.json:
+                print(json.dumps(result, indent=2))
+            else:
+                print("🎯 Logs Around Anomaly")
+                print(f"Target: {args.timestamp}")
+                print(f"Window: ±{args.window} seconds")
+                print("=" * 60)
+                print(f"\n{result['summary']}")
+
+                if result.get("logs_before"):
+                    print(f"\n📤 BEFORE ({len(result['logs_before'])} logs)")
+                    for log in result["logs_before"][-5:]:
+                        print(f"   {format_log_entry(log, max_body_length=100)}")
+
+                if result.get("logs_at"):
+                    print(f"\n🎯 AT TARGET ({len(result['logs_at'])} logs)")
+                    for log in result["logs_at"][:5]:
+                        print(f"   {format_log_entry(log, max_body_length=100)}")
+
+                if result.get("logs_after"):
+                    print(f"\n📥 AFTER ({len(result['logs_after'])} logs)")
+                    for log in result["logs_after"][:5]:
+                        print(f"   {format_log_entry(log, max_body_length=100)}")
+
+            return
+
+        # Build query based on strategy
+        query = "source logs"
+
+        if args.app:
+            query += f" | filter $l.applicationname == '{args.app}'"
+        if args.service:
+            query += f" | filter $l.subsystemname == '{args.service}'"
+
+        if args.strategy == "errors_only":
+            query += " | filter $m.severity == ERROR || $m.severity == CRITICAL"
+        elif args.strategy == "first_last":
+            # Get first half
+            first_query = (
+                query + f" | orderby $m.timestamp asc | limit {args.limit // 2}"
+            )
+            last_query = (
+                query + f" | orderby $m.timestamp desc | limit {args.limit // 2}"
+            )
+
+            first_results = execute_query(
+                first_query, args.time_range, limit=args.limit // 2
+            )
+            last_results = execute_query(
+                last_query, args.time_range, limit=args.limit // 2
+            )
+
+            # Combine
+            all_results = first_results + last_results
+
+            pattern_summary = extract_pattern_summary(all_results)
+
+            result = {
+                "strategy": "first_last",
+                "service": args.service,
+                "application": args.app,
+                "time_range_minutes": args.time_range,
+                "first_logs": first_results,
+                "last_logs": last_results,
+                "total_sampled": len(all_results),
+                "pattern_summary": pattern_summary,
+            }
+
+            if args.json:
+                print(json.dumps(result, indent=2))
+            else:
+                print("📊 First/Last Sample")
+                print(f"Time range: Last {args.time_range} minutes")
+                print("=" * 60)
+
+                print(f"\n🏁 FIRST {len(first_results)} LOGS")
+                for log in first_results[:10]:
+                    print(f"   {format_log_entry(log, max_body_length=100)}")
+
+                print(f"\n🏁 LAST {len(last_results)} LOGS")
+                for log in last_results[:10]:
+                    print(f"   {format_log_entry(log, max_body_length=100)}")
+
+                if pattern_summary:
+                    print("\n🔍 PATTERN SUMMARY")
+                    for p in pattern_summary:
+                        print(f"   [{p['count']}x, {p['percentage']}%] {p['pattern']}")
+
+            return
+
+        # Default: errors_only, random, or all
+        query += f" | limit {args.limit}"
+
+        results = execute_query(query, args.time_range, limit=args.limit)
+
+        # Extract pattern summary
+        pattern_summary = extract_pattern_summary(results)
+
+        result = {
+            "strategy": args.strategy,
+            "service": args.service,
+            "application": args.app,
+            "time_range_minutes": args.time_range,
+            "sample_size": len(results),
+            "logs": results,
+            "pattern_summary": pattern_summary,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            strategy_names = {
+                "errors_only": "🔴 Errors Only",
+                "random": "🎲 Random Sample",
+                "all": "📋 All Logs",
+            }
+            print(f"{strategy_names.get(args.strategy, args.strategy)}")
+            if args.service:
+                print(f"Service: {args.service}")
+            print(f"Time range: Last {args.time_range} minutes")
+            print(f"Sampled: {len(results)} logs")
+            print("=" * 60)
+
+            if not results:
+                print("\nNo logs found matching criteria.")
+            else:
+                for log in results[:20]:  # Show first 20
+                    print(format_log_entry(log, max_body_length=150))
+
+                if len(results) > 20:
+                    print(f"\n... and {len(results) - 20} more logs")
+
+            if pattern_summary:
+                print("\n🔍 PATTERN SUMMARY")
+                for p in pattern_summary:
+                    print(f"   [{p['count']}x, {p['percentage']}%] {p['pattern']}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-datadog/SKILL.md
+++ b/sre-agent/.claude/skills/observability-datadog/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: observability-datadog
+description: Datadog log and metrics analysis. Use when querying Datadog logs, metrics, or APM data. Provides scripts and query syntax reference.
+allowed-tools: Bash(python *)
+---
+
+# Datadog Analysis
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `DATADOG_API_KEY` or `DATADOG_APP_KEY` in environment variables - they won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `DATADOG_SITE` - Datadog site (e.g., `us5.datadoghq.com`, `datadoghq.eu`)
+
+---
+
+## MANDATORY: Statistics-First Investigation
+
+**NEVER dump raw logs.** Always follow this pattern:
+
+```
+STATISTICS → SAMPLE → PATTERNS → CORRELATE
+```
+
+1. **Statistics First** - Know volume, error rate, and top patterns before sampling
+2. **Strategic Sampling** - Choose the right strategy based on statistics
+3. **Pattern Extraction** - Cluster similar errors to find root causes
+4. **Context Correlation** - Investigate around anomaly timestamps
+
+## Available Scripts
+
+All scripts are in `.claude/skills/observability-datadog/scripts/`
+
+### PRIMARY INVESTIGATION SCRIPTS
+
+#### get_statistics.py - ALWAYS START HERE
+Comprehensive statistics with pattern extraction.
+```bash
+python .claude/skills/observability-datadog/scripts/get_statistics.py [--service SERVICE] [--time-range MINUTES]
+
+# Examples:
+python .claude/skills/observability-datadog/scripts/get_statistics.py --time-range 60
+python .claude/skills/observability-datadog/scripts/get_statistics.py --service payment
+```
+
+Output includes:
+- Total count, error count, error rate percentage
+- Status distribution (info, warn, error)
+- Top services by log volume
+- **Top error patterns** (crucial for quick triage)
+- Actionable recommendation
+
+#### sample_logs.py - Strategic Sampling
+Choose the right sampling strategy based on statistics.
+```bash
+python .claude/skills/observability-datadog/scripts/sample_logs.py --strategy STRATEGY [--service SERVICE] [--limit N]
+
+# Strategies:
+#   errors_only   - Only error logs (default for incidents)
+#   warnings_up   - Warning and error logs
+#   around_time   - Logs around a specific timestamp
+#   all           - All log levels
+
+# Examples:
+python .claude/skills/observability-datadog/scripts/sample_logs.py --strategy errors_only --service payment
+python .claude/skills/observability-datadog/scripts/sample_logs.py --strategy around_time --timestamp "2026-01-27T05:00:00Z" --window 5
+```
+
+---
+
+## Datadog Query Language (DQL)
+
+### Basic Filters
+```
+# Service filter
+service:payment
+
+# Status filter
+status:error
+status:warn
+
+# Host filter
+host:web-server-01
+
+# Combine with AND (space) or OR
+service:payment status:error
+service:payment OR service:checkout
+```
+
+### Facet Filters
+```
+# Tag filter
+env:production
+version:1.2.3
+
+# Attribute filter
+@http.status_code:>=500
+@duration:>1000
+
+# Wildcard
+service:payment-*
+```
+
+### Time Ranges
+```
+# Relative
+@timestamp:[now-1h TO now]
+
+# Absolute
+@timestamp:[2026-01-27T00:00:00Z TO 2026-01-27T12:00:00Z]
+```
+
+### Common Patterns
+```
+# All errors in last hour
+status:error
+
+# Errors for specific service
+service:api-gateway status:error
+
+# Slow requests (>1s)
+@duration:>1000000
+
+# HTTP 5xx errors
+@http.status_code:>=500
+
+# Exceptions
+*exception* OR *error* OR *failed*
+```
+
+---
+
+## Investigation Workflow
+
+### Standard Incident Investigation
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. STATISTICS FIRST (mandatory)                              │
+│    python get_statistics.py --service <service>              │
+│    → Know volume, error rate, top patterns                   │
+└─────────────────────────────────────────────────────────────┘
+                             │
+                             ▼
+                     High Error Rate?
+               ┌─────────────┴─────────────┐
+               │                           │
+       YES (>5%)                           NO
+               │                           │
+               ▼                           ▼
+┌─────────────────────────────┐  ┌───────────────────────────────────────────┐
+│ 2. FAST PATH                │  │ 2. TARGETED INVESTIGATION                 │
+│    Sample errors directly   │  │    Filter by specific criteria            │
+│    python sample_logs.py    │  │    python sample_logs.py --strategy all   │
+│    --strategy errors_only   │  │    → Look for anomalies                   │
+└─────────────────────────────┘  └───────────────────────────────────────────┘
+```
+
+### Quick Commands Reference
+
+| Goal | Command |
+|------|---------|
+| Start investigation | `get_statistics.py --service X` |
+| Sample errors only | `sample_logs.py --strategy errors_only --service X` |
+| Investigate spike | `sample_logs.py --strategy around_time --timestamp T` |
+| All logs | `sample_logs.py --strategy all --service X --limit 20` |
+
+---
+
+## Metrics Query Syntax
+
+### Basic Structure
+```
+aggregation:metric_name{tag_filters}
+```
+
+### Aggregations
+```
+avg:   - Average across series
+sum:   - Sum across series
+min:   - Minimum value
+max:   - Maximum value
+p50:   - 50th percentile (APM)
+p95:   - 95th percentile (APM)
+p99:   - 99th percentile (APM)
+```
+
+### Common Metrics
+```
+# System
+avg:system.cpu.user{service:X}
+avg:system.mem.used{service:X}
+
+# APM (traces)
+sum:trace.http.request.hits{service:X}.as_rate()
+sum:trace.http.request.errors{service:X}.as_rate()
+p95:trace.http.request.duration{service:X}
+```
+
+---
+
+## Anti-Patterns to Avoid
+
+1. ❌ **NEVER skip statistics** - `get_statistics.py` is MANDATORY first step
+2. ❌ **Unbounded queries** - Always specify time ranges and limits
+3. ❌ **Fetching all logs** - Use sampling strategies, not unbounded searches
+4. ❌ **Ignoring error rate** - High error rate means immediate investigation
+5. ❌ **Missing service filter** - For multi-service apps, always filter by service

--- a/sre-agent/.claude/skills/observability-datadog/scripts/__init__.py
+++ b/sre-agent/.claude/skills/observability-datadog/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Datadog observability scripts

--- a/sre-agent/.claude/skills/observability-datadog/scripts/datadog_client.py
+++ b/sre-agent/.claude/skills/observability-datadog/scripts/datadog_client.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Shared Datadog API client with proxy support.
+
+This module provides the Datadog API client that works through the credential proxy.
+Credentials are injected transparently by the proxy layer.
+
+Datadog Sites:
+- US1: api.datadoghq.com (default)
+- US3: api.us3.datadoghq.com
+- US5: api.us5.datadoghq.com
+- EU1: api.datadoghq.eu
+- AP1: api.ap1.datadoghq.com
+- GOV: api.ddog-gov.com
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+
+
+def get_config() -> dict[str, str | None]:
+    """Get Datadog configuration from environment.
+
+    Credentials are injected by the credential-proxy based on tenant context.
+
+    Environment variables:
+        OPENSRE_TENANT_ID - Tenant ID for credential lookup
+        OPENSRE_TEAM_ID - Team ID for credential lookup
+        DATADOG_SITE - Datadog site (e.g., us5.datadoghq.com)
+    """
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+        "site": os.getenv("DATADOG_SITE", "datadoghq.com"),
+    }
+
+
+def get_api_url(endpoint: str) -> str:
+    """Build the Datadog API URL.
+
+    Supports two modes:
+    1. Proxy mode (production): Uses DATADOG_BASE_URL
+    2. Direct mode (testing): Uses DATADOG_SITE to build URL
+
+    Args:
+        endpoint: API path (e.g., "/api/v2/logs/events/search")
+
+    Returns:
+        Full API URL
+    """
+    # Proxy mode (production)
+    base_url = os.getenv("DATADOG_BASE_URL")
+    if base_url:
+        return f"{base_url.rstrip('/')}{endpoint}"
+
+    # Direct mode (testing) - requires DATADOG_API_KEY
+    site = os.getenv("DATADOG_SITE", "datadoghq.com")
+    if os.getenv("DATADOG_API_KEY"):
+        return f"https://api.{site}{endpoint}"
+
+    raise RuntimeError(
+        "Either DATADOG_BASE_URL (proxy mode) or DATADOG_API_KEY (direct mode) must be set."
+    )
+
+
+def get_headers() -> dict[str, str]:
+    """Get Datadog API headers.
+
+    In proxy mode: includes tenant context for credential lookup.
+    In direct mode: includes API key and app key directly.
+    """
+    config = get_config()
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    # Direct mode - add API keys directly
+    api_key = os.getenv("DATADOG_API_KEY")
+    app_key = os.getenv("DATADOG_APP_KEY")
+    if api_key:
+        headers["DD-API-KEY"] = api_key
+        if app_key:
+            headers["DD-APPLICATION-KEY"] = app_key
+    else:
+        # Proxy mode - use JWT for credential-resolver auth
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            # Fallback for local dev
+            headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+            headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    return headers
+
+
+def search_logs(
+    query: str,
+    time_range_minutes: int = 60,
+    limit: int = 100,
+    sort: str = "timestamp",
+    sort_order: str = "desc",
+) -> list[dict[str, Any]]:
+    """Search Datadog logs.
+
+    Args:
+        query: Datadog log query (e.g., "service:api status:error")
+        time_range_minutes: Time range to query (default: 60 minutes)
+        limit: Maximum results to return (default: 100)
+        sort: Field to sort by (default: timestamp)
+        sort_order: Sort order - asc or desc (default: desc)
+
+    Returns:
+        List of log entries
+
+    Raises:
+        httpx.HTTPStatusError: On API errors
+    """
+    now = datetime.now(timezone.utc)
+    start_time = now - timedelta(minutes=time_range_minutes)
+
+    url = get_api_url("/api/v2/logs/events/search")
+
+    payload = {
+        "filter": {
+            "query": query,
+            "from": start_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "to": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        },
+        "sort": sort_order,
+        "page": {"limit": min(limit, 1000)},  # Datadog max is 1000
+    }
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.post(url, headers=get_headers(), json=payload)
+        response.raise_for_status()
+
+        data = response.json()
+        logs = []
+
+        for log in data.get("data", []):
+            attrs = log.get("attributes", {})
+            logs.append(
+                {
+                    "id": log.get("id"),
+                    "timestamp": attrs.get("timestamp"),
+                    "status": attrs.get("status"),
+                    "service": attrs.get("service"),
+                    "host": attrs.get("host"),
+                    "message": attrs.get("message"),
+                    "attributes": attrs.get("attributes", {}),
+                    "tags": attrs.get("tags", []),
+                }
+            )
+
+        return logs
+
+
+def aggregate_logs(
+    query: str,
+    group_by: list[str] | None = None,
+    time_range_minutes: int = 60,
+    compute: str = "count",
+) -> dict[str, Any]:
+    """Aggregate Datadog logs.
+
+    Args:
+        query: Datadog log query
+        group_by: Fields to group by (e.g., ["service", "status"])
+        time_range_minutes: Time range to query
+        compute: Aggregation type - count, cardinality, sum, avg, min, max
+
+    Returns:
+        Aggregation results
+
+    Raises:
+        httpx.HTTPStatusError: On API errors
+    """
+    now = datetime.now(timezone.utc)
+    start_time = now - timedelta(minutes=time_range_minutes)
+
+    url = get_api_url("/api/v2/logs/analytics/aggregate")
+
+    payload = {
+        "filter": {
+            "query": query,
+            "from": start_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "to": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        },
+        "compute": [{"aggregation": compute}],
+    }
+
+    if group_by:
+        payload["group_by"] = [{"facet": f, "limit": 50} for f in group_by]
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.post(url, headers=get_headers(), json=payload)
+        response.raise_for_status()
+        return response.json()
+
+
+def query_metrics(
+    query: str,
+    time_range_minutes: int = 60,
+) -> dict[str, Any]:
+    """Query Datadog metrics.
+
+    Args:
+        query: Datadog metric query (e.g., "avg:system.cpu.user{*}")
+        time_range_minutes: Time range to query
+
+    Returns:
+        Metric data with series
+
+    Raises:
+        httpx.HTTPStatusError: On API errors
+    """
+    now = int(datetime.now(timezone.utc).timestamp())
+    start = now - (time_range_minutes * 60)
+
+    url = get_api_url("/api/v1/query")
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.get(
+            url,
+            headers=get_headers(),
+            params={"from": start, "to": now, "query": query},
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+def format_log_entry(log: dict[str, Any], max_message_length: int = 300) -> str:
+    """Format a log entry for display.
+
+    Args:
+        log: Log entry dictionary
+        max_message_length: Maximum length for message (truncated if longer)
+
+    Returns:
+        Formatted string
+    """
+    status = log.get("status", "info").upper()
+    timestamp = log.get("timestamp", "")
+    service = log.get("service", "unknown")
+    message = log.get("message", "")
+
+    # Format timestamp
+    if "T" in str(timestamp):
+        ts = str(timestamp).split(".")[0].replace("T", " ")
+    else:
+        ts = str(timestamp)
+
+    # Truncate message
+    if len(message) > max_message_length:
+        message = message[:max_message_length] + "..."
+
+    lines = [f"[{status}] {ts} | {service}"]
+    if message:
+        lines.append(f"  {message}")
+
+    # Add host context
+    host = log.get("host")
+    if host:
+        lines.append(f"  Host: {host}")
+
+    return "\n".join(lines)

--- a/sre-agent/.claude/skills/observability-datadog/scripts/get_statistics.py
+++ b/sre-agent/.claude/skills/observability-datadog/scripts/get_statistics.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Get comprehensive log statistics from Datadog - THE MANDATORY FIRST STEP.
+
+This should ALWAYS be called before fetching raw logs. It provides:
+- Total count and error rate
+- Status distribution (info, warn, error)
+- Top services by log volume
+- Top error patterns
+- Actionable recommendations
+
+Usage:
+    python get_statistics.py [--service SERVICE] [--time-range MINUTES]
+
+Examples:
+    python get_statistics.py --time-range 60
+    python get_statistics.py --service payment
+"""
+
+import argparse
+import json
+import sys
+
+from datadog_client import aggregate_logs, search_logs
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Get comprehensive log statistics from Datadog (ALWAYS call first)"
+    )
+    parser.add_argument("--service", help="Service name to filter")
+    parser.add_argument("--host", help="Host to filter")
+    parser.add_argument(
+        "--time-range", type=int, default=60, help="Time range in minutes (default: 60)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Build base query
+        query_parts = ["*"]
+        if args.service:
+            query_parts = [f"service:{args.service}"]
+        if args.host:
+            query_parts.append(f"host:{args.host}")
+
+        base_query = " ".join(query_parts)
+
+        # 1. Get status distribution (total count by status)
+        status_result = aggregate_logs(
+            query=base_query,
+            group_by=["status"],
+            time_range_minutes=args.time_range,
+            compute="count",
+        )
+
+        # Parse status distribution
+        status_dist = {}
+        total_count = 0
+        error_count = 0
+        warn_count = 0
+
+        buckets = status_result.get("data", {}).get("buckets", [])
+        for bucket in buckets:
+            status = bucket.get("by", {}).get("status", "unknown")
+            count = bucket.get("computes", {}).get("c0", 0)
+            status_dist[status] = count
+            total_count += count
+            if status == "error":
+                error_count = count
+            elif status in ("warn", "warning"):
+                warn_count = count
+
+        error_rate = round(error_count / total_count * 100, 2) if total_count > 0 else 0
+        warn_rate = round(warn_count / total_count * 100, 2) if total_count > 0 else 0
+
+        # 2. Get top services
+        service_result = aggregate_logs(
+            query=base_query,
+            group_by=["service"],
+            time_range_minutes=args.time_range,
+            compute="count",
+        )
+
+        top_services = []
+        service_buckets = service_result.get("data", {}).get("buckets", [])
+        for bucket in service_buckets[:10]:
+            svc = bucket.get("by", {}).get("service", "unknown")
+            count = bucket.get("computes", {}).get("c0", 0)
+            top_services.append({"service": svc, "count": count})
+
+        # Sort by count descending
+        top_services.sort(key=lambda x: x["count"], reverse=True)
+
+        # 3. Get top error patterns (sample error messages)
+        error_query = f"{base_query} status:error"
+        error_logs = search_logs(
+            query=error_query,
+            time_range_minutes=args.time_range,
+            limit=50,
+        )
+
+        # Extract unique error patterns
+        from collections import Counter
+
+        error_patterns = Counter()
+        for log in error_logs:
+            msg = log.get("message", "")
+            # Normalize: remove timestamps, UUIDs, IPs, numbers for grouping
+            import re
+
+            normalized = re.sub(
+                r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
+                "<UUID>",
+                msg,
+            )
+            normalized = re.sub(
+                r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b", "<IP>", normalized
+            )
+            normalized = re.sub(r"\b\d+\b", "<NUM>", normalized)
+            normalized = normalized[:100]  # Truncate for grouping
+            error_patterns[normalized] += 1
+
+        top_error_patterns = [
+            {"pattern": pattern, "count": count}
+            for pattern, count in error_patterns.most_common(10)
+        ]
+
+        # 4. Build recommendation
+        if total_count == 0:
+            recommendation = "No logs found in the specified time range."
+        elif error_rate > 10:
+            recommendation = f"HIGH error rate ({error_rate}%). Investigate top error patterns immediately."
+        elif error_rate > 5:
+            recommendation = (
+                f"Elevated error rate ({error_rate}%). Review error patterns."
+            )
+        elif total_count > 10000:
+            recommendation = (
+                f"High volume ({total_count:,} logs). Use targeted service filter."
+            )
+        else:
+            recommendation = (
+                f"Normal volume ({total_count:,} logs). Error rate: {error_rate}%"
+            )
+
+        # Build result
+        result = {
+            "total_count": total_count,
+            "error_count": error_count,
+            "warning_count": warn_count,
+            "error_rate_percent": error_rate,
+            "warning_rate_percent": warn_rate,
+            "status_distribution": status_dist,
+            "top_services": top_services,
+            "top_error_patterns": top_error_patterns,
+            "time_range_minutes": args.time_range,
+            "query": base_query,
+            "recommendation": recommendation,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print("=" * 60)
+            print("DATADOG LOG STATISTICS")
+            print("=" * 60)
+            print(f"Query: {base_query}")
+            print(f"Time Range: {args.time_range} minutes")
+            print()
+            print(f"Total Logs: {total_count:,}")
+            print(f"Errors: {error_count:,} ({error_rate}%)")
+            print(f"Warnings: {warn_count:,} ({warn_rate}%)")
+            print()
+            print("Status Distribution:")
+            for status, count in sorted(status_dist.items(), key=lambda x: -x[1]):
+                pct = round(count / total_count * 100, 1) if total_count > 0 else 0
+                print(f"  {status}: {count:,} ({pct}%)")
+            print()
+            print("Top Services:")
+            for svc in top_services[:5]:
+                print(f"  {svc['service']}: {svc['count']:,}")
+            print()
+            if top_error_patterns:
+                print("Top Error Patterns:")
+                for pat in top_error_patterns[:5]:
+                    print(f"  [{pat['count']}x] {pat['pattern'][:80]}")
+            print()
+            print(f"Recommendation: {recommendation}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-datadog/scripts/sample_logs.py
+++ b/sre-agent/.claude/skills/observability-datadog/scripts/sample_logs.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Sample logs from Datadog using intelligent strategies.
+
+Choose the right sampling strategy based on your investigation needs.
+
+Usage:
+    python sample_logs.py --strategy STRATEGY [--service SERVICE] [--limit N]
+
+Strategies:
+    errors_only   - Only error logs (default for incidents)
+    warnings_up   - Warning and error logs
+    around_time   - Logs around a specific timestamp
+    all           - All log levels
+
+Examples:
+    python sample_logs.py --strategy errors_only --service payment
+    python sample_logs.py --strategy around_time --timestamp "2026-01-27T05:00:00Z" --window 5
+    python sample_logs.py --strategy all --service checkout --limit 20
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta
+
+from datadog_client import format_log_entry, search_logs
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Sample logs from Datadog using intelligent strategies"
+    )
+    parser.add_argument(
+        "--strategy",
+        choices=["errors_only", "warnings_up", "around_time", "all"],
+        default="errors_only",
+        help="Sampling strategy (default: errors_only)",
+    )
+    parser.add_argument("--service", help="Service name to filter")
+    parser.add_argument("--host", help="Host to filter")
+    parser.add_argument(
+        "--time-range", type=int, default=60, help="Time range in minutes (default: 60)"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=50, help="Maximum logs to return (default: 50)"
+    )
+    parser.add_argument(
+        "--timestamp",
+        help="ISO timestamp for around_time strategy (e.g., 2026-01-27T05:00:00Z)",
+    )
+    parser.add_argument(
+        "--window",
+        type=int,
+        default=5,
+        help="Window in minutes for around_time strategy (default: 5)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Build query based on strategy
+        query_parts = []
+
+        if args.service:
+            query_parts.append(f"service:{args.service}")
+        if args.host:
+            query_parts.append(f"host:{args.host}")
+
+        # Apply strategy filter
+        if args.strategy == "errors_only":
+            query_parts.append("status:error")
+        elif args.strategy == "warnings_up":
+            query_parts.append("(status:error OR status:warn)")
+
+        query = " ".join(query_parts) if query_parts else "*"
+
+        # Handle around_time strategy
+        time_range = args.time_range
+        if args.strategy == "around_time":
+            if not args.timestamp:
+                print(
+                    "Error: --timestamp required for around_time strategy",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            # Use smaller window around the timestamp
+            time_range = args.window * 2
+
+        # Fetch logs
+        logs = search_logs(
+            query=query,
+            time_range_minutes=time_range,
+            limit=args.limit,
+        )
+
+        # For around_time, filter to window around timestamp
+        if args.strategy == "around_time" and args.timestamp:
+            try:
+                target = datetime.fromisoformat(args.timestamp.replace("Z", "+00:00"))
+                window = timedelta(minutes=args.window)
+                logs = [
+                    log
+                    for log in logs
+                    if log.get("timestamp")
+                    and abs(
+                        (
+                            datetime.fromisoformat(
+                                log["timestamp"].replace("Z", "+00:00")
+                            )
+                            - target
+                        ).total_seconds()
+                    )
+                    <= window.total_seconds()
+                ]
+            except ValueError as e:
+                print(f"Error parsing timestamp: {e}", file=sys.stderr)
+                sys.exit(1)
+
+        result = {
+            "strategy": args.strategy,
+            "query": query,
+            "count": len(logs),
+            "limit": args.limit,
+            "time_range_minutes": time_range,
+            "logs": logs,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print("=" * 60)
+            print(f"DATADOG LOG SAMPLE ({args.strategy})")
+            print("=" * 60)
+            print(f"Query: {query}")
+            print(f"Found: {len(logs)} logs")
+            print()
+
+            if not logs:
+                print("No logs found matching criteria.")
+            else:
+                for log in logs:
+                    print(format_log_entry(log))
+                    print("-" * 40)
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-elasticsearch/SKILL.md
+++ b/sre-agent/.claude/skills/observability-elasticsearch/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: observability-elasticsearch
+description: Elasticsearch/OpenSearch log analysis using Lucene query syntax and Query DSL. Use when investigating issues via ELK stack, OpenSearch, or any Elasticsearch-based logging.
+allowed-tools: Bash(python *)
+---
+
+# Elasticsearch Analysis
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `ELASTICSEARCH_URL`, `ES_USER`, or `ES_PASSWORD` in environment variables - they won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+---
+
+## MANDATORY: Statistics-First Investigation
+
+**NEVER dump raw logs.** Always follow this pattern:
+
+```
+STATISTICS → SAMPLE → PATTERNS → CORRELATE
+```
+
+1. **Statistics First** - Know volume, error rate, and top patterns before sampling
+2. **Strategic Sampling** - Choose the right strategy based on statistics
+3. **Pattern Extraction** - Cluster similar errors to find root causes
+4. **Context Correlation** - Investigate around anomaly timestamps
+
+## Available Scripts
+
+All scripts are in `.claude/skills/observability-elasticsearch/scripts/`
+
+### PRIMARY INVESTIGATION SCRIPTS
+
+#### get_statistics.py - ALWAYS START HERE
+Comprehensive statistics with pattern extraction.
+```bash
+python .claude/skills/observability-elasticsearch/scripts/get_statistics.py [--index INDEX] [--time-range MINUTES]
+
+# Examples:
+python .claude/skills/observability-elasticsearch/scripts/get_statistics.py --time-range 60
+python .claude/skills/observability-elasticsearch/scripts/get_statistics.py --index logs-production
+```
+
+Output includes:
+- Total count, error count, error rate percentage
+- Status distribution (info, warn, error)
+- Top services/sources by log volume
+- **Top error patterns** (crucial for quick triage)
+- Actionable recommendation
+
+#### sample_logs.py - Strategic Sampling
+Choose the right sampling strategy based on statistics.
+```bash
+python .claude/skills/observability-elasticsearch/scripts/sample_logs.py --strategy STRATEGY [--index INDEX] [--limit N]
+
+# Strategies:
+#   errors_only   - Only error logs (default for incidents)
+#   warnings_up   - Warning and error logs
+#   around_time   - Logs around a specific timestamp
+#   all           - All log levels
+
+# Examples:
+python .claude/skills/observability-elasticsearch/scripts/sample_logs.py --strategy errors_only --index logs-production
+python .claude/skills/observability-elasticsearch/scripts/sample_logs.py --strategy around_time --timestamp "2026-01-27T05:00:00Z" --window 5
+```
+
+---
+
+## Lucene Query Syntax
+
+### Basic Searches
+
+```lucene
+# Simple term
+error
+
+# Phrase
+"connection refused"
+
+# Field search
+level:ERROR
+
+# Wildcard
+message:timeout*
+
+# Multiple terms (implicit OR)
+error warning
+
+# Required term (AND)
++error +timeout
+```
+
+### Field Queries
+
+```lucene
+# Exact match
+level:ERROR
+
+# Wildcard
+host:web-*
+
+# Range (numeric)
+status:[400 TO 599]
+
+# Range (dates)
+@timestamp:[2024-01-15T10:00:00 TO 2024-01-15T11:00:00]
+
+# Exists
+_exists_:error.stack_trace
+```
+
+### Boolean Operators
+
+```lucene
+# AND
+error AND timeout
+
+# OR
+error OR warning
+
+# NOT
+error NOT debug
+
+# Grouping
+(error OR warning) AND service:api
+```
+
+---
+
+## Query DSL (JSON)
+
+### Match Query
+
+```json
+{
+  "query": {
+    "match": {
+      "message": "connection error"
+    }
+  }
+}
+```
+
+### Term Query (Exact Match)
+
+```json
+{
+  "query": {
+    "term": {
+      "level": "ERROR"
+    }
+  }
+}
+```
+
+### Bool Query (Compound)
+
+```json
+{
+  "query": {
+    "bool": {
+      "must": [
+        {"term": {"level": "ERROR"}},
+        {"match": {"message": "timeout"}}
+      ],
+      "must_not": [
+        {"term": {"service": "healthcheck"}}
+      ],
+      "filter": [
+        {"range": {"@timestamp": {"gte": "now-1h"}}}
+      ]
+    }
+  }
+}
+```
+
+### Aggregations
+
+```json
+{
+  "size": 0,
+  "aggs": {
+    "errors_by_service": {
+      "terms": {
+        "field": "service.keyword",
+        "size": 10
+      }
+    }
+  }
+}
+```
+
+---
+
+## Investigation Workflow
+
+### Standard Incident Investigation
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. STATISTICS FIRST (mandatory)                              │
+│    python get_statistics.py --index <index>                  │
+│    → Know volume, error rate, top patterns                   │
+└─────────────────────────────────────────────────────────────┘
+                             │
+                             ▼
+                     High Error Rate?
+               ┌─────────────┴─────────────┐
+               │                           │
+       YES (>5%)                           NO
+               │                           │
+               ▼                           ▼
+┌─────────────────────────────┐  ┌───────────────────────────────────────────┐
+│ 2. FAST PATH                │  │ 2. TARGETED INVESTIGATION                 │
+│    Sample errors directly   │  │    Filter by specific criteria            │
+│    python sample_logs.py    │  │    python sample_logs.py --strategy all   │
+│    --strategy errors_only   │  │    → Look for anomalies                   │
+└─────────────────────────────┘  └───────────────────────────────────────────┘
+```
+
+### Quick Commands Reference
+
+| Goal | Command |
+|------|---------|
+| Start investigation | `get_statistics.py --index X` |
+| Sample errors only | `sample_logs.py --strategy errors_only --index X` |
+| Investigate spike | `sample_logs.py --strategy around_time --timestamp T` |
+| All logs | `sample_logs.py --strategy all --index X --limit 20` |
+
+---
+
+## Common Aggregation Patterns
+
+### Errors Over Time
+
+```json
+{
+  "size": 0,
+  "query": {"term": {"level": "ERROR"}},
+  "aggs": {
+    "errors_over_time": {
+      "date_histogram": {
+        "field": "@timestamp",
+        "fixed_interval": "5m"
+      }
+    }
+  }
+}
+```
+
+### Top Error Messages
+
+```json
+{
+  "size": 0,
+  "query": {"term": {"level": "ERROR"}},
+  "aggs": {
+    "top_errors": {
+      "terms": {
+        "field": "message.keyword",
+        "size": 10
+      }
+    }
+  }
+}
+```
+
+### Nested Aggregation (Errors by Service, then by Message)
+
+```json
+{
+  "size": 0,
+  "aggs": {
+    "by_service": {
+      "terms": {"field": "service.keyword", "size": 10},
+      "aggs": {
+        "by_message": {
+          "terms": {"field": "message.keyword", "size": 5}
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## Field Types
+
+### Keyword vs Text
+
+- **keyword**: Exact match, aggregatable (`service.keyword`)
+- **text**: Full-text search, not aggregatable (`message`)
+
+```json
+// For aggregation, use .keyword suffix
+"terms": {"field": "service.keyword"}
+
+// For full-text search, use text field
+"match": {"message": "connection error"}
+```
+
+---
+
+## Anti-Patterns to Avoid
+
+1. ❌ **NEVER skip statistics** - `get_statistics.py` is MANDATORY first step
+2. ❌ **Unbounded queries** - Always specify time ranges and limits
+3. ❌ **Fetching all logs** - Use sampling strategies, not unbounded searches
+4. ❌ **Ignoring error rate** - High error rate means immediate investigation
+5. ❌ **Text field in aggregation** - Use `.keyword` suffix for terms aggs
+6. ❌ **Wildcard prefix** - `*error` is expensive, prefer `error*` or exact match

--- a/sre-agent/.claude/skills/observability-elasticsearch/scripts/__init__.py
+++ b/sre-agent/.claude/skills/observability-elasticsearch/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Elasticsearch observability scripts

--- a/sre-agent/.claude/skills/observability-elasticsearch/scripts/elasticsearch_client.py
+++ b/sre-agent/.claude/skills/observability-elasticsearch/scripts/elasticsearch_client.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Shared Elasticsearch client with proxy support.
+
+This module provides the Elasticsearch client that works through the credential proxy.
+Credentials are injected transparently by the proxy layer.
+
+Works with Elasticsearch 7.x, 8.x, and 9.x via REST API.
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+
+
+def get_config() -> dict[str, str | None]:
+    """Get Elasticsearch configuration from environment.
+
+    Credentials are injected by the credential-proxy based on tenant context.
+
+    Environment variables:
+        OPENSRE_TENANT_ID - Tenant ID for credential lookup
+        OPENSRE_TEAM_ID - Team ID for credential lookup
+        ELASTICSEARCH_INDEX - Default index pattern (e.g., logs-*)
+    """
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+        "index_pattern": os.getenv("ELASTICSEARCH_INDEX", "logs-*"),
+    }
+
+
+def get_api_url(endpoint: str) -> str:
+    """Build the Elasticsearch API URL.
+
+    Supports two modes:
+    1. Proxy mode (production): Uses ELASTICSEARCH_BASE_URL
+    2. Direct mode (testing): Uses ELASTICSEARCH_URL
+
+    Args:
+        endpoint: API path (e.g., "/logs-*/_search")
+
+    Returns:
+        Full API URL
+    """
+    # Proxy mode (production)
+    base_url = os.getenv("ELASTICSEARCH_BASE_URL")
+    if base_url:
+        return f"{base_url.rstrip('/')}{endpoint}"
+
+    # Direct mode (testing)
+    direct_url = os.getenv("ELASTICSEARCH_URL")
+    if direct_url:
+        return f"{direct_url.rstrip('/')}{endpoint}"
+
+    raise RuntimeError(
+        "Either ELASTICSEARCH_BASE_URL (proxy mode) or ELASTICSEARCH_URL (direct mode) must be set."
+    )
+
+
+def get_headers() -> dict[str, str]:
+    """Get Elasticsearch API headers.
+
+    Supports multiple auth methods (checked in order):
+    1. API Key (Elastic Cloud / Enterprise) - ES_API_KEY or ELASTICSEARCH_API_KEY
+    2. Basic auth - ES_USER + ES_PASSWORD
+    3. Bearer token - ES_TOKEN or ELASTICSEARCH_TOKEN
+    4. Proxy mode - tenant context headers
+
+    Environment variables:
+        ES_API_KEY / ELASTICSEARCH_API_KEY: API key (id:secret or encoded)
+        ES_USER / ELASTICSEARCH_USER: Username for basic auth
+        ES_PASSWORD / ELASTICSEARCH_PASSWORD: Password for basic auth
+        ES_TOKEN / ELASTICSEARCH_TOKEN: Bearer token
+    """
+    config = get_config()
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    import base64
+
+    # Priority 1: API Key (Elastic Cloud / Enterprise pattern)
+    api_key = os.getenv("ES_API_KEY") or os.getenv("ELASTICSEARCH_API_KEY")
+    if api_key:
+        # API key can be provided as "id:secret" or already base64 encoded
+        if ":" in api_key:
+            encoded = base64.b64encode(api_key.encode()).decode()
+        else:
+            encoded = api_key  # Assume already encoded
+        headers["Authorization"] = f"ApiKey {encoded}"
+        return headers
+
+    # Priority 2: Basic auth (user:password)
+    user = os.getenv("ES_USER") or os.getenv("ELASTICSEARCH_USER")
+    password = os.getenv("ES_PASSWORD") or os.getenv("ELASTICSEARCH_PASSWORD")
+    if user and password:
+        auth = base64.b64encode(f"{user}:{password}".encode()).decode()
+        headers["Authorization"] = f"Basic {auth}"
+        return headers
+
+    # Priority 3: Bearer token
+    token = os.getenv("ES_TOKEN") or os.getenv("ELASTICSEARCH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+        return headers
+
+    # Priority 4: Proxy mode - use JWT for credential-resolver auth
+    if os.getenv("ELASTICSEARCH_BASE_URL"):
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            # Fallback for local dev
+            headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+            headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    # No auth (local ES without security)
+    return headers
+
+
+def search(
+    query: dict[str, Any],
+    index: str | None = None,
+    size: int = 100,
+    sort: list[dict] | None = None,
+) -> dict[str, Any]:
+    """Execute an Elasticsearch search query.
+
+    Args:
+        query: Elasticsearch query DSL (the "query" part)
+        index: Index pattern (default: from config)
+        size: Maximum results to return (default: 100)
+        sort: Sort specification (default: @timestamp desc)
+
+    Returns:
+        Search response with hits
+
+    Raises:
+        httpx.HTTPStatusError: On API errors
+    """
+    config = get_config()
+    index = index or config.get("index_pattern", "logs-*")
+
+    url = get_api_url(f"/{index}/_search")
+
+    body = {
+        "query": query,
+        "size": size,
+        "sort": sort or [{"@timestamp": {"order": "desc"}}],
+    }
+
+    _verify_tls = os.getenv("ES_VERIFY_TLS", "true").lower() not in ("false", "0", "no")
+    with httpx.Client(timeout=60.0, verify=_verify_tls) as client:
+        response = client.post(url, headers=get_headers(), json=body)
+        response.raise_for_status()
+        return response.json()
+
+
+def aggregate(
+    query: dict[str, Any],
+    aggs: dict[str, Any],
+    index: str | None = None,
+    size: int = 0,
+) -> dict[str, Any]:
+    """Execute an Elasticsearch aggregation query.
+
+    Args:
+        query: Elasticsearch query DSL
+        aggs: Aggregation specification
+        index: Index pattern
+        size: Number of hits to return (default: 0 for aggs only)
+
+    Returns:
+        Search response with aggregations
+
+    Raises:
+        httpx.HTTPStatusError: On API errors
+    """
+    config = get_config()
+    index = index or config.get("index_pattern", "logs-*")
+
+    url = get_api_url(f"/{index}/_search")
+
+    body = {
+        "query": query,
+        "aggs": aggs,
+        "size": size,
+    }
+
+    _verify_tls = os.getenv("ES_VERIFY_TLS", "true").lower() not in ("false", "0", "no")
+    with httpx.Client(timeout=60.0, verify=_verify_tls) as client:
+        response = client.post(url, headers=get_headers(), json=body)
+        response.raise_for_status()
+        return response.json()
+
+
+def build_time_range_query(
+    time_range_minutes: int = 60,
+    filters: list[dict] | None = None,
+) -> dict[str, Any]:
+    """Build a time-range filtered query.
+
+    Args:
+        time_range_minutes: Time range to query
+        filters: Additional filter clauses
+
+    Returns:
+        Elasticsearch bool query
+    """
+    now = datetime.now(timezone.utc)
+    start_time = now - timedelta(minutes=time_range_minutes)
+
+    must_clauses = [
+        {
+            "range": {
+                "@timestamp": {
+                    "gte": start_time.isoformat(),
+                    "lte": now.isoformat(),
+                }
+            }
+        }
+    ]
+
+    if filters:
+        must_clauses.extend(filters)
+
+    return {"bool": {"must": must_clauses}}
+
+
+def format_log_entry(hit: dict[str, Any], max_message_length: int = 300) -> str:
+    """Format an Elasticsearch hit for display.
+
+    Args:
+        hit: Elasticsearch hit document
+        max_message_length: Maximum length for message
+
+    Returns:
+        Formatted string
+    """
+    source = hit.get("_source", {})
+
+    # Common field names for log level
+    level = (
+        source.get("level")
+        or source.get("log.level")
+        or source.get("severity")
+        or source.get("log_level")
+        or "INFO"
+    )
+
+    # Common field names for timestamp
+    timestamp = source.get("@timestamp") or source.get("timestamp") or ""
+
+    # Common field names for service/application
+    service = (
+        source.get("service.name")
+        or source.get("service")
+        or source.get("application")
+        or source.get("kubernetes.container.name")
+        or "unknown"
+    )
+
+    # Common field names for message
+    message = source.get("message") or source.get("log") or source.get("msg") or ""
+
+    # Format timestamp
+    if "T" in str(timestamp):
+        ts = str(timestamp).split(".")[0].replace("T", " ")
+    else:
+        ts = str(timestamp)
+
+    # Truncate message
+    if len(message) > max_message_length:
+        message = message[:max_message_length] + "..."
+
+    lines = [f"[{str(level).upper()}] {ts} | {service}"]
+    if message:
+        lines.append(f"  {message}")
+
+    # Add Kubernetes context if available
+    k8s = source.get("kubernetes", {})
+    if isinstance(k8s, dict):
+        pod = k8s.get("pod", {}).get("name") or k8s.get("pod_name")
+        namespace = k8s.get("namespace")
+        if pod or namespace:
+            ctx = []
+            if namespace:
+                ctx.append(f"ns={namespace}")
+            if pod:
+                ctx.append(f"pod={pod}")
+            lines.append(f"  K8s: {', '.join(ctx)}")
+
+    return "\n".join(lines)

--- a/sre-agent/.claude/skills/observability-elasticsearch/scripts/get_statistics.py
+++ b/sre-agent/.claude/skills/observability-elasticsearch/scripts/get_statistics.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Get comprehensive log statistics from Elasticsearch - THE MANDATORY FIRST STEP.
+
+This should ALWAYS be called before fetching raw logs. It provides:
+- Total count and error rate
+- Log level distribution
+- Top services/applications
+- Top error patterns
+- Actionable recommendations
+
+Usage:
+    python get_statistics.py [--service SERVICE] [--index INDEX] [--time-range MINUTES]
+
+Examples:
+    python get_statistics.py --time-range 60
+    python get_statistics.py --service payment --index logs-prod-*
+"""
+
+import argparse
+import json
+import sys
+
+from elasticsearch_client import (
+    aggregate,
+    build_time_range_query,
+    search,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Get comprehensive log statistics from Elasticsearch (ALWAYS call first)"
+    )
+    parser.add_argument("--service", help="Service name to filter")
+    parser.add_argument("--index", help="Index pattern (default: logs-*)")
+    parser.add_argument(
+        "--time-range", type=int, default=60, help="Time range in minutes (default: 60)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Build base query with time range
+        filters = []
+        if args.service:
+            # Try multiple common service field names
+            filters.append(
+                {
+                    "bool": {
+                        "should": [
+                            {"term": {"service.name": args.service}},
+                            {"term": {"service": args.service}},
+                            {"term": {"application": args.service}},
+                            {"term": {"kubernetes.container.name": args.service}},
+                        ],
+                        "minimum_should_match": 1,
+                    }
+                }
+            )
+
+        query = build_time_range_query(args.time_range, filters)
+
+        # 1. Get level distribution with total count
+        level_aggs = {
+            "level_distribution": {
+                "terms": {
+                    "field": "level.keyword",
+                    "size": 20,
+                    "missing": "INFO",
+                }
+            },
+            "level_alt": {
+                "terms": {
+                    "field": "log.level.keyword",
+                    "size": 20,
+                    "missing": "INFO",
+                }
+            },
+        }
+
+        level_result = aggregate(query, level_aggs, index=args.index)
+
+        total_count = level_result.get("hits", {}).get("total", {})
+        if isinstance(total_count, dict):
+            total_count = total_count.get("value", 0)
+
+        # Parse level distribution (use whichever field has data)
+        level_dist = {}
+        error_count = 0
+        warn_count = 0
+
+        # Try primary level field
+        buckets = (
+            level_result.get("aggregations", {})
+            .get("level_distribution", {})
+            .get("buckets", [])
+        )
+        if not buckets:
+            buckets = (
+                level_result.get("aggregations", {})
+                .get("level_alt", {})
+                .get("buckets", [])
+            )
+
+        for bucket in buckets:
+            level = bucket.get("key", "unknown")
+            count = bucket.get("doc_count", 0)
+            level_dist[level] = count
+            if level.lower() in ("error", "err", "critical", "fatal"):
+                error_count += count
+            elif level.lower() in ("warn", "warning"):
+                warn_count += count
+
+        error_rate = round(error_count / total_count * 100, 2) if total_count > 0 else 0
+        warn_rate = round(warn_count / total_count * 100, 2) if total_count > 0 else 0
+
+        # 2. Get top services
+        service_aggs = {
+            "services": {
+                "terms": {
+                    "field": "service.name.keyword",
+                    "size": 10,
+                }
+            },
+            "services_alt": {
+                "terms": {
+                    "field": "kubernetes.container.name.keyword",
+                    "size": 10,
+                }
+            },
+        }
+
+        service_result = aggregate(query, service_aggs, index=args.index)
+
+        top_services = []
+        buckets = (
+            service_result.get("aggregations", {})
+            .get("services", {})
+            .get("buckets", [])
+        )
+        if not buckets:
+            buckets = (
+                service_result.get("aggregations", {})
+                .get("services_alt", {})
+                .get("buckets", [])
+            )
+
+        for bucket in buckets:
+            top_services.append(
+                {
+                    "service": bucket.get("key"),
+                    "count": bucket.get("doc_count", 0),
+                }
+            )
+
+        # 3. Get sample error messages for pattern analysis
+        error_query = build_time_range_query(
+            args.time_range,
+            filters
+            + [
+                {
+                    "bool": {
+                        "should": [
+                            {
+                                "terms": {
+                                    "level.keyword": [
+                                        "error",
+                                        "ERROR",
+                                        "Error",
+                                        "critical",
+                                        "CRITICAL",
+                                        "fatal",
+                                        "FATAL",
+                                    ]
+                                }
+                            },
+                            {
+                                "terms": {
+                                    "log.level.keyword": [
+                                        "error",
+                                        "ERROR",
+                                        "Error",
+                                        "critical",
+                                        "CRITICAL",
+                                        "fatal",
+                                        "FATAL",
+                                    ]
+                                }
+                            },
+                        ],
+                        "minimum_should_match": 1,
+                    }
+                }
+            ],
+        )
+
+        error_result = search(error_query, index=args.index, size=50)
+        error_hits = error_result.get("hits", {}).get("hits", [])
+
+        # Extract unique error patterns
+        import re
+        from collections import Counter
+
+        error_patterns = Counter()
+
+        for hit in error_hits:
+            source = hit.get("_source", {})
+            msg = source.get("message") or source.get("log") or source.get("msg") or ""
+            # Normalize variable parts
+            normalized = re.sub(
+                r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
+                "<UUID>",
+                str(msg),
+            )
+            normalized = re.sub(
+                r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b", "<IP>", normalized
+            )
+            normalized = re.sub(r"\b\d+\b", "<NUM>", normalized)
+            normalized = normalized[:100]
+            error_patterns[normalized] += 1
+
+        top_error_patterns = [
+            {"pattern": pattern, "count": count}
+            for pattern, count in error_patterns.most_common(10)
+        ]
+
+        # 4. Build recommendation
+        if total_count == 0:
+            recommendation = "No logs found in the specified time range."
+        elif error_rate > 10:
+            recommendation = f"HIGH error rate ({error_rate}%). Investigate top error patterns immediately."
+        elif error_rate > 5:
+            recommendation = (
+                f"Elevated error rate ({error_rate}%). Review error patterns."
+            )
+        elif total_count > 100000:
+            recommendation = (
+                f"Very high volume ({total_count:,} logs). Use targeted service filter."
+            )
+        else:
+            recommendation = (
+                f"Normal volume ({total_count:,} logs). Error rate: {error_rate}%"
+            )
+
+        # Build result
+        result = {
+            "total_count": total_count,
+            "error_count": error_count,
+            "warning_count": warn_count,
+            "error_rate_percent": error_rate,
+            "warning_rate_percent": warn_rate,
+            "level_distribution": level_dist,
+            "top_services": top_services,
+            "top_error_patterns": top_error_patterns,
+            "time_range_minutes": args.time_range,
+            "index": args.index or "logs-*",
+            "recommendation": recommendation,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print("=" * 60)
+            print("ELASTICSEARCH LOG STATISTICS")
+            print("=" * 60)
+            print(f"Index: {args.index or 'logs-*'}")
+            print(f"Time Range: {args.time_range} minutes")
+            print()
+            print(f"Total Logs: {total_count:,}")
+            print(f"Errors: {error_count:,} ({error_rate}%)")
+            print(f"Warnings: {warn_count:,} ({warn_rate}%)")
+            print()
+            print("Level Distribution:")
+            for level, count in sorted(level_dist.items(), key=lambda x: -x[1]):
+                pct = round(count / total_count * 100, 1) if total_count > 0 else 0
+                print(f"  {level}: {count:,} ({pct}%)")
+            print()
+            if top_services:
+                print("Top Services:")
+                for svc in top_services[:5]:
+                    print(f"  {svc['service']}: {svc['count']:,}")
+                print()
+            if top_error_patterns:
+                print("Top Error Patterns:")
+                for pat in top_error_patterns[:5]:
+                    print(f"  [{pat['count']}x] {pat['pattern'][:80]}")
+                print()
+            print(f"Recommendation: {recommendation}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-elasticsearch/scripts/sample_logs.py
+++ b/sre-agent/.claude/skills/observability-elasticsearch/scripts/sample_logs.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Sample logs from Elasticsearch using intelligent strategies.
+
+Choose the right sampling strategy based on your investigation needs.
+
+Usage:
+    python sample_logs.py --strategy STRATEGY [--service SERVICE] [--index INDEX] [--limit N]
+
+Strategies:
+    errors_only   - Only error logs (default for incidents)
+    warnings_up   - Warning and error logs
+    around_time   - Logs around a specific timestamp
+    all           - All log levels
+
+Examples:
+    python sample_logs.py --strategy errors_only --service payment
+    python sample_logs.py --strategy around_time --timestamp "2026-01-27T05:00:00Z" --window 5
+    python sample_logs.py --strategy all --index logs-prod-* --limit 20
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta
+
+from elasticsearch_client import (
+    build_time_range_query,
+    format_log_entry,
+    search,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Sample logs from Elasticsearch using intelligent strategies"
+    )
+    parser.add_argument(
+        "--strategy",
+        choices=["errors_only", "warnings_up", "around_time", "all"],
+        default="errors_only",
+        help="Sampling strategy (default: errors_only)",
+    )
+    parser.add_argument("--service", help="Service name to filter")
+    parser.add_argument("--index", help="Index pattern (default: logs-*)")
+    parser.add_argument(
+        "--time-range", type=int, default=60, help="Time range in minutes (default: 60)"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=50, help="Maximum logs to return (default: 50)"
+    )
+    parser.add_argument(
+        "--timestamp",
+        help="ISO timestamp for around_time strategy (e.g., 2026-01-27T05:00:00Z)",
+    )
+    parser.add_argument(
+        "--window",
+        type=int,
+        default=5,
+        help="Window in minutes for around_time strategy (default: 5)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Build filters based on strategy and options
+        filters = []
+
+        # Service filter
+        if args.service:
+            filters.append(
+                {
+                    "bool": {
+                        "should": [
+                            {"term": {"service.name": args.service}},
+                            {"term": {"service": args.service}},
+                            {"term": {"application": args.service}},
+                            {"term": {"kubernetes.container.name": args.service}},
+                        ],
+                        "minimum_should_match": 1,
+                    }
+                }
+            )
+
+        # Strategy-based level filter
+        if args.strategy == "errors_only":
+            filters.append(
+                {
+                    "bool": {
+                        "should": [
+                            {
+                                "terms": {
+                                    "level.keyword": [
+                                        "error",
+                                        "ERROR",
+                                        "Error",
+                                        "critical",
+                                        "CRITICAL",
+                                        "fatal",
+                                        "FATAL",
+                                    ]
+                                }
+                            },
+                            {
+                                "terms": {
+                                    "log.level.keyword": [
+                                        "error",
+                                        "ERROR",
+                                        "Error",
+                                        "critical",
+                                        "CRITICAL",
+                                        "fatal",
+                                        "FATAL",
+                                    ]
+                                }
+                            },
+                        ],
+                        "minimum_should_match": 1,
+                    }
+                }
+            )
+        elif args.strategy == "warnings_up":
+            filters.append(
+                {
+                    "bool": {
+                        "should": [
+                            {
+                                "terms": {
+                                    "level.keyword": [
+                                        "warn",
+                                        "WARN",
+                                        "warning",
+                                        "WARNING",
+                                        "error",
+                                        "ERROR",
+                                        "critical",
+                                        "CRITICAL",
+                                    ]
+                                }
+                            },
+                            {
+                                "terms": {
+                                    "log.level.keyword": [
+                                        "warn",
+                                        "WARN",
+                                        "warning",
+                                        "WARNING",
+                                        "error",
+                                        "ERROR",
+                                        "critical",
+                                        "CRITICAL",
+                                    ]
+                                }
+                            },
+                        ],
+                        "minimum_should_match": 1,
+                    }
+                }
+            )
+
+        # Handle around_time strategy
+        time_range = args.time_range
+        if args.strategy == "around_time":
+            if not args.timestamp:
+                print(
+                    "Error: --timestamp required for around_time strategy",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            try:
+                target = datetime.fromisoformat(args.timestamp.replace("Z", "+00:00"))
+                window = timedelta(minutes=args.window)
+                start = target - window
+                end = target + window
+
+                # Override time range filter
+                filters = [
+                    f for f in filters if "range" not in str(f)
+                ]  # Remove default time range
+                filters.append(
+                    {
+                        "range": {
+                            "@timestamp": {
+                                "gte": start.isoformat(),
+                                "lte": end.isoformat(),
+                            }
+                        }
+                    }
+                )
+                time_range = args.window * 2
+            except ValueError as e:
+                print(f"Error parsing timestamp: {e}", file=sys.stderr)
+                sys.exit(1)
+
+        # Build query
+        if args.strategy != "around_time":
+            query = build_time_range_query(time_range, filters)
+        else:
+            query = {"bool": {"must": filters}} if filters else {"match_all": {}}
+
+        # Execute search
+        response = search(query, index=args.index, size=args.limit)
+
+        hits = response.get("hits", {}).get("hits", [])
+
+        # Extract log data
+        logs = []
+        for hit in hits:
+            source = hit.get("_source", {})
+            logs.append(
+                {
+                    "id": hit.get("_id"),
+                    "index": hit.get("_index"),
+                    "timestamp": source.get("@timestamp"),
+                    "level": source.get("level") or source.get("log.level") or "INFO",
+                    "service": source.get("service.name")
+                    or source.get("service")
+                    or source.get("kubernetes.container.name"),
+                    "message": source.get("message")
+                    or source.get("log")
+                    or source.get("msg"),
+                    "source": source,
+                }
+            )
+
+        result = {
+            "strategy": args.strategy,
+            "index": args.index or "logs-*",
+            "count": len(logs),
+            "limit": args.limit,
+            "time_range_minutes": time_range,
+            "logs": logs,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2, default=str))
+        else:
+            print("=" * 60)
+            print(f"ELASTICSEARCH LOG SAMPLE ({args.strategy})")
+            print("=" * 60)
+            print(f"Index: {args.index or 'logs-*'}")
+            print(f"Found: {len(logs)} logs")
+            print()
+
+            if not logs:
+                print("No logs found matching criteria.")
+            else:
+                for hit in hits:
+                    print(format_log_entry(hit))
+                    print("-" * 40)
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-grafana/SKILL.md
+++ b/sre-agent/.claude/skills/observability-grafana/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: observability-grafana
+description: Grafana dashboard and metrics analysis. Use when querying dashboards, panels, Prometheus metrics via Grafana, checking datasources, reviewing alerts, or creating dashboards from templates.
+allowed-tools: Bash(python *)
+---
+
+# Grafana Dashboard Analysis
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `GRAFANA_API_KEY` in environment variables - it won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `GRAFANA_URL` - Grafana instance URL (e.g., `https://grafana.company.com`)
+
+---
+
+## Available Scripts
+
+All scripts are in `.claude/skills/observability-grafana/scripts/`
+
+### list_dashboards.py - Search/List Dashboards
+```bash
+python .claude/skills/observability-grafana/scripts/list_dashboards.py [--query "kubernetes"]
+```
+
+### get_dashboard.py - Get Dashboard Details
+```bash
+python .claude/skills/observability-grafana/scripts/get_dashboard.py --uid DASHBOARD_UID
+```
+
+### query_prometheus.py - Query Prometheus via Grafana
+```bash
+python .claude/skills/observability-grafana/scripts/query_prometheus.py --query "PROMQL" [--time-range 60] [--step 1m] [--datasource-id ID]
+
+# Examples (auto-detects Prometheus datasource):
+python .claude/skills/observability-grafana/scripts/query_prometheus.py --query "rate(http_requests_total[5m])"
+python .claude/skills/observability-grafana/scripts/query_prometheus.py --query "up{job='api'}" --time-range 120
+
+# Explicit datasource ID (use list_datasources.py to find it):
+python .claude/skills/observability-grafana/scripts/query_prometheus.py --query "up" --datasource-id 8
+```
+**Note**: The Prometheus datasource ID is auto-detected by default. Use `list_datasources.py` if you need to target a specific datasource.
+
+### list_datasources.py - List Configured Datasources
+```bash
+python .claude/skills/observability-grafana/scripts/list_datasources.py
+```
+
+### get_alerts.py - Get Active Alerts
+```bash
+python .claude/skills/observability-grafana/scripts/get_alerts.py
+```
+
+### create_dashboard.py - Create Dashboard from Template
+```bash
+python .claude/skills/observability-grafana/scripts/create_dashboard.py \
+  --title "My Dashboard" \
+  --template .claude/skills/observability-grafana/templates/vercel-overview.json
+
+# With folder:
+python .claude/skills/observability-grafana/scripts/create_dashboard.py \
+  --title "My Dashboard" \
+  --template .claude/skills/observability-grafana/templates/vercel-overview.json \
+  --folder-uid FOLDER_UID
+
+# Overwrite existing:
+python .claude/skills/observability-grafana/scripts/create_dashboard.py \
+  --title "My Dashboard" \
+  --template .claude/skills/observability-grafana/templates/vercel-overview.json \
+  --overwrite
+```
+
+---
+
+## Dashboard Templates
+
+Pre-built templates are in `.claude/skills/observability-grafana/templates/`:
+
+| Template | Description |
+|----------|-------------|
+| `vercel-overview.json` | 4-panel Vercel monitoring: error count, error rate, log stream, request summary |
+
+---
+
+## PromQL Quick Reference
+
+```promql
+# Request rate
+rate(http_requests_total{service="api"}[5m])
+
+# Error rate %
+sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total[5m])) * 100
+
+# P95 latency
+histogram_quantile(0.95, rate(http_duration_seconds_bucket{service="api"}[5m]))
+
+# CPU usage
+rate(process_cpu_seconds_total{service="api"}[5m])
+```
+
+---
+
+## Investigation Workflow
+
+```
+1. list_datasources.py                    # Find available datasources
+2. list_dashboards.py --query "api"       # Find relevant dashboards
+3. get_dashboard.py --uid <uid>           # Get dashboard details
+4. query_prometheus.py --query "rate(http_requests_total{service='api',status=~'5..'}[5m])"
+5. get_alerts.py                          # Check active alerts
+```

--- a/sre-agent/.claude/skills/observability-grafana/scripts/create_dashboard.py
+++ b/sre-agent/.claude/skills/observability-grafana/scripts/create_dashboard.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Create a Grafana dashboard from a JSON template.
+
+Usage:
+    python create_dashboard.py --title "My Dashboard" --template path/to/template.json
+    python create_dashboard.py --title "My Dashboard" --template path/to/template.json --folder-uid abc123
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from grafana_client import grafana_request
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Create a Grafana dashboard from a template"
+    )
+    parser.add_argument("--title", required=True, help="Dashboard title")
+    parser.add_argument(
+        "--template", required=True, help="Path to dashboard JSON template"
+    )
+    parser.add_argument(
+        "--folder-uid", help="Grafana folder UID to create dashboard in"
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite if dashboard with same title exists",
+    )
+    args = parser.parse_args()
+
+    # Read template
+    template_path = Path(args.template)
+    if not template_path.exists():
+        print(f"ERROR: Template file not found: {template_path}")
+        sys.exit(1)
+
+    with open(template_path) as f:
+        dashboard = json.load(f)
+
+    # Override title
+    dashboard["title"] = args.title
+    # Reset id and uid so Grafana creates a new dashboard
+    dashboard.pop("id", None)
+    dashboard.pop("uid", None)
+    dashboard.pop("version", None)
+
+    # Build request payload
+    payload = {
+        "dashboard": dashboard,
+        "overwrite": args.overwrite,
+    }
+    if args.folder_uid:
+        payload["folderUid"] = args.folder_uid
+
+    result = grafana_request("POST", "api/dashboards/db", json_body=payload)
+
+    print("Dashboard created successfully!")
+    print(f"  ID: {result.get('id')}")
+    print(f"  UID: {result.get('uid')}")
+    print(f"  URL: {result.get('url')}")
+    print(f"  Status: {result.get('status')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-grafana/scripts/get_alerts.py
+++ b/sre-agent/.claude/skills/observability-grafana/scripts/get_alerts.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Get active Grafana alerts.
+
+Supports both legacy alerting (/api/alerts) and unified alerting
+(/api/alertmanager/grafana/api/v2/alerts) used by Grafana Cloud.
+
+Usage:
+    python get_alerts.py
+"""
+
+import argparse
+import json
+import sys
+
+from grafana_client import grafana_request
+
+
+def get_unified_alerts():
+    """Try unified alerting API (Grafana Cloud / Grafana 9+)."""
+    data = grafana_request("GET", "api/alertmanager/grafana/api/v2/alerts")
+    return [
+        {
+            "name": a.get("labels", {}).get("alertname", "?"),
+            "state": a.get("status", {}).get("state", "?"),
+            "severity": a.get("labels", {}).get("severity", ""),
+            "summary": a.get("annotations", {}).get("summary", ""),
+            "starts_at": a.get("startsAt", ""),
+        }
+        for a in data[:50]
+    ]
+
+
+def get_legacy_alerts():
+    """Try legacy alerting API (Grafana < 9)."""
+    data = grafana_request("GET", "api/alerts")
+    return [
+        {
+            "id": a.get("id"),
+            "name": a.get("name"),
+            "state": a.get("state"),
+            "dashboard_uid": a.get("dashboardUid"),
+            "panel_id": a.get("panelId"),
+        }
+        for a in data[:50]
+    ]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Grafana alerts")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Try unified alerting first (Grafana Cloud), fall back to legacy
+        try:
+            alerts = get_unified_alerts()
+        except Exception:
+            alerts = get_legacy_alerts()
+
+        result = {"ok": True, "alerts": alerts, "count": len(alerts)}
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Grafana Alerts ({len(alerts)})")
+            if not alerts:
+                print("  No active alerts")
+            for a in alerts:
+                state = a.get("state", "?").upper()
+                name = a.get("name", "?")
+                severity = a.get("severity", "")
+                suffix = f" [{severity}]" if severity else ""
+                print(f"  [{state}] {name}{suffix}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-grafana/scripts/get_dashboard.py
+++ b/sre-agent/.claude/skills/observability-grafana/scripts/get_dashboard.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Get a specific Grafana dashboard with panels.
+
+Usage:
+    python get_dashboard.py --uid DASHBOARD_UID
+"""
+
+import argparse
+import json
+import sys
+
+from grafana_client import grafana_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Grafana dashboard details")
+    parser.add_argument("--uid", required=True, help="Dashboard UID")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        data = grafana_request("GET", f"api/dashboards/uid/{args.uid}")
+        dashboard = data.get("dashboard", {})
+        panels = [
+            {
+                "id": p.get("id"),
+                "title": p.get("title"),
+                "type": p.get("type"),
+                "datasource": p.get("datasource"),
+            }
+            for p in dashboard.get("panels", [])
+        ]
+
+        result = {
+            "ok": True,
+            "uid": dashboard.get("uid"),
+            "title": dashboard.get("title"),
+            "tags": dashboard.get("tags", []),
+            "panel_count": len(panels),
+            "panels": panels,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(
+                f"Dashboard: {result.get('title', '?')} (UID: {result.get('uid', '?')})"
+            )
+            print(f"\nPanels ({len(panels)}):")
+            for p in panels:
+                print(f"  {p.get('title', '?'):40s} ({p.get('type', '?')})")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-grafana/scripts/grafana_client.py
+++ b/sre-agent/.claude/skills/observability-grafana/scripts/grafana_client.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Shared Grafana API client with proxy support.
+
+Credentials are injected transparently by the proxy layer.
+"""
+
+import os
+from typing import Any
+
+import httpx
+
+
+def get_config() -> dict[str, str | None]:
+    """Get Grafana configuration from environment."""
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+    }
+
+
+def get_base_url() -> str:
+    """Get Grafana API base URL.
+
+    Supports two modes:
+    1. Proxy mode (production): Uses GRAFANA_BASE_URL
+    2. Direct mode (testing): Uses GRAFANA_URL
+    """
+    proxy_url = os.getenv("GRAFANA_BASE_URL")
+    if proxy_url:
+        return proxy_url.rstrip("/")
+
+    url = os.getenv("GRAFANA_URL")
+    if url:
+        return url.rstrip("/")
+
+    raise RuntimeError(
+        "Either GRAFANA_BASE_URL (proxy mode) or GRAFANA_URL (direct mode) must be set."
+    )
+
+
+def get_headers() -> dict[str, str]:
+    """Get Grafana API headers."""
+    config = get_config()
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+
+    api_key = os.getenv("GRAFANA_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    else:
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if not sandbox_jwt:
+            jwt_path = "/tmp/sandbox-jwt"
+            if os.path.exists(jwt_path):
+                with open(jwt_path) as f:
+                    sandbox_jwt = f.read().strip()
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+            headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    return headers
+
+
+def grafana_request(
+    method: str,
+    path: str,
+    params: dict | None = None,
+    json_body: dict | None = None,
+) -> Any:
+    """Make a request to Grafana API."""
+    base_url = get_base_url()
+    url = f"{base_url}/{path.lstrip('/')}"
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.request(
+            method, url, headers=get_headers(), params=params, json=json_body
+        )
+        response.raise_for_status()
+        return response.json()

--- a/sre-agent/.claude/skills/observability-grafana/scripts/list_dashboards.py
+++ b/sre-agent/.claude/skills/observability-grafana/scripts/list_dashboards.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""List Grafana dashboards.
+
+Usage:
+    python list_dashboards.py [--query "kubernetes"]
+"""
+
+import argparse
+import json
+import sys
+
+from grafana_client import grafana_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Grafana dashboards")
+    parser.add_argument("--query", default="", help="Search query")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        params = {"type": "dash-db"}
+        if args.query:
+            params["query"] = args.query
+
+        data = grafana_request("GET", "api/search", params=params)
+        dashboards = [
+            {
+                "uid": d.get("uid"),
+                "title": d.get("title"),
+                "folder": d.get("folderTitle", "General"),
+                "url": d.get("url"),
+                "tags": d.get("tags", []),
+            }
+            for d in data[:50]
+        ]
+        result = {"ok": True, "dashboards": dashboards, "count": len(dashboards)}
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Grafana Dashboards ({len(dashboards)} found)")
+            for d in dashboards:
+                tags = f" [{', '.join(d.get('tags', []))}]" if d.get("tags") else ""
+                print(f"  {d.get('title', '?'):40s} ({d.get('folder', '?')}){tags}")
+                print(f"    UID: {d.get('uid', '?')}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-grafana/scripts/list_datasources.py
+++ b/sre-agent/.claude/skills/observability-grafana/scripts/list_datasources.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""List Grafana datasources.
+
+Usage:
+    python list_datasources.py
+"""
+
+import argparse
+import json
+import sys
+
+from grafana_client import grafana_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Grafana datasources")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        data = grafana_request("GET", "api/datasources")
+        datasources = [
+            {
+                "id": ds.get("id"),
+                "name": ds.get("name"),
+                "type": ds.get("type"),
+                "url": ds.get("url"),
+                "is_default": ds.get("isDefault"),
+            }
+            for ds in data
+        ]
+        result = {"ok": True, "datasources": datasources, "count": len(datasources)}
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Grafana Datasources ({len(datasources)})")
+            for ds in datasources:
+                default = " (default)" if ds.get("is_default") else ""
+                print(
+                    f"  [{ds.get('id', '?')}] {ds.get('name', '?'):30s} ({ds.get('type', '?')}){default}"
+                )
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-grafana/scripts/query_prometheus.py
+++ b/sre-agent/.claude/skills/observability-grafana/scripts/query_prometheus.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Query Prometheus metrics via Grafana.
+
+Usage:
+    python query_prometheus.py --query "rate(http_requests_total[5m])"
+    python query_prometheus.py --query "up{job='api'}" --time-range 120
+    python query_prometheus.py --query "up" --datasource-id 8
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+from grafana_client import grafana_request
+
+
+def find_prometheus_datasource_id():
+    """Auto-discover the default Prometheus datasource ID."""
+    try:
+        datasources = grafana_request("GET", "api/datasources")
+        # First try: find the default datasource of type prometheus
+        for ds in datasources:
+            if ds.get("type") == "prometheus" and ds.get("isDefault"):
+                return ds["id"]
+        # Second try: find any prometheus datasource
+        for ds in datasources:
+            if ds.get("type") == "prometheus":
+                return ds["id"]
+    except Exception:
+        pass
+    return 1  # fallback
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Query Prometheus via Grafana")
+    parser.add_argument("--query", required=True, help="PromQL query")
+    parser.add_argument(
+        "--time-range", type=int, default=60, help="Time range in minutes (default: 60)"
+    )
+    parser.add_argument("--step", default="1m", help="Query step (default: 1m)")
+    parser.add_argument(
+        "--datasource-id", type=int, default=0, help="Datasource ID (0=auto-detect)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        ds_id = args.datasource_id
+        if ds_id == 0:
+            ds_id = find_prometheus_datasource_id()
+
+        end = datetime.now(timezone.utc)
+        start = end - timedelta(minutes=args.time_range)
+
+        params = {
+            "query": args.query,
+            "start": int(start.timestamp()),
+            "end": int(end.timestamp()),
+            "step": args.step,
+        }
+        data = grafana_request(
+            "GET",
+            f"api/datasources/proxy/{ds_id}/api/v1/query_range",
+            params=params,
+        )
+
+        if data.get("status") != "success":
+            print(f"Query failed: {data.get('error', 'Unknown')}", file=sys.stderr)
+            sys.exit(1)
+
+        results = data.get("data", {}).get("result", [])
+        formatted = [
+            {"metric": r.get("metric", {}), "values": r.get("values", [])[-100:]}
+            for r in results[:20]
+        ]
+        result = {
+            "ok": True,
+            "query": args.query,
+            "datasource_id": ds_id,
+            "result_count": len(results),
+            "results": formatted,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Query: {args.query}")
+            print(
+                f"Time range: {args.time_range}m | Step: {args.step} | Datasource: {ds_id} | Series: {len(results)}"
+            )
+            for r in formatted:
+                labels = r.get("metric", {})
+                label_str = (
+                    ", ".join(f"{k}={v}" for k, v in labels.items())
+                    if labels
+                    else "no labels"
+                )
+                values = r.get("values", [])
+                if values:
+                    latest = values[-1]
+                    print(f"\n  {{{label_str}}}")
+                    print(f"    Latest: {latest[1]} | Points: {len(values)}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-grafana/templates/vercel-overview.json
+++ b/sre-agent/.claude/skills/observability-grafana/templates/vercel-overview.json
@@ -1,0 +1,166 @@
+{
+  "title": "Vercel Overview",
+  "tags": ["vercel", "opensre", "auto-generated"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "DS_LOKI",
+        "type": "datasource",
+        "query": "loki",
+        "current": {},
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Error Count (12h)",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({source=\"vercel\"} |= \"error\" [12h]))",
+          "legendFormat": "Errors",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 50 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 2,
+      "title": "Error Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "targets": [
+        {
+          "expr": "sum(rate({source=\"vercel\"} |= \"error\" [5m])) by (host)",
+          "legendFormat": "{{host}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 15,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "lineWidth": 2
+          },
+          "color": { "mode": "palette-classic" },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Log Stream",
+      "type": "logs",
+      "gridPos": { "h": 10, "w": 16, "x": 0, "y": 8 },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "targets": [
+        {
+          "expr": "{source=\"vercel\"} |~ \"(?i)(error|warn|fatal|panic|exception)\"",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      }
+    },
+    {
+      "id": 4,
+      "title": "Request Summary (6h)",
+      "type": "stat",
+      "gridPos": { "h": 10, "w": 8, "x": 16, "y": 8 },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({source=\"vercel\"} [6h]))",
+          "legendFormat": "Total Logs",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(count_over_time({source=\"vercel\"} |= \"error\" [6h]))",
+          "legendFormat": "Errors",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(count_over_time({source=\"vercel\"} |= \"warn\" [6h]))",
+          "legendFormat": "Warnings",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 1000 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "vertical",
+        "textMode": "value_and_name",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "fiscalYearStartMonth": 0,
+  "liveNow": false,
+  "editable": true,
+  "graphTooltip": 1
+}

--- a/sre-agent/.claude/skills/observability-honeycomb/SKILL.md
+++ b/sre-agent/.claude/skills/observability-honeycomb/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: observability-honeycomb
+description: Honeycomb observability analysis. Use when querying Honeycomb datasets, traces, or metrics. Provides scripts and query syntax reference for high-cardinality exploration.
+allowed-tools: Bash(python *)
+---
+
+# Honeycomb Analysis
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `HONEYCOMB_API_KEY` in environment variables - it won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `HONEYCOMB_API_ENDPOINT` - Honeycomb API endpoint (default: `https://api.honeycomb.io`)
+
+---
+
+## MANDATORY: Statistics-First Investigation
+
+**NEVER dump raw events.** Always follow this pattern:
+
+```
+STATISTICS → SAMPLE → PATTERNS → CORRELATE
+```
+
+1. **Statistics First** - Know volume, error rate, and top patterns before sampling
+2. **Strategic Sampling** - Choose the right strategy based on statistics
+3. **Pattern Extraction** - Cluster similar errors to find root causes
+4. **Context Correlation** - Investigate around anomaly timestamps
+
+## Available Scripts
+
+All scripts are in `.claude/skills/observability-honeycomb/scripts/`
+
+### PRIMARY INVESTIGATION SCRIPTS
+
+#### get_statistics.py - ALWAYS START HERE
+Comprehensive statistics with pattern extraction.
+```bash
+python .claude/skills/observability-honeycomb/scripts/get_statistics.py DATASET [--time-range SECONDS] [--filter FILTER]
+
+# Examples:
+python .claude/skills/observability-honeycomb/scripts/get_statistics.py production --time-range 3600
+python .claude/skills/observability-honeycomb/scripts/get_statistics.py api-requests --filter "http.status_code >= 500"
+```
+
+Output includes:
+- Total event count
+- Error distribution by status code
+- Top services/endpoints
+- **Top error patterns** (crucial for quick triage)
+- Actionable recommendation
+
+#### run_query.py - Custom Queries
+Run custom analytics queries with aggregations.
+```bash
+python .claude/skills/observability-honeycomb/scripts/run_query.py DATASET --calc CALCULATION [--breakdown FIELD] [--filter FILTER]
+
+# Calculations: COUNT, SUM, AVG, MAX, MIN, P50, P75, P90, P95, P99, HEATMAP, COUNT_DISTINCT
+# Examples:
+python .claude/skills/observability-honeycomb/scripts/run_query.py production --calc COUNT
+python .claude/skills/observability-honeycomb/scripts/run_query.py production --calc P99 --column duration_ms --breakdown service.name
+python .claude/skills/observability-honeycomb/scripts/run_query.py production --calc COUNT --filter "http.status_code >= 500" --breakdown error.message
+```
+
+#### list_datasets.py - Dataset Discovery
+List available datasets in the environment.
+```bash
+python .claude/skills/observability-honeycomb/scripts/list_datasets.py
+
+# Output: List of datasets with names and last write times
+```
+
+---
+
+## Honeycomb Query Concepts
+
+### Calculations (Aggregations)
+
+| Calculation | Description | Example |
+|-------------|-------------|---------|
+| `COUNT` | Count events | Total requests |
+| `SUM` | Sum a column | Total bytes transferred |
+| `AVG` | Average value | Average duration |
+| `MAX` / `MIN` | Extremes | Peak latency |
+| `P50`, `P75`, `P90`, `P95`, `P99` | Percentiles | P99 latency |
+| `HEATMAP` | Distribution | Latency heatmap |
+| `COUNT_DISTINCT` | Unique values | Unique users |
+| `RATE_AVG`, `RATE_SUM`, `RATE_MAX` | Rate per second | Requests/second |
+
+### Filters
+
+Filters use operators to narrow results:
+```
+column = value          # Exact match
+column != value         # Not equal
+column > value          # Greater than
+column >= value         # Greater or equal
+column < value          # Less than
+column <= value         # Less or equal
+column exists           # Field exists
+column does-not-exist   # Field missing
+column contains "str"   # Contains substring
+column starts-with "s"  # Starts with prefix
+column in (a, b, c)     # In set
+```
+
+### Breakdowns (Group By)
+
+Breakdowns split results by field values:
+```bash
+# Group by service
+--breakdown service.name
+
+# Multiple breakdowns
+--breakdown service.name --breakdown http.method
+```
+
+### Common Fields
+
+Honeycomb typically has these fields (varies by instrumentation):
+```
+# Trace fields
+trace.trace_id
+trace.span_id
+trace.parent_id
+duration_ms
+name
+
+# HTTP fields
+http.method
+http.url
+http.status_code
+http.host
+
+# Service fields
+service.name
+service.version
+
+# Error fields
+error
+error.message
+exception.type
+exception.message
+```
+
+---
+
+## Investigation Workflow
+
+### Standard Incident Investigation
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. STATISTICS FIRST (mandatory)                              │
+│    python get_statistics.py <dataset>                        │
+│    → Know volume, error rate, top patterns                   │
+└─────────────────────────────────────────────────────────────┘
+                             │
+                             ▼
+                     High Error Rate?
+               ┌─────────────┴─────────────┐
+               │                           │
+       YES (>5%)                           NO
+               │                           │
+               ▼                           ▼
+┌─────────────────────────────┐  ┌───────────────────────────────────────────┐
+│ 2. FAST PATH                │  │ 2. TARGETED INVESTIGATION                 │
+│    Query errors directly    │  │    Filter by specific criteria            │
+│    python run_query.py      │  │    python run_query.py dataset            │
+│    --filter "error=true"    │  │    --filter "duration_ms > 1000"          │
+│    --breakdown error.message│  │    → Look for anomalies                   │
+└─────────────────────────────┘  └───────────────────────────────────────────┘
+```
+
+### Quick Commands Reference
+
+| Goal | Command |
+|------|---------|
+| Start investigation | `get_statistics.py <dataset>` |
+| Count errors | `run_query.py <dataset> --calc COUNT --filter "error=true"` |
+| P99 latency by service | `run_query.py <dataset> --calc P99 --column duration_ms --breakdown service.name` |
+| Error distribution | `run_query.py <dataset> --calc COUNT --filter "error=true" --breakdown error.message` |
+| List datasets | `list_datasets.py` |
+
+---
+
+## SLOs and Triggers
+
+### Checking SLOs
+```bash
+python .claude/skills/observability-honeycomb/scripts/run_query.py <dataset> --list-slos
+```
+
+### Checking Triggers (Alerts)
+```bash
+python .claude/skills/observability-honeycomb/scripts/run_query.py <dataset> --list-triggers
+```
+
+---
+
+## Anti-Patterns to Avoid
+
+1. **NEVER skip statistics** - `get_statistics.py` is MANDATORY first step
+2. **Unbounded queries** - Always specify time ranges (default: 1 hour)
+3. **Fetching all events** - Use aggregations, not raw event dumps
+4. **Ignoring error rate** - High error rate means immediate investigation
+5. **Missing service filter** - For multi-service datasets, always filter by service
+
+## Key Differences from Other Platforms
+
+- **High cardinality native** - Honeycomb excels at high-cardinality fields (user IDs, request IDs)
+- **No pre-aggregation** - Queries run on raw events, enabling ad-hoc exploration
+- **Trace-first** - Designed for distributed tracing, not just logs
+- **BubbleUp** - Use breakdowns to identify anomalous dimensions automatically

--- a/sre-agent/.claude/skills/observability-honeycomb/scripts/__init__.py
+++ b/sre-agent/.claude/skills/observability-honeycomb/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Honeycomb analysis scripts for SRE Agent

--- a/sre-agent/.claude/skills/observability-honeycomb/scripts/get_statistics.py
+++ b/sre-agent/.claude/skills/observability-honeycomb/scripts/get_statistics.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Get comprehensive statistics from Honeycomb - THE MANDATORY FIRST STEP.
+
+This should ALWAYS be called before running detailed queries. It provides:
+- Total event count
+- Error rate and distribution
+- Top services/endpoints
+- Top error patterns
+- Actionable recommendations
+
+Usage:
+    python get_statistics.py DATASET [--time-range SECONDS] [--filter FILTER]
+
+Examples:
+    python get_statistics.py production --time-range 3600
+    python get_statistics.py api-requests --filter "http.status_code >= 500"
+"""
+
+import argparse
+import json
+import re
+import sys
+
+from honeycomb_client import run_query
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Get comprehensive Honeycomb statistics (ALWAYS call first)"
+    )
+    parser.add_argument("dataset", help="Dataset slug to analyze")
+    parser.add_argument(
+        "--time-range",
+        type=int,
+        default=3600,
+        help="Time range in seconds (default: 3600 = 1 hour)",
+    )
+    parser.add_argument(
+        "--filter", help="Filter expression (e.g., 'service.name = api')"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        dataset = args.dataset
+        time_range = args.time_range
+
+        # Build base filters
+        base_filters = []
+        if args.filter:
+            # Parse simple filter expression
+            base_filters.append(parse_filter(args.filter))
+
+        # 1. Get total count
+        total_result = run_query(
+            dataset,
+            calculations=[{"op": "COUNT"}],
+            filters=base_filters if base_filters else None,
+            time_range=time_range,
+        )
+        total_count = extract_count(total_result)
+
+        # 2. Get error count (try common error indicators)
+        error_count = 0
+        error_filters = list(base_filters)
+
+        # Try http.status_code >= 500 first
+        try:
+            http_error_filters = error_filters + [
+                {"column": "http.status_code", "op": ">=", "value": 500}
+            ]
+            error_result = run_query(
+                dataset,
+                calculations=[{"op": "COUNT"}],
+                filters=http_error_filters,
+                time_range=time_range,
+            )
+            error_count = extract_count(error_result)
+        except Exception:
+            # Try error=true
+            try:
+                bool_error_filters = error_filters + [
+                    {"column": "error", "op": "=", "value": True}
+                ]
+                error_result = run_query(
+                    dataset,
+                    calculations=[{"op": "COUNT"}],
+                    filters=bool_error_filters,
+                    time_range=time_range,
+                )
+                error_count = extract_count(error_result)
+            except Exception:
+                pass  # No error field available
+
+        error_rate = round(error_count / total_count * 100, 2) if total_count > 0 else 0
+
+        # 3. Get service distribution
+        service_dist = []
+        try:
+            service_result = run_query(
+                dataset,
+                calculations=[{"op": "COUNT"}],
+                filters=base_filters if base_filters else None,
+                breakdowns=["service.name"],
+                time_range=time_range,
+                limit=10,
+            )
+            for row in service_result.get("data", []):
+                svc = row.get("service.name", "unknown")
+                count = row.get("COUNT", 0)
+                service_dist.append({"service": svc, "count": count})
+        except Exception:
+            pass
+
+        # Sort by count descending
+        service_dist.sort(key=lambda x: x["count"], reverse=True)
+
+        # 4. Get status code distribution (for HTTP services)
+        status_dist = {}
+        try:
+            status_result = run_query(
+                dataset,
+                calculations=[{"op": "COUNT"}],
+                filters=base_filters if base_filters else None,
+                breakdowns=["http.status_code"],
+                time_range=time_range,
+                limit=20,
+            )
+            for row in status_result.get("data", []):
+                status = str(row.get("http.status_code", "unknown"))
+                count = row.get("COUNT", 0)
+                status_dist[status] = count
+        except Exception:
+            pass
+
+        # 5. Get top error messages
+        top_error_patterns = []
+        try:
+            error_msg_result = run_query(
+                dataset,
+                calculations=[{"op": "COUNT"}],
+                filters=[{"column": "error", "op": "=", "value": True}]
+                + (base_filters if base_filters else []),
+                breakdowns=["error.message"],
+                time_range=time_range,
+                limit=10,
+            )
+            for row in error_msg_result.get("data", []):
+                msg = row.get("error.message", "")
+                count = row.get("COUNT", 0)
+                if msg:
+                    # Normalize message
+                    normalized = normalize_message(msg)
+                    top_error_patterns.append({"pattern": normalized, "count": count})
+        except Exception:
+            # Try exception.message instead
+            try:
+                exc_result = run_query(
+                    dataset,
+                    calculations=[{"op": "COUNT"}],
+                    filters=[{"column": "http.status_code", "op": ">=", "value": 500}]
+                    + (base_filters if base_filters else []),
+                    breakdowns=["exception.message"],
+                    time_range=time_range,
+                    limit=10,
+                )
+                for row in exc_result.get("data", []):
+                    msg = row.get("exception.message", "")
+                    count = row.get("COUNT", 0)
+                    if msg:
+                        normalized = normalize_message(msg)
+                        top_error_patterns.append(
+                            {"pattern": normalized, "count": count}
+                        )
+            except Exception:
+                pass
+
+        # 6. Build recommendation
+        if total_count == 0:
+            recommendation = "No events found in the specified time range."
+        elif error_rate > 10:
+            recommendation = f"HIGH error rate ({error_rate}%). Investigate top error patterns immediately."
+        elif error_rate > 5:
+            recommendation = (
+                f"Elevated error rate ({error_rate}%). Review error patterns."
+            )
+        elif total_count > 100000:
+            recommendation = (
+                f"High volume ({total_count:,} events). Use targeted service filter."
+            )
+        else:
+            recommendation = (
+                f"Normal volume ({total_count:,} events). Error rate: {error_rate}%"
+            )
+
+        # Build result
+        result = {
+            "dataset": dataset,
+            "total_count": total_count,
+            "error_count": error_count,
+            "error_rate_percent": error_rate,
+            "status_distribution": status_dist,
+            "top_services": service_dist,
+            "top_error_patterns": top_error_patterns,
+            "time_range_seconds": time_range,
+            "recommendation": recommendation,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print("=" * 60)
+            print("HONEYCOMB STATISTICS")
+            print("=" * 60)
+            print(f"Dataset: {dataset}")
+            print(f"Time Range: {time_range} seconds ({time_range // 60} minutes)")
+            print()
+            print(f"Total Events: {total_count:,}")
+            print(f"Errors: {error_count:,} ({error_rate}%)")
+            print()
+
+            if status_dist:
+                print("Status Code Distribution:")
+                for status, count in sorted(status_dist.items(), key=lambda x: -x[1])[
+                    :10
+                ]:
+                    pct = round(count / total_count * 100, 1) if total_count > 0 else 0
+                    print(f"  {status}: {count:,} ({pct}%)")
+                print()
+
+            if service_dist:
+                print("Top Services:")
+                for svc in service_dist[:5]:
+                    print(f"  {svc['service']}: {svc['count']:,}")
+                print()
+
+            if top_error_patterns:
+                print("Top Error Patterns:")
+                for pat in top_error_patterns[:5]:
+                    print(f"  [{pat['count']}x] {pat['pattern'][:80]}")
+                print()
+
+            print(f"Recommendation: {recommendation}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def extract_count(result: dict) -> int:
+    """Extract count from query result."""
+    data = result.get("data", [])
+    if data and len(data) > 0:
+        return data[0].get("COUNT", 0)
+    return 0
+
+
+def normalize_message(msg: str) -> str:
+    """Normalize error message for pattern grouping."""
+    # Remove UUIDs
+    normalized = re.sub(
+        r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
+        "<UUID>",
+        msg,
+    )
+    # Remove IPs
+    normalized = re.sub(r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b", "<IP>", normalized)
+    # Remove numbers
+    normalized = re.sub(r"\b\d+\b", "<NUM>", normalized)
+    # Truncate
+    return normalized[:100]
+
+
+def parse_filter(filter_expr: str) -> dict:
+    """Parse a simple filter expression into Honeycomb filter format.
+
+    Supports: =, !=, >, >=, <, <=, exists, contains, starts-with
+
+    Examples:
+        "service.name = api" -> {"column": "service.name", "op": "=", "value": "api"}
+        "http.status_code >= 500" -> {"column": "http.status_code", "op": ">=", "value": 500}
+    """
+    # Try operators in order of length (longer first to avoid partial matches)
+    operators = [">=", "<=", "!=", "=", ">", "<", "exists", "contains", "starts-with"]
+
+    for op in operators:
+        if op in filter_expr:
+            parts = filter_expr.split(op, 1)
+            if len(parts) == 2:
+                column = parts[0].strip()
+                value = parts[1].strip()
+
+                # Try to parse value as number
+                try:
+                    if "." in value:
+                        value = float(value)
+                    else:
+                        value = int(value)
+                except ValueError:
+                    # Keep as string, remove quotes if present
+                    value = value.strip("\"'")
+
+                return {"column": column, "op": op, "value": value}
+
+    raise ValueError(f"Could not parse filter: {filter_expr}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-honeycomb/scripts/honeycomb_client.py
+++ b/sre-agent/.claude/skills/observability-honeycomb/scripts/honeycomb_client.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Shared Honeycomb API client with proxy support.
+
+This module provides the Honeycomb API client that works through the credential proxy.
+Credentials are injected transparently by the proxy layer.
+
+Honeycomb Endpoints:
+- US: api.honeycomb.io (default)
+- EU: api.eu1.honeycomb.io
+"""
+
+import os
+import time
+from typing import Any
+
+import httpx
+
+DEFAULT_API_ENDPOINT = "https://api.honeycomb.io"
+
+
+def get_config() -> dict[str, str | None]:
+    """Get Honeycomb configuration from environment.
+
+    Credentials are injected by the credential-proxy based on tenant context.
+
+    Environment variables:
+        OPENSRE_TENANT_ID - Tenant ID for credential lookup
+        OPENSRE_TEAM_ID - Team ID for credential lookup
+        HONEYCOMB_API_ENDPOINT - Honeycomb API endpoint (optional)
+    """
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+        "api_endpoint": os.getenv("HONEYCOMB_API_ENDPOINT", DEFAULT_API_ENDPOINT),
+    }
+
+
+def get_api_url(endpoint: str) -> str:
+    """Build the Honeycomb API URL.
+
+    Supports two modes:
+    1. Proxy mode (production): Uses HONEYCOMB_BASE_URL
+    2. Direct mode (testing): Uses HONEYCOMB_API_KEY
+
+    Args:
+        endpoint: API path (e.g., "/1/datasets")
+
+    Returns:
+        Full API URL
+    """
+    # Proxy mode (production)
+    base_url = os.getenv("HONEYCOMB_BASE_URL")
+    if base_url:
+        return f"{base_url.rstrip('/')}{endpoint}"
+
+    # Direct mode (testing) - requires HONEYCOMB_API_KEY
+    api_endpoint = os.getenv("HONEYCOMB_API_ENDPOINT", DEFAULT_API_ENDPOINT)
+    if os.getenv("HONEYCOMB_API_KEY"):
+        return f"{api_endpoint.rstrip('/')}{endpoint}"
+
+    raise RuntimeError(
+        "Either HONEYCOMB_BASE_URL (proxy mode) or HONEYCOMB_API_KEY (direct mode) must be set."
+    )
+
+
+def get_headers() -> dict[str, str]:
+    """Get Honeycomb API headers.
+
+    In proxy mode: includes tenant context for credential lookup.
+    In direct mode: includes API key directly.
+    """
+    config = get_config()
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    # Direct mode - add API key directly
+    api_key = os.getenv("HONEYCOMB_API_KEY")
+    if api_key:
+        headers["X-Honeycomb-Team"] = api_key
+    else:
+        # Proxy mode - use JWT for credential-resolver auth
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            # Fallback for local dev
+            headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+            headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    return headers
+
+
+def list_datasets() -> list[dict[str, Any]]:
+    """List all datasets in the Honeycomb environment.
+
+    Returns:
+        List of datasets with name, slug, description, and timestamps
+
+    Raises:
+        httpx.HTTPStatusError: On API errors
+    """
+    url = get_api_url("/1/datasets")
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+
+        datasets = response.json()
+        return [
+            {
+                "name": ds.get("name"),
+                "slug": ds.get("slug"),
+                "description": ds.get("description"),
+                "created_at": ds.get("created_at"),
+                "last_written_at": ds.get("last_written_at"),
+            }
+            for ds in datasets
+        ]
+
+
+def get_columns(dataset_slug: str) -> list[dict[str, Any]]:
+    """Get columns (fields) for a dataset.
+
+    Args:
+        dataset_slug: The dataset slug/identifier
+
+    Returns:
+        List of columns with name, type, and metadata
+
+    Raises:
+        httpx.HTTPStatusError: On API errors
+    """
+    url = get_api_url(f"/1/columns/{dataset_slug}")
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+
+        columns = response.json()
+        return [
+            {
+                "key_name": col.get("key_name"),
+                "type": col.get("type"),
+                "description": col.get("description"),
+                "hidden": col.get("hidden", False),
+                "last_written": col.get("last_written"),
+            }
+            for col in columns
+        ]
+
+
+def run_query(
+    dataset_slug: str,
+    calculations: list[dict[str, Any]] | None = None,
+    filters: list[dict[str, Any]] | None = None,
+    breakdowns: list[str] | None = None,
+    time_range: int = 3600,
+    granularity: int | None = None,
+    limit: int | None = None,
+    timeout_seconds: int = 60,
+) -> dict[str, Any]:
+    """Run a query on a Honeycomb dataset.
+
+    Args:
+        dataset_slug: The dataset slug/identifier
+        calculations: List of calculations, e.g., [{"op": "COUNT"}, {"op": "P99", "column": "duration_ms"}]
+        filters: List of filters, e.g., [{"column": "status", "op": "=", "value": "error"}]
+        breakdowns: List of columns to group by
+        time_range: Time range in seconds (default: 3600 = 1 hour)
+        granularity: Time bucket size in seconds (optional)
+        limit: Maximum results per group (optional)
+        timeout_seconds: Query timeout (default: 60)
+
+    Returns:
+        Query results with data and series
+
+    Raises:
+        httpx.HTTPStatusError: On API errors
+        TimeoutError: If query doesn't complete in time
+    """
+    headers = get_headers()
+
+    # Default to COUNT if no calculations specified
+    if not calculations:
+        calculations = [{"op": "COUNT"}]
+
+    # Build query spec
+    query_spec = {
+        "calculations": calculations,
+        "time_range": time_range,
+    }
+
+    if filters:
+        query_spec["filters"] = filters
+    if breakdowns:
+        query_spec["breakdowns"] = breakdowns
+    if granularity:
+        query_spec["granularity"] = granularity
+    if limit:
+        query_spec["limit"] = limit
+
+    with httpx.Client(timeout=float(timeout_seconds + 10)) as client:
+        # Step 1: Create query spec
+        create_url = get_api_url(f"/1/queries/{dataset_slug}")
+        create_response = client.post(create_url, headers=headers, json=query_spec)
+        create_response.raise_for_status()
+
+        query_data = create_response.json()
+        query_id = query_data.get("id")
+
+        if not query_id:
+            raise RuntimeError("Failed to create query - no query ID returned")
+
+        # Step 2: Execute query
+        execute_url = get_api_url(f"/1/query_results/{dataset_slug}")
+        execute_response = client.post(
+            execute_url, headers=headers, json={"query_id": query_id}
+        )
+        execute_response.raise_for_status()
+
+        result_data = execute_response.json()
+        query_result_id = result_data.get("id")
+
+        if not query_result_id:
+            raise RuntimeError("Failed to execute query - no result ID returned")
+
+        # Step 3: Poll for results
+        poll_url = get_api_url(f"/1/query_results/{dataset_slug}/{query_result_id}")
+        max_attempts = timeout_seconds
+        poll_interval = 1.0
+
+        for _ in range(max_attempts):
+            poll_response = client.get(poll_url, headers=headers)
+            poll_response.raise_for_status()
+            poll_data = poll_response.json()
+
+            if poll_data.get("complete"):
+                return {
+                    "query_id": query_id,
+                    "result_id": query_result_id,
+                    "data": poll_data.get("data", {}).get("results", []),
+                    "series": poll_data.get("data", {}).get("series", []),
+                    "complete": True,
+                }
+
+            time.sleep(poll_interval)
+
+        raise TimeoutError(f"Query timed out after {timeout_seconds} seconds")
+
+
+def list_slos(dataset_slug: str) -> list[dict[str, Any]]:
+    """List SLOs for a dataset.
+
+    Args:
+        dataset_slug: The dataset slug/identifier
+
+    Returns:
+        List of SLOs with name, target, and status
+
+    Raises:
+        httpx.HTTPStatusError: On API errors
+    """
+    url = get_api_url(f"/1/slos/{dataset_slug}")
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+
+        slos = response.json()
+        return [
+            {
+                "id": slo.get("id"),
+                "name": slo.get("name"),
+                "description": slo.get("description"),
+                "target_percentage": slo.get("target_percentage"),
+                "time_period_days": slo.get("time_period_days"),
+                "sli": slo.get("sli"),
+            }
+            for slo in slos
+        ]
+
+
+def list_triggers(dataset_slug: str) -> list[dict[str, Any]]:
+    """List triggers (alerts) for a dataset.
+
+    Args:
+        dataset_slug: The dataset slug/identifier
+
+    Returns:
+        List of triggers with name, threshold, and status
+
+    Raises:
+        httpx.HTTPStatusError: On API errors
+    """
+    url = get_api_url(f"/1/triggers/{dataset_slug}")
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+
+        triggers = response.json()
+        return [
+            {
+                "id": trigger.get("id"),
+                "name": trigger.get("name"),
+                "description": trigger.get("description"),
+                "disabled": trigger.get("disabled", False),
+                "triggered": trigger.get("triggered", False),
+                "frequency": trigger.get("frequency"),
+                "threshold": trigger.get("threshold"),
+            }
+            for trigger in triggers
+        ]
+
+
+def format_results(
+    results: list[dict[str, Any]], breakdowns: list[str] | None = None
+) -> str:
+    """Format query results for display.
+
+    Args:
+        results: Query results from run_query
+        breakdowns: Breakdown columns used in query
+
+    Returns:
+        Formatted string for display
+    """
+    if not results:
+        return "No results found."
+
+    lines = []
+    for i, row in enumerate(results[:50]):  # Limit to 50 rows
+        parts = []
+
+        # Add breakdown values
+        if breakdowns:
+            for bd in breakdowns:
+                val = row.get(bd, "N/A")
+                parts.append(f"{bd}={val}")
+
+        # Add aggregation values
+        for key, value in row.items():
+            if breakdowns and key in breakdowns:
+                continue
+            if isinstance(value, float):
+                parts.append(f"{key}={value:.2f}")
+            else:
+                parts.append(f"{key}={value}")
+
+        lines.append(" | ".join(parts))
+
+    return "\n".join(lines)

--- a/sre-agent/.claude/skills/observability-honeycomb/scripts/list_datasets.py
+++ b/sre-agent/.claude/skills/observability-honeycomb/scripts/list_datasets.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""List all datasets available in Honeycomb.
+
+Use this to discover what datasets are available for analysis.
+
+Usage:
+    python list_datasets.py [--json]
+
+Examples:
+    python list_datasets.py
+    python list_datasets.py --json
+"""
+
+import argparse
+import json
+import sys
+
+from honeycomb_client import list_datasets
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Honeycomb datasets")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        datasets = list_datasets()
+
+        if args.json:
+            print(json.dumps(datasets, indent=2))
+        else:
+            print("=" * 60)
+            print("HONEYCOMB DATASETS")
+            print("=" * 60)
+            print()
+
+            if not datasets:
+                print("No datasets found.")
+            else:
+                print(f"Found {len(datasets)} dataset(s):")
+                print()
+
+                for ds in datasets:
+                    print(f"  {ds['name']}")
+                    print(f"    Slug: {ds['slug']}")
+                    if ds.get("description"):
+                        print(f"    Description: {ds['description']}")
+                    if ds.get("last_written_at"):
+                        print(f"    Last Written: {ds['last_written_at']}")
+                    print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-honeycomb/scripts/run_query.py
+++ b/sre-agent/.claude/skills/observability-honeycomb/scripts/run_query.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Run custom queries on Honeycomb datasets.
+
+Supports various calculations, filters, and breakdowns for detailed analysis.
+
+Usage:
+    python run_query.py DATASET --calc CALCULATION [options]
+
+Examples:
+    python run_query.py production --calc COUNT
+    python run_query.py production --calc P99 --column duration_ms --breakdown service.name
+    python run_query.py production --calc COUNT --filter "http.status_code >= 500" --breakdown error.message
+"""
+
+import argparse
+import json
+import sys
+
+from honeycomb_client import (
+    format_results,
+    list_slos,
+    list_triggers,
+    run_query,
+)
+
+VALID_CALCULATIONS = [
+    "COUNT",
+    "SUM",
+    "AVG",
+    "MAX",
+    "MIN",
+    "P50",
+    "P75",
+    "P90",
+    "P95",
+    "P99",
+    "HEATMAP",
+    "COUNT_DISTINCT",
+    "CONCURRENCY",
+    "RATE_AVG",
+    "RATE_SUM",
+    "RATE_MAX",
+]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run custom Honeycomb queries")
+    parser.add_argument("dataset", help="Dataset slug to query")
+    parser.add_argument(
+        "--calc",
+        action="append",
+        help=f"Calculation to perform. Options: {', '.join(VALID_CALCULATIONS)}. Can specify multiple.",
+    )
+    parser.add_argument(
+        "--column",
+        action="append",
+        help="Column for calculation (required for SUM, AVG, MAX, MIN, percentiles)",
+    )
+    parser.add_argument(
+        "--breakdown",
+        action="append",
+        help="Column to group by (can specify multiple)",
+    )
+    parser.add_argument(
+        "--filter",
+        action="append",
+        help="Filter expression (e.g., 'http.status_code >= 500'). Can specify multiple.",
+    )
+    parser.add_argument(
+        "--time-range",
+        type=int,
+        default=3600,
+        help="Time range in seconds (default: 3600 = 1 hour)",
+    )
+    parser.add_argument(
+        "--granularity",
+        type=int,
+        help="Time bucket size in seconds for time series",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Maximum results per group (default: 100)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument(
+        "--list-slos", action="store_true", help="List SLOs for this dataset"
+    )
+    parser.add_argument(
+        "--list-triggers", action="store_true", help="List triggers for this dataset"
+    )
+    args = parser.parse_args()
+
+    try:
+        dataset = args.dataset
+
+        # Handle SLO listing
+        if args.list_slos:
+            slos = list_slos(dataset)
+            if args.json:
+                print(json.dumps(slos, indent=2))
+            else:
+                print(f"SLOs for {dataset}:")
+                print("-" * 40)
+                if not slos:
+                    print("No SLOs found.")
+                else:
+                    for slo in slos:
+                        print(f"  {slo['name']}")
+                        print(f"    ID: {slo['id']}")
+                        print(f"    Target: {slo['target_percentage']}%")
+                        print(f"    Period: {slo['time_period_days']} days")
+                        print()
+            return
+
+        # Handle trigger listing
+        if args.list_triggers:
+            triggers = list_triggers(dataset)
+            if args.json:
+                print(json.dumps(triggers, indent=2))
+            else:
+                print(f"Triggers for {dataset}:")
+                print("-" * 40)
+                if not triggers:
+                    print("No triggers found.")
+                else:
+                    for trigger in triggers:
+                        status = "DISABLED" if trigger["disabled"] else "ACTIVE"
+                        fired = " [TRIGGERED]" if trigger["triggered"] else ""
+                        print(f"  [{status}] {trigger['name']}{fired}")
+                        print(f"    ID: {trigger['id']}")
+                        if trigger.get("description"):
+                            print(f"    Description: {trigger['description']}")
+                        print()
+            return
+
+        # Build calculations
+        calculations = []
+        calcs = args.calc or ["COUNT"]
+        columns = args.column or []
+
+        for i, calc in enumerate(calcs):
+            calc_upper = calc.upper()
+            if calc_upper not in VALID_CALCULATIONS:
+                print(
+                    f"Invalid calculation: {calc}. Valid options: {', '.join(VALID_CALCULATIONS)}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+            calc_spec = {"op": calc_upper}
+
+            # Add column if specified and calculation needs it
+            if calc_upper not in ["COUNT", "CONCURRENCY"]:
+                if i < len(columns):
+                    calc_spec["column"] = columns[i]
+                elif columns:
+                    calc_spec["column"] = columns[0]
+                else:
+                    print(
+                        f"Calculation {calc_upper} requires --column",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+
+            calculations.append(calc_spec)
+
+        # Build filters
+        filters = []
+        if args.filter:
+            for f in args.filter:
+                filters.append(parse_filter(f))
+
+        # Run query
+        result = run_query(
+            dataset,
+            calculations=calculations,
+            filters=filters if filters else None,
+            breakdowns=args.breakdown,
+            time_range=args.time_range,
+            granularity=args.granularity,
+            limit=args.limit,
+        )
+
+        # Output
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print("=" * 60)
+            print("HONEYCOMB QUERY RESULTS")
+            print("=" * 60)
+            print(f"Dataset: {dataset}")
+            print(f"Calculations: {[c['op'] for c in calculations]}")
+            if args.breakdown:
+                print(f"Breakdowns: {args.breakdown}")
+            if filters:
+                print(f"Filters: {args.filter}")
+            print(f"Time Range: {args.time_range}s")
+            print()
+
+            data = result.get("data", [])
+            if not data:
+                print("No results found.")
+            else:
+                print(f"Results ({len(data)} rows):")
+                print("-" * 40)
+                print(format_results(data, args.breakdown))
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def parse_filter(filter_expr: str) -> dict:
+    """Parse a simple filter expression into Honeycomb filter format."""
+    operators = [
+        ">=",
+        "<=",
+        "!=",
+        "=",
+        ">",
+        "<",
+        "exists",
+        "does-not-exist",
+        "contains",
+        "starts-with",
+        "in",
+    ]
+
+    for op in operators:
+        if f" {op} " in filter_expr or filter_expr.endswith(f" {op}"):
+            parts = filter_expr.split(op, 1)
+            if len(parts) >= 1:
+                column = parts[0].strip()
+                value = parts[1].strip() if len(parts) > 1 else None
+
+                result = {"column": column, "op": op}
+
+                if value is not None:
+                    # Try to parse as number
+                    try:
+                        if "." in value:
+                            result["value"] = float(value)
+                        else:
+                            result["value"] = int(value)
+                    except ValueError:
+                        # Try to parse as boolean
+                        if value.lower() == "true":
+                            result["value"] = True
+                        elif value.lower() == "false":
+                            result["value"] = False
+                        else:
+                            # Keep as string, remove quotes
+                            result["value"] = value.strip("\"'")
+
+                return result
+
+    raise ValueError(f"Could not parse filter: {filter_expr}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-jaeger/SKILL.md
+++ b/sre-agent/.claude/skills/observability-jaeger/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: observability-jaeger
+description: Jaeger distributed tracing analysis. Use when investigating request latency, tracing errors across services, finding slow spans, or understanding service dependencies.
+allowed-tools: Bash(python *)
+---
+
+# Jaeger Tracing Analysis
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `JAEGER_URL` or other credentials in environment variables - they won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `JAEGER_URL` - Jaeger Query API URL (e.g., `http://jaeger-query:16686`)
+
+---
+
+## MANDATORY: Statistics-First Investigation
+
+**NEVER dump all traces.** Always follow this pattern:
+
+```
+SERVICES → OPERATIONS → STATISTICS → SAMPLE TRACES
+```
+
+1. **List Services** - Know what services exist
+2. **List Operations** - Understand endpoints/operations per service
+3. **Get Statistics** - Error rates, latency percentiles
+4. **Sample Traces** - Get specific traces after understanding the landscape
+
+## Available Scripts
+
+All scripts are in `.claude/skills/observability-jaeger/scripts/`
+
+### SERVICE DISCOVERY
+
+#### list_services.py - List All Traced Services
+```bash
+python .claude/skills/observability-jaeger/scripts/list_services.py
+
+# Output: List of all services sending traces to Jaeger
+```
+
+#### list_operations.py - List Operations for a Service
+```bash
+python .claude/skills/observability-jaeger/scripts/list_operations.py <service>
+
+# Example:
+python .claude/skills/observability-jaeger/scripts/list_operations.py frontend
+```
+
+### TRACE INVESTIGATION
+
+#### get_traces.py - Search for Traces
+```bash
+python .claude/skills/observability-jaeger/scripts/get_traces.py --service SERVICE [OPTIONS]
+
+# Options:
+#   --operation OPERATION  Filter by operation name
+#   --tags KEY=VALUE       Filter by tags (can repeat)
+#   --min-duration MS      Minimum duration in milliseconds
+#   --max-duration MS      Maximum duration in milliseconds
+#   --limit N              Max traces to return (default: 20)
+#   --lookback HOURS       How far back to search (default: 1)
+
+# Examples:
+python .claude/skills/observability-jaeger/scripts/get_traces.py --service frontend --limit 10
+python .claude/skills/observability-jaeger/scripts/get_traces.py --service checkout --min-duration 500
+python .claude/skills/observability-jaeger/scripts/get_traces.py --service api --operation "HTTP GET /users" --limit 5
+python .claude/skills/observability-jaeger/scripts/get_traces.py --service payment --tags error=true
+```
+
+#### get_trace.py - Get Full Trace by ID
+```bash
+python .claude/skills/observability-jaeger/scripts/get_trace.py <trace-id>
+
+# Example:
+python .claude/skills/observability-jaeger/scripts/get_trace.py abc123def456789
+```
+
+### LATENCY ANALYSIS
+
+#### get_slow_traces.py - Find Slow Traces
+```bash
+python .claude/skills/observability-jaeger/scripts/get_slow_traces.py --service SERVICE [OPTIONS]
+
+# Options:
+#   --min-duration MS      Minimum duration threshold (default: 1000)
+#   --operation OPERATION  Filter by specific operation
+#   --limit N              Max traces to return (default: 20)
+#   --lookback HOURS       How far back to search (default: 1)
+
+# Examples:
+python .claude/skills/observability-jaeger/scripts/get_slow_traces.py --service checkout --min-duration 500
+python .claude/skills/observability-jaeger/scripts/get_slow_traces.py --service api --operation "POST /orders"
+```
+
+#### get_latency_stats.py - Latency Statistics
+```bash
+python .claude/skills/observability-jaeger/scripts/get_latency_stats.py --service SERVICE [OPTIONS]
+
+# Options:
+#   --operation OPERATION  Filter by operation
+#   --lookback HOURS       Time window (default: 1)
+
+# Example:
+python .claude/skills/observability-jaeger/scripts/get_latency_stats.py --service frontend
+python .claude/skills/observability-jaeger/scripts/get_latency_stats.py --service checkout --operation "POST /checkout"
+```
+
+### ERROR ANALYSIS
+
+#### get_error_traces.py - Find Traces with Errors
+```bash
+python .claude/skills/observability-jaeger/scripts/get_error_traces.py --service SERVICE [OPTIONS]
+
+# Options:
+#   --operation OPERATION  Filter by operation
+#   --limit N              Max traces (default: 20)
+#   --lookback HOURS       Time window (default: 1)
+
+# Example:
+python .claude/skills/observability-jaeger/scripts/get_error_traces.py --service payment
+python .claude/skills/observability-jaeger/scripts/get_error_traces.py --service api --operation "POST /checkout"
+```
+
+---
+
+## Investigation Workflow
+
+### Standard Latency Investigation
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. LIST SERVICES                                              │
+│    python list_services.py                                    │
+│    → Identify which service to investigate                    │
+└─────────────────────────────────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 2. GET LATENCY STATS                                          │
+│    python get_latency_stats.py --service X                    │
+│    → See p50, p95, p99 latencies per operation                │
+└─────────────────────────────────────────────────────────────┘
+                             │
+                             ▼
+                   High Latency Found?
+               ┌─────────────┴─────────────┐
+               │                           │
+              YES                          NO
+               │                           │
+               ▼                           ▼
+┌─────────────────────────────┐  ┌───────────────────────────────────────────┐
+│ 3a. GET SLOW TRACES         │  │ 3b. CHECK ERRORS                          │
+│    python get_slow_traces.py│  │    python get_error_traces.py --service X │
+│    --service X              │  │    → Look for error patterns              │
+│    → Analyze slow paths     │  └───────────────────────────────────────────┘
+└─────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 4. ANALYZE SPECIFIC TRACE                                     │
+│    python get_trace.py <trace-id>                             │
+│    → See full span tree, find bottleneck                      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Quick Commands Reference
+
+| Goal | Command |
+|------|---------|
+| List all services | `list_services.py` |
+| List operations | `list_operations.py <service>` |
+| Get latency stats | `get_latency_stats.py --service X` |
+| Find slow traces | `get_slow_traces.py --service X --min-duration 500` |
+| Find error traces | `get_error_traces.py --service X` |
+| Get specific trace | `get_trace.py <trace-id>` |
+| Search with tags | `get_traces.py --service X --tags http.status_code=500` |
+
+---
+
+## Trace Anatomy
+
+### Span Structure
+```
+Trace (trace_id: abc123)
+├── Span: frontend (span_id: 001, duration: 250ms)
+│   ├── Span: api-gateway (span_id: 002, duration: 200ms)
+│   │   ├── Span: auth-service (span_id: 003, duration: 50ms)
+│   │   └── Span: order-service (span_id: 004, duration: 120ms) ← bottleneck
+│   │       └── Span: database (span_id: 005, duration: 100ms) ← root cause
+│   └── Span: cache-lookup (span_id: 006, duration: 5ms)
+```
+
+### Common Tags
+- `http.method` - HTTP method (GET, POST, etc.)
+- `http.url` - Request URL
+- `http.status_code` - Response status code
+- `error` - Boolean, true if span has error
+- `span.kind` - client, server, producer, consumer
+- `db.type` - Database type (mysql, postgres, redis)
+- `db.statement` - Database query (may be truncated)
+
+### Finding Bottlenecks
+1. Sort spans by duration (longest first)
+2. Look for the **critical path** (spans on the main request flow)
+3. Check if slow span has child spans (slow child = propagated latency)
+4. Check tags for error=true or high status codes
+
+---
+
+## Common Patterns
+
+### Find Slow Database Queries
+```bash
+# Find traces with slow DB operations
+python .claude/skills/observability-jaeger/scripts/get_traces.py \
+  --service order-service \
+  --tags db.type=postgres \
+  --min-duration 100
+```
+
+### Find HTTP Errors
+```bash
+# Find 5xx errors
+python .claude/skills/observability-jaeger/scripts/get_traces.py \
+  --service api-gateway \
+  --tags http.status_code=500
+
+# Or use error traces script
+python .claude/skills/observability-jaeger/scripts/get_error_traces.py --service api-gateway
+```
+
+### Compare Latency Across Services
+```bash
+# Get stats for each service
+python .claude/skills/observability-jaeger/scripts/get_latency_stats.py --service frontend
+python .claude/skills/observability-jaeger/scripts/get_latency_stats.py --service api
+python .claude/skills/observability-jaeger/scripts/get_latency_stats.py --service database
+```
+
+---
+
+## Anti-Patterns to Avoid
+
+1. **NEVER fetch all traces** - Always use filters (service, time, duration)
+2. **Skip service discovery** - Always start with `list_services.py`
+3. **Ignore latency stats** - Get percentiles before diving into individual traces
+4. **Focus on single spans** - Look at the full trace context
+5. **Miss error tags** - Always check for `error=true` in slow traces
+6. **Unbounded time ranges** - Always specify `--lookback` for time bounds
+
+---
+
+## Output Format
+
+When reporting trace findings, use this structure:
+
+```
+## Trace Analysis Summary
+
+### Service: [service name]
+### Time Window: [start] to [end]
+
+### Latency Statistics
+| Operation | p50 | p95 | p99 | Count |
+|-----------|-----|-----|-----|-------|
+| GET /api  | 50ms| 150ms| 300ms| 1000|
+
+### Slow Traces Found
+1. **Trace ID**: abc123
+   - **Duration**: 2.5s
+   - **Bottleneck**: database span (1.8s)
+   - **Root Cause**: Slow query on orders table
+
+### Error Traces Found
+1. **Trace ID**: def456
+   - **Error**: Connection refused to payment-service
+   - **Impact**: 5xx returned to client
+
+### Root Cause Hypothesis
+[Based on trace analysis]
+
+### Recommended Action
+[Specific remediation step]
+```

--- a/sre-agent/.claude/skills/observability-jaeger/scripts/get_error_traces.py
+++ b/sre-agent/.claude/skills/observability-jaeger/scripts/get_error_traces.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Find traces with errors in Jaeger."""
+
+import argparse
+import json
+import sys
+
+from jaeger_client import extract_span_info, search_traces
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Find traces with errors in Jaeger")
+    parser.add_argument(
+        "--service", "-s", required=True, help="Service name (required)"
+    )
+    parser.add_argument("--operation", "-o", help="Operation name filter")
+    parser.add_argument(
+        "--limit", "-l", type=int, default=20, help="Max traces to return (default: 20)"
+    )
+    parser.add_argument(
+        "--lookback", type=float, default=1, help="Hours to look back (default: 1)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Search for traces with error tag
+        traces = search_traces(
+            service=args.service,
+            operation=args.operation,
+            tags={"error": "true"},
+            limit=args.limit,
+            lookback_hours=args.lookback,
+        )
+
+        error_traces = []
+        for trace in traces:
+            spans = trace.get("spans", [])
+            processes = trace.get("processes", {})
+
+            if not spans:
+                continue
+
+            root_span = min(spans, key=lambda s: s.get("startTime", float("inf")))
+            root_info = extract_span_info(root_span, processes)
+
+            # Find error spans
+            error_spans = []
+            for span in spans:
+                info = extract_span_info(span, processes)
+                if info["has_error"]:
+                    # Try to extract error message from logs or tags
+                    error_msg = info["tags"].get("error.message", "")
+                    if not error_msg:
+                        for log in info["logs"]:
+                            for field in log.get("fields", []):
+                                if field.get("key") in [
+                                    "message",
+                                    "error",
+                                    "error.message",
+                                ]:
+                                    error_msg = str(field.get("value", ""))[:200]
+                                    break
+                            if error_msg:
+                                break
+
+                    error_spans.append(
+                        {
+                            "service": info["service"],
+                            "operation": info["operation"],
+                            "duration": info["duration"],
+                            "error_message": error_msg or "Unknown error",
+                            "http_status": info["tags"].get("http.status_code"),
+                        }
+                    )
+
+            if error_spans:
+                error_traces.append(
+                    {
+                        "trace_id": root_info["trace_id"],
+                        "service": root_info["service"],
+                        "operation": root_info["operation"],
+                        "duration": root_info["duration"],
+                        "duration_us": root_info["duration_us"],
+                        "span_count": len(spans),
+                        "error_spans": error_spans,
+                    }
+                )
+
+        if args.json:
+            print(
+                json.dumps(
+                    {"traces": error_traces, "count": len(error_traces)}, indent=2
+                )
+            )
+        else:
+            print(f"Error traces for '{args.service}'")
+            print(
+                f"Found {len(error_traces)} traces with errors in the last {args.lookback}h"
+            )
+            print()
+
+            if not error_traces:
+                print("No error traces found.")
+                return
+
+            for t in error_traces:
+                print(f"Trace: {t['trace_id']}")
+                print(f"  Duration: {t['duration']}")
+                print(f"  Operation: {t['operation']}")
+                print(f"  Error Spans ({len(t['error_spans'])}):")
+                for err_span in t["error_spans"][:3]:  # Limit to first 3
+                    status = (
+                        f" (HTTP {err_span['http_status']})"
+                        if err_span["http_status"]
+                        else ""
+                    )
+                    print(
+                        f"    - {err_span['service']}: {err_span['operation']}{status}"
+                    )
+                    if err_span["error_message"]:
+                        msg = err_span["error_message"][:80]
+                        if len(err_span["error_message"]) > 80:
+                            msg += "..."
+                        print(f"      Error: {msg}")
+                print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-jaeger/scripts/get_latency_stats.py
+++ b/sre-agent/.claude/skills/observability-jaeger/scripts/get_latency_stats.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Get latency statistics for a service from Jaeger."""
+
+import argparse
+import json
+import sys
+
+from jaeger_client import (
+    calculate_latency_stats,
+    format_duration,
+    get_operations,
+    search_traces,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get latency statistics for a service")
+    parser.add_argument(
+        "--service", "-s", required=True, help="Service name (required)"
+    )
+    parser.add_argument("--operation", "-o", help="Filter to specific operation")
+    parser.add_argument(
+        "--lookback", type=float, default=1, help="Hours to look back (default: 1)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        if args.operation:
+            # Stats for single operation
+            operations = [args.operation]
+        else:
+            # Get all operations
+            operations = get_operations(args.service)
+
+        stats_by_operation = {}
+
+        for op in operations:
+            traces = search_traces(
+                service=args.service,
+                operation=op,
+                limit=100,  # Get more traces for better stats
+                lookback_hours=args.lookback,
+            )
+            stats = calculate_latency_stats(traces)
+            if stats["count"] > 0:
+                stats_by_operation[op] = stats
+
+        if args.json:
+            # Convert durations to formatted strings for JSON
+            output = {}
+            for op, stats in stats_by_operation.items():
+                output[op] = {
+                    "count": stats["count"],
+                    "p50": format_duration(stats["p50"]),
+                    "p95": format_duration(stats["p95"]),
+                    "p99": format_duration(stats["p99"]),
+                    "min": format_duration(stats["min"]),
+                    "max": format_duration(stats["max"]),
+                    "avg": format_duration(stats["avg"]),
+                    "p50_us": stats["p50"],
+                    "p95_us": stats["p95"],
+                    "p99_us": stats["p99"],
+                }
+            print(
+                json.dumps(
+                    {
+                        "service": args.service,
+                        "lookback_hours": args.lookback,
+                        "operations": output,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(f"Latency Statistics for '{args.service}'")
+            print(f"Time window: last {args.lookback}h")
+            print()
+
+            if not stats_by_operation:
+                print("No trace data found.")
+                return
+
+            # Print header
+            print(
+                f"{'Operation':<40} {'Count':>8} {'p50':>10} {'p95':>10} {'p99':>10} {'Max':>10}"
+            )
+            print("-" * 98)
+
+            # Sort by p99 descending
+            sorted_ops = sorted(
+                stats_by_operation.items(),
+                key=lambda x: x[1]["p99"],
+                reverse=True,
+            )
+
+            for op, stats in sorted_ops:
+                # Truncate long operation names
+                op_display = op[:38] + ".." if len(op) > 40 else op
+                print(
+                    f"{op_display:<40} "
+                    f"{stats['count']:>8} "
+                    f"{format_duration(stats['p50']):>10} "
+                    f"{format_duration(stats['p95']):>10} "
+                    f"{format_duration(stats['p99']):>10} "
+                    f"{format_duration(stats['max']):>10}"
+                )
+
+            print()
+            print("Note: High p99 indicates tail latency issues.")
+            print(
+                "      Large gap between p50 and p99 suggests inconsistent performance."
+            )
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-jaeger/scripts/get_slow_traces.py
+++ b/sre-agent/.claude/skills/observability-jaeger/scripts/get_slow_traces.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Find slow traces in Jaeger."""
+
+import argparse
+import json
+import sys
+
+from jaeger_client import extract_span_info, search_traces
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Find slow traces in Jaeger")
+    parser.add_argument(
+        "--service", "-s", required=True, help="Service name (required)"
+    )
+    parser.add_argument("--operation", "-o", help="Operation name filter")
+    parser.add_argument(
+        "--min-duration",
+        type=int,
+        default=1000,
+        help="Minimum duration threshold in ms (default: 1000)",
+    )
+    parser.add_argument(
+        "--limit", "-l", type=int, default=20, help="Max traces to return (default: 20)"
+    )
+    parser.add_argument(
+        "--lookback", type=float, default=1, help="Hours to look back (default: 1)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        traces = search_traces(
+            service=args.service,
+            operation=args.operation,
+            min_duration=args.min_duration,
+            limit=args.limit,
+            lookback_hours=args.lookback,
+        )
+
+        # Sort by duration descending
+        trace_info = []
+        for trace in traces:
+            spans = trace.get("spans", [])
+            processes = trace.get("processes", {})
+            if spans:
+                root_span = min(spans, key=lambda s: s.get("startTime", float("inf")))
+                info = extract_span_info(root_span, processes)
+
+                # Find slowest child span
+                slowest_child = max(spans, key=lambda s: s.get("duration", 0))
+                slowest_info = extract_span_info(slowest_child, processes)
+
+                trace_info.append(
+                    {
+                        "trace_id": info["trace_id"],
+                        "service": info["service"],
+                        "operation": info["operation"],
+                        "duration": info["duration"],
+                        "duration_us": info["duration_us"],
+                        "has_error": info["has_error"],
+                        "span_count": len(spans),
+                        "slowest_span": {
+                            "service": slowest_info["service"],
+                            "operation": slowest_info["operation"],
+                            "duration": slowest_info["duration"],
+                            "duration_us": slowest_info["duration_us"],
+                        },
+                    }
+                )
+
+        # Sort by duration
+        trace_info.sort(key=lambda x: x["duration_us"], reverse=True)
+
+        if args.json:
+            print(
+                json.dumps({"traces": trace_info, "count": len(trace_info)}, indent=2)
+            )
+        else:
+            print(f"Slow traces for '{args.service}' (>{args.min_duration}ms)")
+            print(f"Found {len(trace_info)} traces in the last {args.lookback}h")
+            print()
+
+            if not trace_info:
+                print("No slow traces found.")
+                return
+
+            for t in trace_info:
+                error_marker = " [ERROR]" if t["has_error"] else ""
+                print(f"Trace: {t['trace_id']}")
+                print(f"  Total Duration: {t['duration']}{error_marker}")
+                print(f"  Operation: {t['operation']}")
+                print(f"  Spans: {t['span_count']}")
+                print(
+                    f"  Slowest Span: {t['slowest_span']['service']}: {t['slowest_span']['operation']} ({t['slowest_span']['duration']})"
+                )
+                print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-jaeger/scripts/get_trace.py
+++ b/sre-agent/.claude/skills/observability-jaeger/scripts/get_trace.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Get a specific trace by ID from Jaeger."""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+
+from jaeger_client import extract_span_info, get_trace
+
+
+def build_span_tree(spans: list[dict], processes: dict) -> list[dict]:
+    """Build a tree structure from flat span list."""
+    # Extract span info for all spans
+    span_map = {}
+    for span in spans:
+        info = extract_span_info(span, processes)
+        info["children"] = []
+        info["parent_id"] = None
+        # Find parent from references
+        for ref in span.get("references", []):
+            if ref.get("refType") == "CHILD_OF":
+                info["parent_id"] = ref.get("spanID")
+                break
+        span_map[info["span_id"]] = info
+
+    # Build tree
+    roots = []
+    for span_id, span_info in span_map.items():
+        parent_id = span_info["parent_id"]
+        if parent_id and parent_id in span_map:
+            span_map[parent_id]["children"].append(span_info)
+        else:
+            roots.append(span_info)
+
+    # Sort children by start time
+    def sort_children(node):
+        node["children"].sort(key=lambda x: x["start_time"])
+        for child in node["children"]:
+            sort_children(child)
+
+    for root in roots:
+        sort_children(root)
+
+    return sorted(roots, key=lambda x: x["start_time"])
+
+
+def print_span_tree(spans: list[dict], indent: int = 0):
+    """Print span tree with indentation."""
+    for span in spans:
+        prefix = "  " * indent
+        error_marker = " [ERROR]" if span["has_error"] else ""
+        print(f"{prefix}├─ {span['service']}: {span['operation']}")
+        print(f"{prefix}│  Duration: {span['duration']}{error_marker}")
+
+        # Print relevant tags
+        important_tags = [
+            "http.method",
+            "http.url",
+            "http.status_code",
+            "db.type",
+            "db.statement",
+            "error",
+        ]
+        for tag in important_tags:
+            if tag in span["tags"]:
+                value = span["tags"][tag]
+                # Truncate long values
+                if isinstance(value, str) and len(value) > 80:
+                    value = value[:77] + "..."
+                print(f"{prefix}│  {tag}: {value}")
+
+        # Print error logs if any
+        if span["has_error"] and span["logs"]:
+            for log in span["logs"][:2]:  # Limit to first 2 logs
+                for field in log.get("fields", []):
+                    if field.get("key") in ["message", "error", "event"]:
+                        print(f"{prefix}│  Log: {field.get('value', '')[:100]}")
+
+        print(f"{prefix}│")
+
+        if span["children"]:
+            print_span_tree(span["children"], indent + 1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get a specific trace by ID")
+    parser.add_argument("trace_id", help="Trace ID")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        trace = get_trace(args.trace_id)
+
+        if not trace:
+            print(f"Trace not found: {args.trace_id}", file=sys.stderr)
+            sys.exit(1)
+
+        spans = trace.get("spans", [])
+        processes = trace.get("processes", {})
+
+        if args.json:
+            # Build simplified span tree for JSON
+            tree = build_span_tree(spans, processes)
+            print(
+                json.dumps(
+                    {
+                        "trace_id": args.trace_id,
+                        "span_count": len(spans),
+                        "spans": tree,
+                    },
+                    indent=2,
+                    default=str,
+                )
+            )
+        else:
+            # Find root span for summary
+            if spans:
+                root_span = min(spans, key=lambda s: s.get("startTime", float("inf")))
+                root_info = extract_span_info(root_span, processes)
+                total_duration = root_info["duration"]
+
+                # Calculate time
+                start_time = datetime.fromtimestamp(
+                    root_span.get("startTime", 0) / 1_000_000, tz=timezone.utc
+                )
+
+                print(f"Trace: {args.trace_id}")
+                print(f"Time: {start_time.isoformat()}")
+                print(f"Total Duration: {total_duration}")
+                print(f"Span Count: {len(spans)}")
+
+                # Count errors
+                error_count = sum(
+                    1
+                    for s in spans
+                    if extract_span_info(s, processes).get("has_error", False)
+                )
+                if error_count:
+                    print(f"Errors: {error_count} spans with errors")
+
+                # Find slowest spans
+                sorted_spans = sorted(
+                    spans, key=lambda s: s.get("duration", 0), reverse=True
+                )
+                print("\nSlowest Spans:")
+                for span in sorted_spans[:5]:
+                    info = extract_span_info(span, processes)
+                    error = " [ERROR]" if info["has_error"] else ""
+                    print(
+                        f"  {info['duration']:>10} - {info['service']}: {info['operation']}{error}"
+                    )
+
+                print("\nSpan Tree:")
+                print("-" * 60)
+                tree = build_span_tree(spans, processes)
+                print_span_tree(tree)
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-jaeger/scripts/get_traces.py
+++ b/sre-agent/.claude/skills/observability-jaeger/scripts/get_traces.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Search for traces in Jaeger with filters."""
+
+import argparse
+import json
+import sys
+
+from jaeger_client import extract_span_info, search_traces
+
+
+def parse_tags(tag_strings: list[str] | None) -> dict[str, str]:
+    """Parse tag strings in key=value format."""
+    if not tag_strings:
+        return {}
+    tags = {}
+    for tag in tag_strings:
+        if "=" in tag:
+            key, value = tag.split("=", 1)
+            tags[key] = value
+    return tags
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search for traces in Jaeger")
+    parser.add_argument(
+        "--service", "-s", required=True, help="Service name (required)"
+    )
+    parser.add_argument("--operation", "-o", help="Operation name filter")
+    parser.add_argument(
+        "--tags", "-t", action="append", help="Tag filter (key=value, can repeat)"
+    )
+    parser.add_argument("--min-duration", type=int, help="Minimum duration in ms")
+    parser.add_argument("--max-duration", type=int, help="Maximum duration in ms")
+    parser.add_argument(
+        "--limit", "-l", type=int, default=20, help="Max traces to return (default: 20)"
+    )
+    parser.add_argument(
+        "--lookback", type=float, default=1, help="Hours to look back (default: 1)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        tags = parse_tags(args.tags)
+
+        traces = search_traces(
+            service=args.service,
+            operation=args.operation,
+            tags=tags,
+            min_duration=args.min_duration,
+            max_duration=args.max_duration,
+            limit=args.limit,
+            lookback_hours=args.lookback,
+        )
+
+        if args.json:
+            # Simplified JSON output
+            output = []
+            for trace in traces:
+                spans = trace.get("spans", [])
+                processes = trace.get("processes", {})
+                if spans:
+                    root_span = min(
+                        spans, key=lambda s: s.get("startTime", float("inf"))
+                    )
+                    info = extract_span_info(root_span, processes)
+                    output.append(
+                        {
+                            "trace_id": info["trace_id"],
+                            "service": info["service"],
+                            "operation": info["operation"],
+                            "duration": info["duration"],
+                            "duration_us": info["duration_us"],
+                            "has_error": info["has_error"],
+                            "span_count": len(spans),
+                        }
+                    )
+            print(json.dumps({"traces": output, "count": len(output)}, indent=2))
+        else:
+            print(f"Found {len(traces)} traces for service '{args.service}'")
+            if args.operation:
+                print(f"Operation filter: {args.operation}")
+            if tags:
+                print(f"Tag filters: {tags}")
+            if args.min_duration:
+                print(f"Min duration: {args.min_duration}ms")
+            print()
+
+            for trace in traces:
+                spans = trace.get("spans", [])
+                processes = trace.get("processes", {})
+                if spans:
+                    root_span = min(
+                        spans, key=lambda s: s.get("startTime", float("inf"))
+                    )
+                    info = extract_span_info(root_span, processes)
+                    error_marker = " [ERROR]" if info["has_error"] else ""
+                    print(f"Trace: {info['trace_id']}")
+                    print(f"  Operation: {info['operation']}")
+                    print(f"  Duration: {info['duration']}{error_marker}")
+                    print(f"  Spans: {len(spans)}")
+                    print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-jaeger/scripts/jaeger_client.py
+++ b/sre-agent/.claude/skills/observability-jaeger/scripts/jaeger_client.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Shared Jaeger API client with proxy support."""
+
+import json
+import os
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+
+def get_api_url() -> str:
+    """Get Jaeger API URL from environment.
+
+    Supports two modes:
+    1. Proxy mode: JAEGER_BASE_URL (credential proxy)
+    2. Direct mode: JAEGER_URL
+
+    Returns:
+        Jaeger API base URL
+    """
+    # Proxy mode (production)
+    base_url = os.environ.get("JAEGER_BASE_URL")
+    if base_url:
+        return base_url.rstrip("/")
+
+    # Direct mode
+    if os.environ.get("JAEGER_URL"):
+        return os.environ["JAEGER_URL"].rstrip("/")
+
+    # Default to proxy endpoint
+    return "http://localhost:8001/jaeger"
+
+
+def get_headers() -> dict[str, str]:
+    """Get headers for Jaeger API requests.
+
+    Supports multiple auth methods:
+    1. Bearer token - JAEGER_TOKEN
+    2. Basic auth - JAEGER_USER + JAEGER_PASSWORD
+    3. Proxy mode - tenant context headers
+    4. No auth (default for internal Jaeger)
+
+    Environment variables:
+        JAEGER_TOKEN: Bearer token
+        JAEGER_USER + JAEGER_PASSWORD: Basic auth
+    """
+    import base64
+
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    # Priority 1: Bearer token
+    token = os.environ.get("JAEGER_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+        return headers
+
+    # Priority 2: Basic auth
+    user = os.environ.get("JAEGER_USER")
+    password = os.environ.get("JAEGER_PASSWORD")
+    if user and password:
+        encoded = base64.b64encode(f"{user}:{password}".encode()).decode()
+        headers["Authorization"] = f"Basic {encoded}"
+        return headers
+
+    # Priority 3: Proxy mode - use JWT for credential-resolver auth
+    if os.environ.get("JAEGER_BASE_URL"):
+        sandbox_jwt = os.environ.get("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            # Fallback for local dev
+            headers["X-Tenant-Id"] = os.environ.get("OPENSRE_TENANT_ID", "local")
+            headers["X-Team-Id"] = os.environ.get("OPENSRE_TEAM_ID", "local")
+
+    # No auth (internal Jaeger)
+    return headers
+
+
+def api_request(endpoint: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Make a GET request to Jaeger API.
+
+    Args:
+        endpoint: API endpoint (e.g., '/api/services')
+        params: Query parameters
+
+    Returns:
+        JSON response as dict
+    """
+    base_url = get_api_url()
+    url = f"{base_url}{endpoint}"
+
+    if params:
+        # Filter out None values and convert to strings
+        filtered_params = {k: str(v) for k, v in params.items() if v is not None}
+        if filtered_params:
+            url = f"{url}?{urllib.parse.urlencode(filtered_params)}"
+
+    req = urllib.request.Request(url, headers=get_headers())
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode("utf-8") if e.fp else ""
+        raise RuntimeError(f"Jaeger API error {e.code}: {error_body}") from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"Failed to connect to Jaeger: {e.reason}") from e
+
+
+def get_services() -> list[str]:
+    """Get list of all services."""
+    response = api_request("/api/services")
+    return response.get("data", [])
+
+
+def get_operations(service: str) -> list[str]:
+    """Get list of operations for a service."""
+    response = api_request(f"/api/services/{urllib.parse.quote(service)}/operations")
+    return response.get("data", [])
+
+
+def search_traces(
+    service: str,
+    operation: str | None = None,
+    tags: dict[str, str] | None = None,
+    min_duration: int | None = None,
+    max_duration: int | None = None,
+    limit: int = 20,
+    lookback_hours: float = 1,
+) -> list[dict[str, Any]]:
+    """Search for traces with filters.
+
+    Args:
+        service: Service name (required)
+        operation: Operation name filter
+        tags: Tag filters as key=value pairs
+        min_duration: Minimum duration in milliseconds
+        max_duration: Maximum duration in milliseconds
+        limit: Maximum number of traces to return
+        lookback_hours: How far back to search in hours
+
+    Returns:
+        List of trace objects
+    """
+    now = datetime.now(timezone.utc)
+    start_time = now - timedelta(hours=lookback_hours)
+
+    params = {
+        "service": service,
+        "limit": limit,
+        "start": int(start_time.timestamp() * 1_000_000),  # microseconds
+        "end": int(now.timestamp() * 1_000_000),
+    }
+
+    if operation:
+        params["operation"] = operation
+
+    if min_duration:
+        params["minDuration"] = f"{min_duration}ms"
+
+    if max_duration:
+        params["maxDuration"] = f"{max_duration}ms"
+
+    if tags:
+        # Jaeger expects tags as JSON string
+        params["tags"] = json.dumps(tags)
+
+    response = api_request("/api/traces", params)
+    return response.get("data", [])
+
+
+def get_trace(trace_id: str) -> dict[str, Any] | None:
+    """Get a specific trace by ID.
+
+    Args:
+        trace_id: The trace ID
+
+    Returns:
+        Trace object or None if not found
+    """
+    response = api_request(f"/api/traces/{trace_id}")
+    traces = response.get("data", [])
+    return traces[0] if traces else None
+
+
+def format_duration(microseconds: int) -> str:
+    """Format duration in microseconds to human readable string."""
+    if microseconds < 1000:
+        return f"{microseconds}µs"
+    elif microseconds < 1_000_000:
+        return f"{microseconds / 1000:.1f}ms"
+    else:
+        return f"{microseconds / 1_000_000:.2f}s"
+
+
+def extract_span_info(
+    span: dict[str, Any], processes: dict[str, Any]
+) -> dict[str, Any]:
+    """Extract relevant info from a span.
+
+    Args:
+        span: Span object from Jaeger
+        processes: Process map from trace
+
+    Returns:
+        Simplified span info dict
+    """
+    process_id = span.get("processID", "")
+    process = processes.get(process_id, {})
+    service_name = process.get("serviceName", "unknown")
+
+    # Extract tags
+    tags = {}
+    for tag in span.get("tags", []):
+        tags[tag["key"]] = tag["value"]
+
+    # Check for errors
+    has_error = tags.get("error", False) or tags.get("otel.status_code") == "ERROR"
+
+    return {
+        "span_id": span.get("spanID", ""),
+        "trace_id": span.get("traceID", ""),
+        "operation": span.get("operationName", ""),
+        "service": service_name,
+        "duration_us": span.get("duration", 0),
+        "duration": format_duration(span.get("duration", 0)),
+        "start_time": span.get("startTime", 0),
+        "tags": tags,
+        "has_error": has_error,
+        "logs": span.get("logs", []),
+    }
+
+
+def calculate_latency_stats(traces: list[dict[str, Any]]) -> dict[str, Any]:
+    """Calculate latency statistics from traces.
+
+    Args:
+        traces: List of trace objects
+
+    Returns:
+        Statistics dict with p50, p95, p99, etc.
+    """
+    if not traces:
+        return {"count": 0, "p50": 0, "p95": 0, "p99": 0, "min": 0, "max": 0, "avg": 0}
+
+    # Get root span durations
+    durations = []
+    for trace in traces:
+        spans = trace.get("spans", [])
+        if spans:
+            # Find root span (no parent or min start time)
+            root_span = min(spans, key=lambda s: s.get("startTime", float("inf")))
+            durations.append(root_span.get("duration", 0))
+
+    if not durations:
+        return {"count": 0, "p50": 0, "p95": 0, "p99": 0, "min": 0, "max": 0, "avg": 0}
+
+    durations.sort()
+    n = len(durations)
+
+    def percentile(p: float) -> int:
+        idx = int(n * p / 100)
+        return durations[min(idx, n - 1)]
+
+    return {
+        "count": n,
+        "p50": percentile(50),
+        "p95": percentile(95),
+        "p99": percentile(99),
+        "min": durations[0],
+        "max": durations[-1],
+        "avg": sum(durations) // n,
+    }

--- a/sre-agent/.claude/skills/observability-jaeger/scripts/list_operations.py
+++ b/sre-agent/.claude/skills/observability-jaeger/scripts/list_operations.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""List operations for a service in Jaeger."""
+
+import argparse
+import json
+import sys
+
+from jaeger_client import get_operations
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List operations for a service")
+    parser.add_argument("service", help="Service name")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        operations = get_operations(args.service)
+
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "service": args.service,
+                        "operations": operations,
+                        "count": len(operations),
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(f"Operations for '{args.service}' ({len(operations)} found):\n")
+            for op in sorted(operations):
+                print(f"  - {op}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-jaeger/scripts/list_services.py
+++ b/sre-agent/.claude/skills/observability-jaeger/scripts/list_services.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""List all services traced in Jaeger."""
+
+import argparse
+import json
+import sys
+
+from jaeger_client import get_services
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List all services in Jaeger")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        services = get_services()
+
+        if args.json:
+            print(json.dumps({"services": services, "count": len(services)}, indent=2))
+        else:
+            print(f"Found {len(services)} services:\n")
+            for service in sorted(services):
+                print(f"  - {service}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-loki/SKILL.md
+++ b/sre-agent/.claude/skills/observability-loki/SKILL.md
@@ -1,0 +1,118 @@
+---
+description: Query and analyze logs from Grafana Loki using LogQL
+allowed-tools:
+  - Bash
+---
+
+# Loki Log Analysis Skill
+
+Query and analyze logs from Grafana Loki for incident investigation and debugging.
+
+## Investigation Workflow
+
+1. **List available labels** to understand what's queryable
+2. **Get statistics** to understand log volume and error rates
+3. **Sample logs** to see representative entries
+4. **Query specific patterns** with LogQL
+
+## LogQL Quick Reference
+
+### Stream Selectors (required)
+```logql
+{app="frontend"}                    # Exact match
+{namespace=~"prod-.*"}              # Regex match
+{container!="sidecar"}              # Not equal
+{pod=~".+"}                         # Any non-empty value
+```
+
+### Line Filters
+```logql
+{app="api"} |= "error"              # Contains "error"
+{app="api"} != "debug"              # Does not contain
+{app="api"} |~ "error|warn"         # Regex match
+{app="api"} !~ "health|ready"       # Regex not match
+```
+
+### Parser & Label Extraction
+```logql
+{app="api"} | json                  # Parse JSON logs
+{app="api"} | logfmt                # Parse logfmt
+{app="api"} | pattern `<ip> - <_> [<timestamp>] "<method> <path>"`
+{app="api"} | json | level="error"  # Filter on extracted labels
+```
+
+### Aggregations (Metric Queries)
+```logql
+# Count logs per second
+rate({app="api"}[5m])
+
+# Count errors per minute
+sum(rate({app="api"} |= "error" [1m])) by (pod)
+
+# Bytes processed
+bytes_rate({app="api"}[5m])
+
+# Unique values
+count_over_time({app="api"} | json | __error__="" [1h])
+```
+
+## Available Scripts
+
+### list_labels.py
+List available labels and their values.
+```bash
+python scripts/list_labels.py
+python scripts/list_labels.py --label app
+python scripts/list_labels.py --label namespace --json
+```
+
+### get_statistics.py
+Get log volume and error statistics.
+```bash
+python scripts/get_statistics.py --selector '{app="frontend"}'
+python scripts/get_statistics.py --selector '{namespace="production"}' --lookback 2
+python scripts/get_statistics.py --selector '{app=~"api.*"}' --json
+```
+
+### sample_logs.py
+Get sample log entries.
+```bash
+python scripts/sample_logs.py --selector '{app="frontend"}'
+python scripts/sample_logs.py --selector '{app="api"}' --filter "error"
+python scripts/sample_logs.py --selector '{namespace="prod"}' --limit 50 --json
+```
+
+### query_logs.py
+Execute raw LogQL queries.
+```bash
+python scripts/query_logs.py '{app="api"} |= "error" | json'
+python scripts/query_logs.py 'rate({app="api"} |= "error" [5m])' --type metric
+python scripts/query_logs.py '{app="api"}' --limit 100 --lookback 2 --json
+```
+
+## Environment Variables
+
+- `LOKI_BASE_URL`: Proxy endpoint (production)
+- `LOKI_URL`: Direct Loki URL (testing, e.g., http://loki:3100)
+
+## Common Investigation Patterns
+
+### Find errors in a service
+```bash
+python scripts/sample_logs.py --selector '{app="api"}' --filter "error|exception|fail"
+```
+
+### Compare error rates across pods
+```bash
+python scripts/query_logs.py 'sum(rate({app="api"} |= "error" [5m])) by (pod)' --type metric
+```
+
+### Find slow requests (if using JSON logs with duration)
+```bash
+python scripts/query_logs.py '{app="api"} | json | duration > 1000' --limit 20
+```
+
+### Correlate logs around a timestamp
+```bash
+python scripts/query_logs.py '{app="api"}' --start "2024-01-15T10:30:00Z" --end "2024-01-15T10:35:00Z"
+```

--- a/sre-agent/.claude/skills/observability-loki/scripts/get_statistics.py
+++ b/sre-agent/.claude/skills/observability-loki/scripts/get_statistics.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Get log volume and error statistics from Loki."""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+from loki_client import query_instant
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get log statistics from Loki")
+    parser.add_argument(
+        "--selector",
+        "-s",
+        required=True,
+        help="Stream selector (e.g., '{app=\"api\"}')",
+    )
+    parser.add_argument(
+        "--lookback",
+        type=float,
+        default=1,
+        help="Hours to look back (default: 1)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        now = datetime.now(timezone.utc)
+        now - timedelta(hours=args.lookback)
+
+        # Get total log count
+        total_query = f"count_over_time({args.selector}[{args.lookback}h])"
+        total_result = query_instant(total_query)
+
+        total_count = 0
+        if total_result.get("data", {}).get("result"):
+            for item in total_result["data"]["result"]:
+                value = item.get("value", [None, "0"])
+                total_count += int(float(value[1]))
+
+        # Get error count
+        error_selector = f'{args.selector} |~ "(?i)error|exception|fail|fatal"'
+        error_query = f"count_over_time({error_selector}[{args.lookback}h])"
+        error_result = query_instant(error_query)
+
+        error_count = 0
+        if error_result.get("data", {}).get("result"):
+            for item in error_result["data"]["result"]:
+                value = item.get("value", [None, "0"])
+                error_count += int(float(value[1]))
+
+        # Get warning count
+        warn_selector = f'{args.selector} |~ "(?i)warn"'
+        warn_query = f"count_over_time({warn_selector}[{args.lookback}h])"
+        warn_result = query_instant(warn_query)
+
+        warn_count = 0
+        if warn_result.get("data", {}).get("result"):
+            for item in warn_result["data"]["result"]:
+                value = item.get("value", [None, "0"])
+                warn_count += int(float(value[1]))
+
+        # Calculate rates
+        logs_per_minute = total_count / (args.lookback * 60) if total_count > 0 else 0
+        error_rate = (error_count / total_count * 100) if total_count > 0 else 0
+
+        stats = {
+            "selector": args.selector,
+            "time_range_hours": args.lookback,
+            "total_logs": total_count,
+            "error_logs": error_count,
+            "warning_logs": warn_count,
+            "logs_per_minute": round(logs_per_minute, 2),
+            "error_rate_percent": round(error_rate, 2),
+        }
+
+        if args.json:
+            print(json.dumps(stats, indent=2))
+        else:
+            print(f"Log Statistics for: {args.selector}")
+            print(f"Time window: last {args.lookback}h")
+            print()
+            print(f"  Total logs:       {total_count:,}")
+            print(f"  Error logs:       {error_count:,}")
+            print(f"  Warning logs:     {warn_count:,}")
+            print()
+            print(f"  Logs/minute:      {logs_per_minute:.2f}")
+            print(f"  Error rate:       {error_rate:.2f}%")
+            print()
+
+            if error_rate > 5:
+                print("⚠ High error rate detected!")
+            elif error_rate > 1:
+                print("Note: Elevated error rate")
+            else:
+                print("✓ Error rate within normal range")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-loki/scripts/list_labels.py
+++ b/sre-agent/.claude/skills/observability-loki/scripts/list_labels.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""List available labels and their values from Loki."""
+
+import argparse
+import json
+import sys
+
+from loki_client import get_label_values, get_labels
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Loki labels and values")
+    parser.add_argument("--label", "-l", help="Get values for a specific label")
+    parser.add_argument(
+        "--lookback",
+        type=float,
+        default=6,
+        help="Hours to look back for labels (default: 6)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        if args.label:
+            # Get values for specific label
+            values = get_label_values(args.label)
+
+            if args.json:
+                print(json.dumps({"label": args.label, "values": values}, indent=2))
+            else:
+                print(f"Values for label '{args.label}':")
+                print()
+                if not values:
+                    print("  No values found")
+                else:
+                    for value in sorted(values):
+                        print(f"  {value}")
+                print()
+                print(f"Total: {len(values)} values")
+        else:
+            # Get all labels
+            labels = get_labels()
+
+            if args.json:
+                print(json.dumps({"labels": labels}, indent=2))
+            else:
+                print("Available Labels:")
+                print()
+                if not labels:
+                    print("  No labels found")
+                else:
+                    for label in sorted(labels):
+                        print(f"  {label}")
+                print()
+                print(f"Total: {len(labels)} labels")
+                print()
+                print("Tip: Use --label <name> to see values for a specific label")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-loki/scripts/loki_client.py
+++ b/sre-agent/.claude/skills/observability-loki/scripts/loki_client.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Shared Loki client with proxy support.
+
+This module provides the Loki client that works through the credential proxy.
+Credentials are injected transparently by the proxy layer.
+
+Supports Loki 2.x and 3.x via HTTP API.
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+
+
+def get_config() -> dict[str, str | None]:
+    """Get Loki configuration from environment.
+
+    Credentials are injected by the credential-proxy based on tenant context.
+
+    Environment variables:
+        OPENSRE_TENANT_ID - Tenant ID for credential lookup
+        OPENSRE_TEAM_ID - Team ID for credential lookup
+    """
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+    }
+
+
+def get_api_url(endpoint: str) -> str:
+    """Build the Loki API URL.
+
+    Supports two modes:
+    1. Proxy mode (production): Uses LOKI_BASE_URL
+    2. Direct mode (testing): Uses LOKI_URL
+
+    Args:
+        endpoint: API path (e.g., "/loki/api/v1/query")
+
+    Returns:
+        Full API URL
+    """
+    # Proxy mode (production)
+    base_url = os.getenv("LOKI_BASE_URL")
+    if base_url:
+        return f"{base_url.rstrip('/')}{endpoint}"
+
+    # Direct mode (testing)
+    direct_url = os.getenv("LOKI_URL")
+    if direct_url:
+        return f"{direct_url.rstrip('/')}{endpoint}"
+
+    raise RuntimeError(
+        "Either LOKI_BASE_URL (proxy mode) or LOKI_URL (direct mode) must be set."
+    )
+
+
+def get_headers() -> dict[str, str]:
+    """Get Loki API headers.
+
+    Supports multiple auth methods:
+    1. Bearer token - LOKI_TOKEN
+    2. Basic auth - LOKI_USER + LOKI_PASSWORD
+    3. Multi-tenant org ID - LOKI_ORG_ID (X-Scope-OrgID header)
+    4. Proxy mode - tenant context headers
+
+    Environment variables:
+        LOKI_TOKEN: Bearer token (Grafana Cloud, enterprise)
+        LOKI_USER + LOKI_PASSWORD: Basic auth
+        LOKI_ORG_ID: Multi-tenant organization ID
+    """
+    config = get_config()
+    import base64
+
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    # Always add org ID if provided (multi-tenant Loki)
+    org_id = os.getenv("LOKI_ORG_ID")
+    if org_id:
+        headers["X-Scope-OrgID"] = org_id
+
+    # Priority 1: Bearer token (Grafana Cloud / enterprise)
+    token = os.getenv("LOKI_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+        return headers
+
+    # Priority 2: Basic auth
+    user = os.getenv("LOKI_USER")
+    password = os.getenv("LOKI_PASSWORD")
+    if user and password:
+        encoded = base64.b64encode(f"{user}:{password}".encode()).decode()
+        headers["Authorization"] = f"Basic {encoded}"
+        return headers
+
+    # Priority 3: Proxy mode - use JWT for credential-resolver auth
+    if os.getenv("LOKI_BASE_URL"):
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            # Fallback for local dev
+            headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+            headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    # No auth (local Loki without security)
+    return headers
+
+
+def query(
+    query: str,
+    limit: int = 100,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    direction: str = "backward",
+) -> dict[str, Any]:
+    """Execute a LogQL query (log stream query).
+
+    Args:
+        query: LogQL query string
+        limit: Maximum number of entries to return
+        start: Start time (default: 1 hour ago)
+        end: End time (default: now)
+        direction: "forward" or "backward" (default)
+
+    Returns:
+        Query response with streams or matrix data
+    """
+    now = datetime.now(timezone.utc)
+    if end is None:
+        end = now
+    if start is None:
+        start = now - timedelta(hours=1)
+
+    # Convert to nanoseconds
+    start_ns = int(start.timestamp() * 1e9)
+    end_ns = int(end.timestamp() * 1e9)
+
+    params = {
+        "query": query,
+        "limit": limit,
+        "start": start_ns,
+        "end": end_ns,
+        "direction": direction,
+    }
+
+    url = get_api_url(f"/loki/api/v1/query_range?{urlencode(params)}")
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+        return response.json()
+
+
+def query_instant(query: str, time: datetime | None = None) -> dict[str, Any]:
+    """Execute an instant LogQL query (for metric queries at a single point).
+
+    Args:
+        query: LogQL metric query
+        time: Evaluation time (default: now)
+
+    Returns:
+        Query response with vector data
+    """
+    if time is None:
+        time = datetime.now(timezone.utc)
+
+    time_ns = int(time.timestamp() * 1e9)
+
+    params = {
+        "query": query,
+        "time": time_ns,
+    }
+
+    url = get_api_url(f"/loki/api/v1/query?{urlencode(params)}")
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+        return response.json()
+
+
+def get_labels(start: datetime | None = None, end: datetime | None = None) -> list[str]:
+    """Get all label names.
+
+    Args:
+        start: Start time (default: 6 hours ago)
+        end: End time (default: now)
+
+    Returns:
+        List of label names
+    """
+    now = datetime.now(timezone.utc)
+    if end is None:
+        end = now
+    if start is None:
+        start = now - timedelta(hours=6)
+
+    start_ns = int(start.timestamp() * 1e9)
+    end_ns = int(end.timestamp() * 1e9)
+
+    params = {"start": start_ns, "end": end_ns}
+    url = get_api_url(f"/loki/api/v1/labels?{urlencode(params)}")
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+        data = response.json()
+        return data.get("data", [])
+
+
+def get_label_values(
+    label: str, start: datetime | None = None, end: datetime | None = None
+) -> list[str]:
+    """Get values for a specific label.
+
+    Args:
+        label: Label name
+        start: Start time (default: 6 hours ago)
+        end: End time (default: now)
+
+    Returns:
+        List of label values
+    """
+    now = datetime.now(timezone.utc)
+    if end is None:
+        end = now
+    if start is None:
+        start = now - timedelta(hours=6)
+
+    start_ns = int(start.timestamp() * 1e9)
+    end_ns = int(end.timestamp() * 1e9)
+
+    params = {"start": start_ns, "end": end_ns}
+    url = get_api_url(f"/loki/api/v1/label/{label}/values?{urlencode(params)}")
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+        data = response.json()
+        return data.get("data", [])
+
+
+def get_series(
+    match: list[str], start: datetime | None = None, end: datetime | None = None
+) -> list[dict]:
+    """Get series (label combinations) matching selectors.
+
+    Args:
+        match: List of stream selectors (e.g., ['{app="api"}'])
+        start: Start time (default: 1 hour ago)
+        end: End time (default: now)
+
+    Returns:
+        List of label sets
+    """
+    now = datetime.now(timezone.utc)
+    if end is None:
+        end = now
+    if start is None:
+        start = now - timedelta(hours=1)
+
+    start_ns = int(start.timestamp() * 1e9)
+    end_ns = int(end.timestamp() * 1e9)
+
+    params = [("start", start_ns), ("end", end_ns)]
+    for m in match:
+        params.append(("match[]", m))
+
+    url = get_api_url(f"/loki/api/v1/series?{urlencode(params)}")
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+        data = response.json()
+        return data.get("data", [])
+
+
+def format_log_entry(stream: dict, entry: list, max_length: int = 300) -> str:
+    """Format a log entry for display.
+
+    Args:
+        stream: Stream labels dict
+        entry: [timestamp_ns, line] tuple
+        max_length: Maximum line length
+
+    Returns:
+        Formatted string
+    """
+    ts_ns, line = entry
+    # Convert nanoseconds to datetime
+    ts = datetime.fromtimestamp(int(ts_ns) / 1e9, tz=timezone.utc)
+    ts_str = ts.strftime("%Y-%m-%d %H:%M:%S")
+
+    # Get key labels
+    app = (
+        stream.get("app")
+        or stream.get("application")
+        or stream.get("container")
+        or "unknown"
+    )
+    pod = stream.get("pod") or stream.get("instance") or ""
+    namespace = stream.get("namespace") or ""
+
+    # Build context
+    context_parts = [app]
+    if namespace:
+        context_parts.insert(0, namespace)
+    if pod:
+        context_parts.append(pod)
+
+    context = "/".join(context_parts)
+
+    # Truncate line
+    if len(line) > max_length:
+        line = line[: max_length - 3] + "..."
+
+    return f"[{ts_str}] {context}\n  {line}"

--- a/sre-agent/.claude/skills/observability-loki/scripts/query_logs.py
+++ b/sre-agent/.claude/skills/observability-loki/scripts/query_logs.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Execute raw LogQL queries against Loki."""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+from loki_client import format_log_entry, query, query_instant
+
+
+def format_metric_result(result: list) -> str:
+    """Format metric query results."""
+    lines = []
+    for item in result:
+        metric = item.get("metric", {})
+        values = item.get("values", [])
+        value = item.get("value")  # For instant queries
+
+        # Format metric labels
+        if metric:
+            label_str = ", ".join(f'{k}="{v}"' for k, v in sorted(metric.items()))
+            label_str = f"{{{label_str}}}"
+        else:
+            label_str = "{}"
+
+        if value:
+            # Instant query result
+            ts, val = value
+            lines.append(f"{label_str} => {val}")
+        elif values:
+            # Range query result
+            lines.append(f"{label_str}:")
+            for ts, val in values[-5:]:  # Last 5 values
+                dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+                lines.append(f"  {dt.strftime('%H:%M:%S')} => {val}")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Execute LogQL queries")
+    parser.add_argument("query", help="LogQL query string")
+    parser.add_argument(
+        "--type",
+        "-t",
+        choices=["log", "metric"],
+        default="log",
+        help="Query type: 'log' for streams, 'metric' for aggregations (default: log)",
+    )
+    parser.add_argument(
+        "--limit",
+        "-l",
+        type=int,
+        default=50,
+        help="Max entries for log queries (default: 50)",
+    )
+    parser.add_argument(
+        "--lookback",
+        type=float,
+        default=1,
+        help="Hours to look back (default: 1)",
+    )
+    parser.add_argument(
+        "--start",
+        help="Start time (ISO format, e.g., 2024-01-15T10:00:00Z)",
+    )
+    parser.add_argument(
+        "--end",
+        help="End time (ISO format, e.g., 2024-01-15T11:00:00Z)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Parse time range
+        if args.start:
+            start = datetime.fromisoformat(args.start.replace("Z", "+00:00"))
+        else:
+            start = datetime.now(timezone.utc) - timedelta(hours=args.lookback)
+
+        if args.end:
+            end = datetime.fromisoformat(args.end.replace("Z", "+00:00"))
+        else:
+            end = datetime.now(timezone.utc)
+
+        if args.type == "metric":
+            # Metric query
+            result = query_instant(args.query)
+            data = result.get("data", {})
+            result_type = data.get("resultType", "vector")
+            results = data.get("result", [])
+
+            if args.json:
+                print(
+                    json.dumps(
+                        {
+                            "query": args.query,
+                            "type": result_type,
+                            "result": results,
+                        },
+                        indent=2,
+                    )
+                )
+            else:
+                print(f"Metric Query: {args.query}")
+                print(f"Result Type: {result_type}")
+                print()
+
+                if not results:
+                    print("No data returned.")
+                else:
+                    print(format_metric_result(results))
+
+        else:
+            # Log query
+            result = query(args.query, limit=args.limit, start=start, end=end)
+            data = result.get("data", {})
+            result_type = data.get("resultType", "streams")
+            streams = data.get("result", [])
+
+            if args.json:
+                entries = []
+                for stream in streams:
+                    labels = stream.get("stream", {})
+                    for entry in stream.get("values", []):
+                        ts_ns, line = entry
+                        ts = datetime.fromtimestamp(int(ts_ns) / 1e9, tz=timezone.utc)
+                        entries.append(
+                            {
+                                "timestamp": ts.isoformat(),
+                                "labels": labels,
+                                "line": line,
+                            }
+                        )
+                entries.sort(key=lambda x: x["timestamp"], reverse=True)
+                print(
+                    json.dumps(
+                        {
+                            "query": args.query,
+                            "count": len(entries),
+                            "entries": entries,
+                        },
+                        indent=2,
+                    )
+                )
+            else:
+                print(f"Log Query: {args.query}")
+                print(f"Time Range: {start.isoformat()} to {end.isoformat()}")
+                print()
+
+                # Collect all entries
+                all_entries = []
+                for stream in streams:
+                    labels = stream.get("stream", {})
+                    for entry in stream.get("values", []):
+                        all_entries.append((labels, entry))
+
+                all_entries.sort(key=lambda x: x[1][0], reverse=True)
+
+                if not all_entries:
+                    print("No logs found.")
+                    return
+
+                for labels, entry in all_entries[: args.limit]:
+                    print(format_log_entry(labels, entry))
+                    print()
+
+                print("-" * 60)
+                print(f"Returned {len(all_entries)} entries")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-loki/scripts/sample_logs.py
+++ b/sre-agent/.claude/skills/observability-loki/scripts/sample_logs.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Sample log entries from Loki."""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+from loki_client import format_log_entry, query
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Sample logs from Loki")
+    parser.add_argument(
+        "--selector",
+        "-s",
+        required=True,
+        help="Stream selector (e.g., '{app=\"api\"}')",
+    )
+    parser.add_argument(
+        "--filter",
+        "-f",
+        help="Line filter pattern (e.g., 'error|exception')",
+    )
+    parser.add_argument(
+        "--limit",
+        "-l",
+        type=int,
+        default=20,
+        help="Max entries to return (default: 20)",
+    )
+    parser.add_argument(
+        "--lookback",
+        type=float,
+        default=1,
+        help="Hours to look back (default: 1)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Build query
+        logql = args.selector
+        if args.filter:
+            logql = f'{args.selector} |~ "{args.filter}"'
+
+        now = datetime.now(timezone.utc)
+        start = now - timedelta(hours=args.lookback)
+
+        result = query(logql, limit=args.limit, start=start, end=now)
+
+        data = result.get("data", {})
+        data.get("resultType", "streams")
+        streams = data.get("result", [])
+
+        if args.json:
+            # Flatten for JSON output
+            entries = []
+            for stream in streams:
+                labels = stream.get("stream", {})
+                for entry in stream.get("values", []):
+                    ts_ns, line = entry
+                    ts = datetime.fromtimestamp(int(ts_ns) / 1e9, tz=timezone.utc)
+                    entries.append(
+                        {
+                            "timestamp": ts.isoformat(),
+                            "labels": labels,
+                            "line": line,
+                        }
+                    )
+            # Sort by timestamp descending
+            entries.sort(key=lambda x: x["timestamp"], reverse=True)
+            print(
+                json.dumps(
+                    {
+                        "query": logql,
+                        "count": len(entries),
+                        "entries": entries[: args.limit],
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(f"Logs matching: {logql}")
+            print(f"Time window: last {args.lookback}h")
+            print()
+
+            # Collect all entries with their stream labels
+            all_entries = []
+            for stream in streams:
+                labels = stream.get("stream", {})
+                for entry in stream.get("values", []):
+                    all_entries.append((labels, entry))
+
+            # Sort by timestamp descending
+            all_entries.sort(key=lambda x: x[1][0], reverse=True)
+
+            if not all_entries:
+                print("No logs found matching the query.")
+                return
+
+            for labels, entry in all_entries[: args.limit]:
+                print(format_log_entry(labels, entry))
+                print()
+
+            print("-" * 60)
+            print(
+                f"Showing {min(len(all_entries), args.limit)} of {len(all_entries)} entries"
+            )
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-newrelic/SKILL.md
+++ b/sre-agent/.claude/skills/observability-newrelic/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: observability-newrelic
+description: New Relic APM and monitoring. Use when running NRQL queries, checking application performance, error rates, or throughput via New Relic.
+allowed-tools: Bash(python *)
+---
+
+# New Relic Observability
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `NEWRELIC_API_KEY` in environment variables - it won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `NEWRELIC_ACCOUNT_ID` - New Relic account ID
+- `NEWRELIC_BASE_URL` - API base URL (proxy mode)
+
+---
+
+## Available Scripts
+
+All scripts are in `.claude/skills/observability-newrelic/scripts/`
+
+### query_nrql.py - Run NRQL Queries (START HERE)
+```bash
+python .claude/skills/observability-newrelic/scripts/query_nrql.py --account-id ACCOUNT_ID --query "SELECT average(duration) FROM Transaction SINCE 1 hour ago"
+```
+
+### get_apm_summary.py - APM Summary
+```bash
+python .claude/skills/observability-newrelic/scripts/get_apm_summary.py --account-id ACCOUNT_ID --app-name MyApp [--time-range 30m]
+```
+
+---
+
+## NRQL Query Reference
+
+```sql
+-- Response time
+SELECT average(duration) FROM Transaction WHERE appName = 'MyApp' SINCE 1 hour ago
+
+-- Throughput
+SELECT count(*) FROM Transaction WHERE appName = 'MyApp' SINCE 1 hour ago TIMESERIES 5 minutes
+
+-- Error rate
+SELECT percentage(count(*), WHERE error = true) FROM Transaction WHERE appName = 'MyApp' SINCE 1 hour ago
+
+-- Apdex score
+SELECT apdex(duration, t: 0.5) FROM Transaction WHERE appName = 'MyApp' SINCE 1 hour ago
+
+-- Slowest transactions
+SELECT average(duration), count(*) FROM Transaction WHERE appName = 'MyApp' SINCE 1 hour ago FACET name LIMIT 10
+
+-- Database query time
+SELECT average(databaseDuration) FROM Transaction WHERE appName = 'MyApp' SINCE 1 hour ago TIMESERIES
+
+-- External service calls
+SELECT average(externalDuration), count(*) FROM Transaction WHERE appName = 'MyApp' SINCE 1 hour ago FACET externalTransactionName
+```
+
+---
+
+## Investigation Workflow
+
+### Application Performance Issue
+```
+1. get_apm_summary.py --account-id <id> --app-name <app> (overview)
+2. query_nrql.py --query "SELECT average(duration) FROM Transaction WHERE appName = '<app>' SINCE 1 hour ago TIMESERIES 5 minutes"
+3. query_nrql.py --query "SELECT percentage(count(*), WHERE error = true) FROM Transaction WHERE appName = '<app>' SINCE 1 hour ago TIMESERIES 5 minutes"
+```

--- a/sre-agent/.claude/skills/observability-newrelic/scripts/get_apm_summary.py
+++ b/sre-agent/.claude/skills/observability-newrelic/scripts/get_apm_summary.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Get APM summary for an application from New Relic."""
+
+import argparse
+import sys
+
+from newrelic_client import format_output, newrelic_graphql
+
+
+def _run_nrql(account_id: str, query: str):
+    """Run a single NRQL query and return results."""
+    graphql_query = """
+    query($accountId: Int!, $nrql: Nrql!) {
+        actor {
+            account(id: $accountId) {
+                nrql(query: $nrql) {
+                    results
+                }
+            }
+        }
+    }
+    """
+    data = newrelic_graphql(
+        graphql_query,
+        variables={"accountId": int(account_id), "nrql": query},
+    )
+    results = (
+        data.get("data", {})
+        .get("actor", {})
+        .get("account", {})
+        .get("nrql", {})
+        .get("results", [])
+    )
+    return results[0] if results else None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get APM summary")
+    parser.add_argument("--account-id", required=True, help="New Relic account ID")
+    parser.add_argument(
+        "--app-name", required=True, help="Application name in New Relic"
+    )
+    parser.add_argument(
+        "--time-range", default="30m", help="Time range (e.g., 30m, 1h)"
+    )
+    args = parser.parse_args()
+
+    try:
+        queries = {
+            "response_time": f"SELECT average(duration) FROM Transaction WHERE appName = '{args.app_name}' SINCE {args.time_range} ago",
+            "throughput": f"SELECT count(*) FROM Transaction WHERE appName = '{args.app_name}' SINCE {args.time_range} ago",
+            "error_rate": f"SELECT percentage(count(*), WHERE error = true) FROM Transaction WHERE appName = '{args.app_name}' SINCE {args.time_range} ago",
+            "apdex": f"SELECT apdex(duration, t: 0.5) FROM Transaction WHERE appName = '{args.app_name}' SINCE {args.time_range} ago",
+        }
+
+        summary = {}
+        for metric_name, query in queries.items():
+            try:
+                summary[metric_name] = _run_nrql(args.account_id, query)
+            except Exception:
+                summary[metric_name] = None
+
+        print(
+            format_output(
+                {
+                    "app_name": args.app_name,
+                    "account_id": args.account_id,
+                    "time_range": args.time_range,
+                    "summary": summary,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e), "app_name": args.app_name}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-newrelic/scripts/newrelic_client.py
+++ b/sre-agent/.claude/skills/observability-newrelic/scripts/newrelic_client.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Shared New Relic API client with proxy support.
+
+Credentials are injected transparently by the proxy layer.
+"""
+
+import json
+import os
+from typing import Any
+
+import httpx
+
+
+def get_config() -> dict[str, str | None]:
+    """Get New Relic configuration from environment."""
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+        "account_id": os.getenv("NEWRELIC_ACCOUNT_ID", ""),
+    }
+
+
+def get_base_url() -> str:
+    """Get New Relic API base URL.
+
+    Supports two modes:
+    1. Proxy mode (production): Uses NEWRELIC_BASE_URL
+    2. Direct mode (testing): Uses https://api.newrelic.com
+    """
+    proxy_url = os.getenv("NEWRELIC_BASE_URL")
+    if proxy_url:
+        return proxy_url.rstrip("/")
+
+    if os.getenv("NEWRELIC_API_KEY"):
+        return "https://api.newrelic.com"
+
+    raise RuntimeError(
+        "Either NEWRELIC_BASE_URL (proxy mode) or NEWRELIC_API_KEY (direct mode) must be set."
+    )
+
+
+def get_headers() -> dict[str, str]:
+    """Get New Relic API headers."""
+    config = get_config()
+    headers = {"Content-Type": "application/json"}
+
+    api_key = os.getenv("NEWRELIC_API_KEY")
+    if api_key:
+        headers["Api-Key"] = api_key
+    else:
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+            headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    return headers
+
+
+def newrelic_graphql(query: str, variables: dict | None = None) -> Any:
+    """Execute a GraphQL query against New Relic."""
+    base_url = get_base_url()
+    url = f"{base_url}/graphql"
+
+    payload = {"query": query}
+    if variables:
+        payload["variables"] = variables
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.post(url, headers=get_headers(), json=payload)
+        response.raise_for_status()
+        return response.json()
+
+
+def format_output(data: dict) -> str:
+    """Format output as JSON string."""
+    return json.dumps(data, indent=2, default=str)

--- a/sre-agent/.claude/skills/observability-newrelic/scripts/query_nrql.py
+++ b/sre-agent/.claude/skills/observability-newrelic/scripts/query_nrql.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Run an NRQL query against New Relic."""
+
+import argparse
+import sys
+
+from newrelic_client import format_output, newrelic_graphql
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run NRQL query")
+    parser.add_argument("--account-id", required=True, help="New Relic account ID")
+    parser.add_argument("--query", required=True, help="NRQL query string")
+    args = parser.parse_args()
+
+    try:
+        graphql_query = """
+        query($accountId: Int!, $nrql: Nrql!) {
+            actor {
+                account(id: $accountId) {
+                    nrql(query: $nrql) {
+                        results
+                    }
+                }
+            }
+        }
+        """
+
+        data = newrelic_graphql(
+            graphql_query,
+            variables={"accountId": int(args.account_id), "nrql": args.query},
+        )
+
+        results = (
+            data.get("data", {})
+            .get("actor", {})
+            .get("account", {})
+            .get("nrql", {})
+            .get("results", [])
+        )
+
+        print(
+            format_output(
+                {
+                    "account_id": args.account_id,
+                    "query": args.query,
+                    "result_count": len(results),
+                    "results": results,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e), "query": args.query}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-sentry/SKILL.md
+++ b/sre-agent/.claude/skills/observability-sentry/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: observability-sentry
+description: Sentry error tracking and performance monitoring. Use when investigating application errors, checking error frequency, managing issue status, or reviewing releases.
+allowed-tools: Bash(python *)
+---
+
+# Sentry Error Tracking
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `SENTRY_AUTH_TOKEN` in environment variables - it won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `SENTRY_ORGANIZATION` - Sentry organization slug
+- `SENTRY_PROJECT` - Default Sentry project slug
+
+---
+
+## MANDATORY: Error-First Investigation
+
+**Start with listing issues, then drill into details.**
+
+```
+LIST ISSUES -> GET DETAILS -> CHECK STATS -> REVIEW RELEASES
+```
+
+## Available Scripts
+
+All scripts are in `.claude/skills/observability-sentry/scripts/`
+
+### list_issues.py - ALWAYS START HERE
+```bash
+python .claude/skills/observability-sentry/scripts/list_issues.py --project PROJECT_SLUG [--query "is:unresolved"]
+
+# Examples:
+python .claude/skills/observability-sentry/scripts/list_issues.py --project api-backend
+python .claude/skills/observability-sentry/scripts/list_issues.py --project api-backend --query "is:unresolved level:error"
+```
+
+### get_issue.py - Get Issue Details
+```bash
+python .claude/skills/observability-sentry/scripts/get_issue.py --issue-id 12345678
+```
+
+### update_issue_status.py - Update Issue Status
+```bash
+python .claude/skills/observability-sentry/scripts/update_issue_status.py --issue-id 12345678 --status resolved
+# Status options: resolved, unresolved, ignored, resolvedInNextRelease
+```
+
+### list_projects.py - List Organization Projects
+```bash
+python .claude/skills/observability-sentry/scripts/list_projects.py
+```
+
+### get_project_stats.py - Project Statistics
+```bash
+python .claude/skills/observability-sentry/scripts/get_project_stats.py --project PROJECT_SLUG [--stat received] [--resolution 1h]
+```
+
+### list_releases.py - List Releases
+```bash
+python .claude/skills/observability-sentry/scripts/list_releases.py --project PROJECT_SLUG [--limit 10]
+```
+
+---
+
+## Sentry Search Query Syntax
+```
+is:unresolved                    # Status
+level:error                      # Level
+first-release:1.2.0              # Release
+firstSeen:-24h                   # Time
+assigned:user@company.com        # Assignment
+is:unresolved level:error firstSeen:-24h   # Combined
+```
+
+---
+
+## Investigation Workflow
+
+### Error Spike Investigation
+```
+1. list_issues.py --project api --query "is:unresolved"
+2. get_issue.py --issue-id <id>
+3. list_releases.py --project api
+4. get_project_stats.py --project api --stat received --resolution 1h
+```

--- a/sre-agent/.claude/skills/observability-sentry/scripts/get_issue.py
+++ b/sre-agent/.claude/skills/observability-sentry/scripts/get_issue.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Get details of a specific Sentry issue.
+
+Usage:
+    python get_issue.py --issue-id 12345678
+"""
+
+import argparse
+import json
+import sys
+
+from sentry_client import sentry_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Sentry issue details")
+    parser.add_argument("--issue-id", required=True, help="Sentry issue ID")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        issue = sentry_request("GET", f"issues/{args.issue_id}/")
+
+        result = {
+            "ok": True,
+            "id": issue["id"],
+            "title": issue["title"],
+            "short_id": issue["shortId"],
+            "status": issue["status"],
+            "level": issue["level"],
+            "count": issue["count"],
+            "user_count": issue["userCount"],
+            "first_seen": issue["firstSeen"],
+            "last_seen": issue["lastSeen"],
+            "permalink": issue["permalink"],
+            "metadata": issue.get("metadata", {}),
+            "tags": issue.get("tags", []),
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Issue: #{result['short_id']} - {result['title']}")
+            print(f"Level: {result['level'].upper()} | Status: {result['status']}")
+            print(f"Events: {result['count']} | Users: {result['user_count']}")
+            print(f"First: {result['first_seen']} | Last: {result['last_seen']}")
+            print(f"URL: {result['permalink']}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-sentry/scripts/get_project_stats.py
+++ b/sre-agent/.claude/skills/observability-sentry/scripts/get_project_stats.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Get statistics for a Sentry project.
+
+Usage:
+    python get_project_stats.py --project api-backend
+    python get_project_stats.py --project api-backend --stat received --resolution 1d
+"""
+
+import argparse
+import json
+import sys
+
+from sentry_client import get_organization, sentry_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Sentry project statistics")
+    parser.add_argument("--project", required=True, help="Project slug")
+    parser.add_argument(
+        "--stat",
+        default="received",
+        choices=["received", "rejected", "blacklisted"],
+        help="Stat type",
+    )
+    parser.add_argument(
+        "--resolution", default="1h", help="Resolution (1h, 1d, 1w, 1m)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        org = get_organization()
+        data = sentry_request(
+            "GET",
+            f"projects/{org}/{args.project}/stats/",
+            params={"stat": args.stat, "resolution": args.resolution},
+        )
+
+        result = {
+            "ok": True,
+            "project": args.project,
+            "stat": args.stat,
+            "resolution": args.resolution,
+            "data": data,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Project Stats: {args.project} ({args.stat}, {args.resolution})")
+            if isinstance(data, list):
+                total = sum(point[1] for point in data if len(point) > 1)
+                print(f"Total events: {total} | Data points: {len(data)}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-sentry/scripts/list_issues.py
+++ b/sre-agent/.claude/skills/observability-sentry/scripts/list_issues.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""List Sentry issues for a project.
+
+Usage:
+    python list_issues.py --project api-backend
+    python list_issues.py --project api-backend --query "is:unresolved level:error"
+"""
+
+import argparse
+import json
+import sys
+
+from sentry_client import get_config, get_organization, sentry_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Sentry issues")
+    parser.add_argument("--project", default="", help="Project slug")
+    parser.add_argument("--query", default="", help="Search query")
+    parser.add_argument(
+        "--limit", type=int, default=25, help="Max issues (default: 25)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        config = get_config()
+        org = get_organization()
+        project = args.project or config.get("project")
+        if not project:
+            print("Error: --project required (or set SENTRY_PROJECT)", file=sys.stderr)
+            sys.exit(1)
+
+        params = {"limit": args.limit}
+        if args.query:
+            params["query"] = args.query
+
+        data = sentry_request("GET", f"projects/{org}/{project}/issues/", params=params)
+
+        issues = [
+            {
+                "id": i["id"],
+                "title": i["title"],
+                "short_id": i["shortId"],
+                "status": i["status"],
+                "level": i["level"],
+                "count": i["count"],
+                "user_count": i["userCount"],
+                "first_seen": i["firstSeen"],
+                "last_seen": i["lastSeen"],
+                "permalink": i["permalink"],
+            }
+            for i in data
+        ]
+
+        result = {
+            "ok": True,
+            "project": project,
+            "issues": issues,
+            "count": len(issues),
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Sentry Issues: {project} ({len(issues)} found)")
+            for issue in issues:
+                print(
+                    f"  [{issue['level'].upper()}] #{issue['short_id']} - {issue['title']}"
+                )
+                print(
+                    f"    Events: {issue['count']} | Users: {issue['user_count']} | Status: {issue['status']}"
+                )
+                print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-sentry/scripts/list_projects.py
+++ b/sre-agent/.claude/skills/observability-sentry/scripts/list_projects.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""List all Sentry projects in the organization.
+
+Usage:
+    python list_projects.py
+"""
+
+import argparse
+import json
+import sys
+
+from sentry_client import get_organization, sentry_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Sentry projects")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        org = get_organization()
+        data = sentry_request("GET", f"organizations/{org}/projects/")
+
+        projects = [
+            {
+                "id": p["id"],
+                "slug": p["slug"],
+                "name": p["name"],
+                "platform": p.get("platform"),
+                "status": p.get("status"),
+            }
+            for p in data
+        ]
+        result = {
+            "ok": True,
+            "organization": org,
+            "projects": projects,
+            "count": len(projects),
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Sentry Projects ({org}): {len(projects)}")
+            for p in projects:
+                print(f"  {p['slug']:30s} ({p.get('platform') or '?'}) - {p['name']}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-sentry/scripts/list_releases.py
+++ b/sre-agent/.claude/skills/observability-sentry/scripts/list_releases.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""List releases for a Sentry project.
+
+Usage:
+    python list_releases.py --project api-backend
+"""
+
+import argparse
+import json
+import sys
+
+from sentry_client import get_organization, sentry_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Sentry releases")
+    parser.add_argument("--project", required=True, help="Project slug")
+    parser.add_argument(
+        "--limit", type=int, default=10, help="Max releases (default: 10)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        org = get_organization()
+        data = sentry_request(
+            "GET",
+            f"projects/{org}/{args.project}/releases/",
+            params={"per_page": args.limit},
+        )
+
+        releases = [
+            {
+                "version": r["version"],
+                "short_version": r.get("shortVersion"),
+                "date_created": r["dateCreated"],
+                "date_released": r.get("dateReleased"),
+                "new_groups": r.get("newGroups", 0),
+            }
+            for r in data
+        ]
+        result = {
+            "ok": True,
+            "project": args.project,
+            "releases": releases,
+            "count": len(releases),
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Releases: {args.project} ({len(releases)} found)")
+            for r in releases:
+                version = r.get("short_version") or r["version"]
+                print(
+                    f"  {version:30s} Created: {r['date_created']} | New errors: {r.get('new_groups', 0)}"
+                )
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-sentry/scripts/sentry_client.py
+++ b/sre-agent/.claude/skills/observability-sentry/scripts/sentry_client.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Shared Sentry API client with proxy support.
+
+Credentials are injected transparently by the proxy layer.
+"""
+
+import os
+from typing import Any
+
+import httpx
+
+
+def get_config() -> dict[str, str | None]:
+    """Get Sentry configuration from environment."""
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+        "organization": os.getenv("SENTRY_ORGANIZATION", ""),
+        "project": os.getenv("SENTRY_PROJECT"),
+    }
+
+
+def get_base_url() -> str:
+    """Get Sentry API base URL.
+
+    Supports two modes:
+    1. Proxy mode (production): Uses SENTRY_BASE_URL
+    2. Direct mode (testing): Uses https://sentry.io/api/0
+    """
+    proxy_url = os.getenv("SENTRY_BASE_URL")
+    if proxy_url:
+        return proxy_url.rstrip("/")
+
+    if os.getenv("SENTRY_AUTH_TOKEN"):
+        return "https://sentry.io/api/0"
+
+    raise RuntimeError(
+        "Either SENTRY_BASE_URL (proxy mode) or SENTRY_AUTH_TOKEN (direct mode) must be set."
+    )
+
+
+def get_headers() -> dict[str, str]:
+    """Get Sentry API headers."""
+    config = get_config()
+    headers = {"Content-Type": "application/json"}
+
+    auth_token = os.getenv("SENTRY_AUTH_TOKEN")
+    if auth_token:
+        headers["Authorization"] = f"Bearer {auth_token}"
+    else:
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+            headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    return headers
+
+
+def sentry_request(
+    method: str,
+    path: str,
+    params: dict | None = None,
+    json_body: dict | None = None,
+) -> Any:
+    """Make a request to Sentry API."""
+    base_url = get_base_url()
+    url = f"{base_url}/{path.lstrip('/')}"
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.request(
+            method, url, headers=get_headers(), params=params, json=json_body
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+def get_organization() -> str:
+    """Get the Sentry organization slug."""
+    org = os.getenv("SENTRY_ORGANIZATION", "")
+    if not org:
+        raise RuntimeError("SENTRY_ORGANIZATION must be set")
+    return org

--- a/sre-agent/.claude/skills/observability-sentry/scripts/update_issue_status.py
+++ b/sre-agent/.claude/skills/observability-sentry/scripts/update_issue_status.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Update the status of a Sentry issue.
+
+Usage:
+    python update_issue_status.py --issue-id 12345678 --status resolved
+"""
+
+import argparse
+import json
+import sys
+
+from sentry_client import sentry_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Update Sentry issue status")
+    parser.add_argument("--issue-id", required=True, help="Sentry issue ID")
+    parser.add_argument(
+        "--status",
+        required=True,
+        choices=["resolved", "unresolved", "ignored", "resolvedInNextRelease"],
+        help="New status",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        sentry_request(
+            "PUT", f"issues/{args.issue_id}/", json_body={"status": args.status}
+        )
+        result = {"ok": True, "issue_id": args.issue_id, "status": args.status}
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Issue {args.issue_id} status updated to: {args.status}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-splunk/SKILL.md
+++ b/sre-agent/.claude/skills/observability-splunk/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: observability-splunk
+description: Splunk log analysis using SPL (Search Processing Language). Use when investigating issues via Splunk logs, saved searches, or alerts.
+allowed-tools: Bash(python *)
+---
+
+# Splunk Analysis
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `SPLUNK_HOST`, `SPLUNK_TOKEN`, or other credentials in environment variables - they won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+---
+
+## MANDATORY: Statistics-First Investigation
+
+**NEVER dump raw logs.** Always follow this pattern:
+
+```
+STATISTICS → SAMPLE → PATTERNS → CORRELATE
+```
+
+1. **Statistics First** - Know volume, error rate, and top patterns before sampling
+2. **Strategic Sampling** - Choose the right strategy based on statistics
+3. **Pattern Extraction** - Cluster similar errors to find root causes
+4. **Context Correlation** - Investigate around anomaly timestamps
+
+## Available Scripts
+
+All scripts are in `.claude/skills/observability-splunk/scripts/`
+
+### PRIMARY INVESTIGATION SCRIPTS
+
+#### get_statistics.py - ALWAYS START HERE
+Comprehensive statistics with pattern extraction.
+```bash
+python .claude/skills/observability-splunk/scripts/get_statistics.py [--index INDEX] [--sourcetype SOURCETYPE] [--time-range MINUTES]
+
+# Examples:
+python .claude/skills/observability-splunk/scripts/get_statistics.py --time-range 60
+python .claude/skills/observability-splunk/scripts/get_statistics.py --index main
+python .claude/skills/observability-splunk/scripts/get_statistics.py --sourcetype access_combined
+```
+
+Output includes:
+- Total count, error count, error rate percentage
+- Status distribution (info, warn, error)
+- Top sourcetypes and hosts by log volume
+- **Top error patterns** (crucial for quick triage)
+- Actionable recommendation
+
+#### sample_logs.py - Strategic Sampling
+Choose the right sampling strategy based on statistics.
+```bash
+python .claude/skills/observability-splunk/scripts/sample_logs.py --strategy STRATEGY [--index INDEX] [--sourcetype SOURCETYPE] [--limit N]
+
+# Strategies:
+#   errors_only   - Only error logs (default for incidents)
+#   warnings_up   - Warning and error logs
+#   around_time   - Logs around a specific timestamp
+#   all           - All log levels
+
+# Examples:
+python .claude/skills/observability-splunk/scripts/sample_logs.py --strategy errors_only --index main
+python .claude/skills/observability-splunk/scripts/sample_logs.py --strategy around_time --timestamp "2026-01-27T05:00:00" --window 5
+python .claude/skills/observability-splunk/scripts/sample_logs.py --strategy all --sourcetype access_combined --limit 20
+```
+
+---
+
+## SPL (Search Processing Language)
+
+### Basic Search
+
+```spl
+# Simple keyword search
+error
+
+# Index specific search (ALWAYS specify index for performance)
+index=main error
+
+# Multiple keywords (implicit AND)
+index=main error connection
+
+# Exact phrase
+index=main "connection refused"
+```
+
+### Field Searches
+
+```spl
+# Exact field match
+index=main host=web-01
+
+# Wildcard
+index=main host=web-*
+
+# Numeric comparison
+index=main status>=400
+
+# NOT operator
+index=main NOT status=200
+
+# OR operator
+index=main (status=500 OR status=503)
+```
+
+### Time Range
+
+```spl
+# Relative time (in tool call)
+earliest=-15m latest=now
+
+# Absolute time
+earliest="01/15/2024:10:00:00" latest="01/15/2024:11:00:00"
+
+# Natural time modifiers
+earliest=-1h@h  # 1 hour ago, rounded to hour
+earliest=-1d@d  # 1 day ago, rounded to day
+```
+
+---
+
+## Investigation Workflow
+
+### Standard Incident Investigation
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. STATISTICS FIRST (mandatory)                              │
+│    python get_statistics.py --index <index>                  │
+│    → Know volume, error rate, top patterns                   │
+└─────────────────────────────────────────────────────────────┘
+                             │
+                             ▼
+                     High Error Rate?
+               ┌─────────────┴─────────────┐
+               │                           │
+       YES (>5%)                           NO
+               │                           │
+               ▼                           ▼
+┌─────────────────────────────┐  ┌───────────────────────────────────────────┐
+│ 2. FAST PATH                │  │ 2. TARGETED INVESTIGATION                 │
+│    Sample errors directly   │  │    Filter by specific criteria            │
+│    python sample_logs.py    │  │    python sample_logs.py --strategy all   │
+│    --strategy errors_only   │  │    → Look for anomalies                   │
+└─────────────────────────────┘  └───────────────────────────────────────────┘
+```
+
+### Quick Commands Reference
+
+| Goal | Command |
+|------|---------|
+| Start investigation | `get_statistics.py --index X` |
+| Sample errors only | `sample_logs.py --strategy errors_only --index X` |
+| Investigate spike | `sample_logs.py --strategy around_time --timestamp T` |
+| All logs | `sample_logs.py --strategy all --index X --limit 20` |
+
+---
+
+## SPL Commands Reference
+
+### Filtering Commands
+
+| Command | Purpose | Example |
+|---------|---------|---------|
+| `search` | Filter events | `search error` |
+| `where` | Filter with expressions | `where status > 400` |
+| `dedup` | Remove duplicates | `dedup host` |
+| `head` | First N results | `head 10` |
+| `tail` | Last N results | `tail 10` |
+
+### Transformation Commands
+
+| Command | Purpose | Example |
+|---------|---------|---------|
+| `stats` | Aggregate statistics | `stats count by host` |
+| `timechart` | Time-based aggregation | `timechart span=5m count` |
+| `chart` | Pivot table | `chart count by status, host` |
+| `top` | Top values | `top 10 host` |
+| `rare` | Rare values | `rare message` |
+| `table` | Select fields | `table _time, host, message` |
+
+### Field Operations
+
+| Command | Purpose | Example |
+|---------|---------|---------|
+| `eval` | Calculate fields | `eval duration_sec=duration/1000` |
+| `rex` | Regex extraction | `rex field=message "error: (?<error_type>\w+)"` |
+| `rename` | Rename fields | `rename src_ip as source_ip` |
+| `fields` | Include/exclude fields | `fields host, message` |
+
+---
+
+## Common Query Patterns
+
+### Error Rate Analysis
+
+```spl
+# Error count per 5 minutes
+index=main | timechart span=5m count(eval(level="ERROR")) as errors, count as total
+
+# Error percentage over time
+index=main
+| timechart span=5m count(eval(level="ERROR")) as errors, count as total
+| eval error_rate=errors/total*100
+```
+
+### Top Errors by Service
+
+```spl
+index=main level=ERROR
+| stats count by service, message
+| sort -count
+| head 20
+```
+
+### Response Time Analysis
+
+```spl
+index=main sourcetype=access_combined
+| stats avg(response_time) as avg_rt,
+        p95(response_time) as p95_rt,
+        max(response_time) as max_rt
+    by uri_path
+| sort -avg_rt
+```
+
+### Anomaly Detection
+
+```spl
+# Sudden spike detection
+index=main
+| timechart span=5m count as events
+| eventstats avg(events) as avg_events, stdev(events) as stdev_events
+| eval anomaly=if(events > avg_events + 2*stdev_events, 1, 0)
+| where anomaly=1
+```
+
+---
+
+## Anti-Patterns to Avoid
+
+1. ❌ **NEVER skip statistics** - `get_statistics.py` is MANDATORY first step
+2. ❌ **No index specified** - Always use `index=X` for performance
+3. ❌ **Unbounded time range** - Always specify time ranges
+4. ❌ **Fetching all logs** - Use sampling strategies, not unbounded searches
+5. ❌ **Ignoring error rate** - High error rate means immediate investigation
+6. ❌ **Complex rex on all events** - Filter first, then extract

--- a/sre-agent/.claude/skills/observability-splunk/scripts/__init__.py
+++ b/sre-agent/.claude/skills/observability-splunk/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Splunk observability scripts

--- a/sre-agent/.claude/skills/observability-splunk/scripts/get_statistics.py
+++ b/sre-agent/.claude/skills/observability-splunk/scripts/get_statistics.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Get comprehensive log statistics from Splunk - THE MANDATORY FIRST STEP.
+
+This should ALWAYS be called before fetching raw logs. It provides:
+- Total count and error rate
+- Log level distribution
+- Top sourcetypes and hosts
+- Top error patterns
+- Actionable recommendations
+
+Usage:
+    python get_statistics.py [--index INDEX] [--sourcetype SOURCETYPE] [--time-range MINUTES]
+
+Examples:
+    python get_statistics.py --time-range 60
+    python get_statistics.py --index main --sourcetype access_combined
+"""
+
+import argparse
+import json
+import sys
+from collections import Counter
+
+from splunk_client import execute_search
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Get comprehensive log statistics from Splunk (ALWAYS call first)"
+    )
+    parser.add_argument("--index", help="Index name (default: main)")
+    parser.add_argument("--sourcetype", help="Sourcetype to filter")
+    parser.add_argument("--host", help="Host to filter")
+    parser.add_argument(
+        "--time-range", type=int, default=60, help="Time range in minutes (default: 60)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Build base search
+        base_parts = []
+        if args.index:
+            base_parts.append(f"index={args.index}")
+        else:
+            base_parts.append("index=*")
+        if args.sourcetype:
+            base_parts.append(f"sourcetype={args.sourcetype}")
+        if args.host:
+            base_parts.append(f"host={args.host}")
+
+        base_search = " ".join(base_parts)
+
+        # 1. Get total count and log level distribution
+        stats_query = f'{base_search} | stats count as total, count(eval(log_level="ERROR" OR log_level="error" OR severity="ERROR")) as errors, count(eval(log_level="WARN" OR log_level="warn" OR log_level="WARNING" OR severity="WARN")) as warnings'
+
+        stats_results = execute_search(stats_query, args.time_range, max_results=1)
+
+        total_count = 0
+        error_count = 0
+        warn_count = 0
+
+        if stats_results:
+            stat = stats_results[0]
+            total_count = int(stat.get("total", 0))
+            error_count = int(stat.get("errors", 0))
+            warn_count = int(stat.get("warnings", 0))
+
+        error_rate = round(error_count / total_count * 100, 2) if total_count > 0 else 0
+        warn_rate = round(warn_count / total_count * 100, 2) if total_count > 0 else 0
+
+        # 2. Get level distribution
+        level_query = f'{base_search} | eval level=coalesce(log_level, severity, "INFO") | stats count by level | sort -count'
+        level_results = execute_search(level_query, args.time_range, max_results=20)
+
+        level_dist = {}
+        for result in level_results:
+            level = result.get("level", "unknown")
+            count = int(result.get("count", 0))
+            level_dist[level] = count
+
+        # 3. Get top sourcetypes
+        sourcetype_query = (
+            f"{base_search} | stats count by sourcetype | sort -count | head 10"
+        )
+        sourcetype_results = execute_search(
+            sourcetype_query, args.time_range, max_results=10
+        )
+
+        top_sourcetypes = [
+            {"sourcetype": r.get("sourcetype"), "count": int(r.get("count", 0))}
+            for r in sourcetype_results
+        ]
+
+        # 4. Get top hosts
+        host_query = f"{base_search} | stats count by host | sort -count | head 10"
+        host_results = execute_search(host_query, args.time_range, max_results=10)
+
+        top_hosts = [
+            {"host": r.get("host"), "count": int(r.get("count", 0))}
+            for r in host_results
+        ]
+
+        # 5. Get sample errors for pattern analysis
+        error_query = f"{base_search} (log_level=ERROR OR log_level=error OR severity=ERROR) | head 50"
+        error_results = execute_search(error_query, args.time_range, max_results=50)
+
+        # Extract unique error patterns
+        import re
+
+        error_patterns = Counter()
+        for result in error_results:
+            msg = result.get("_raw") or result.get("message") or ""
+            # Normalize
+            normalized = re.sub(
+                r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
+                "<UUID>",
+                str(msg),
+            )
+            normalized = re.sub(
+                r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b", "<IP>", normalized
+            )
+            normalized = re.sub(r"\b\d+\b", "<NUM>", normalized)
+            normalized = normalized[:100]
+            error_patterns[normalized] += 1
+
+        top_error_patterns = [
+            {"pattern": pattern, "count": count}
+            for pattern, count in error_patterns.most_common(10)
+        ]
+
+        # 6. Build recommendation
+        if total_count == 0:
+            recommendation = "No logs found in the specified time range."
+        elif error_rate > 10:
+            recommendation = f"HIGH error rate ({error_rate}%). Investigate top error patterns immediately."
+        elif error_rate > 5:
+            recommendation = (
+                f"Elevated error rate ({error_rate}%). Review error patterns."
+            )
+        elif total_count > 100000:
+            recommendation = f"Very high volume ({total_count:,} logs). Use targeted sourcetype/index filter."
+        else:
+            recommendation = (
+                f"Normal volume ({total_count:,} logs). Error rate: {error_rate}%"
+            )
+
+        # Build result
+        result = {
+            "total_count": total_count,
+            "error_count": error_count,
+            "warning_count": warn_count,
+            "error_rate_percent": error_rate,
+            "warning_rate_percent": warn_rate,
+            "level_distribution": level_dist,
+            "top_sourcetypes": top_sourcetypes,
+            "top_hosts": top_hosts,
+            "top_error_patterns": top_error_patterns,
+            "time_range_minutes": args.time_range,
+            "base_search": base_search,
+            "recommendation": recommendation,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print("=" * 60)
+            print("SPLUNK LOG STATISTICS")
+            print("=" * 60)
+            print(f"Search: {base_search}")
+            print(f"Time Range: {args.time_range} minutes")
+            print()
+            print(f"Total Logs: {total_count:,}")
+            print(f"Errors: {error_count:,} ({error_rate}%)")
+            print(f"Warnings: {warn_count:,} ({warn_rate}%)")
+            print()
+            if level_dist:
+                print("Level Distribution:")
+                for level, count in sorted(level_dist.items(), key=lambda x: -x[1]):
+                    pct = round(count / total_count * 100, 1) if total_count > 0 else 0
+                    print(f"  {level}: {count:,} ({pct}%)")
+                print()
+            if top_sourcetypes:
+                print("Top Sourcetypes:")
+                for st in top_sourcetypes[:5]:
+                    print(f"  {st['sourcetype']}: {st['count']:,}")
+                print()
+            if top_hosts:
+                print("Top Hosts:")
+                for h in top_hosts[:5]:
+                    print(f"  {h['host']}: {h['count']:,}")
+                print()
+            if top_error_patterns:
+                print("Top Error Patterns:")
+                for pat in top_error_patterns[:5]:
+                    print(f"  [{pat['count']}x] {pat['pattern'][:80]}")
+                print()
+            print(f"Recommendation: {recommendation}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-splunk/scripts/sample_logs.py
+++ b/sre-agent/.claude/skills/observability-splunk/scripts/sample_logs.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Sample logs from Splunk using intelligent strategies.
+
+Choose the right sampling strategy based on your investigation needs.
+
+Usage:
+    python sample_logs.py --strategy STRATEGY [--index INDEX] [--sourcetype SOURCETYPE] [--limit N]
+
+Strategies:
+    errors_only   - Only error logs (default for incidents)
+    warnings_up   - Warning and error logs
+    around_time   - Logs around a specific timestamp
+    all           - All log levels
+
+Examples:
+    python sample_logs.py --strategy errors_only --index main
+    python sample_logs.py --strategy around_time --timestamp "2026-01-27T05:00:00" --window 5
+    python sample_logs.py --strategy all --sourcetype access_combined --limit 20
+"""
+
+import argparse
+import json
+import sys
+
+from splunk_client import execute_search, format_log_entry
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Sample logs from Splunk using intelligent strategies"
+    )
+    parser.add_argument(
+        "--strategy",
+        choices=["errors_only", "warnings_up", "around_time", "all"],
+        default="errors_only",
+        help="Sampling strategy (default: errors_only)",
+    )
+    parser.add_argument("--index", help="Index name (default: *)")
+    parser.add_argument("--sourcetype", help="Sourcetype to filter")
+    parser.add_argument("--host", help="Host to filter")
+    parser.add_argument(
+        "--time-range", type=int, default=60, help="Time range in minutes (default: 60)"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=50, help="Maximum logs to return (default: 50)"
+    )
+    parser.add_argument(
+        "--timestamp",
+        help="Timestamp for around_time strategy (e.g., 2026-01-27T05:00:00)",
+    )
+    parser.add_argument(
+        "--window",
+        type=int,
+        default=5,
+        help="Window in minutes for around_time strategy (default: 5)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Build base search
+        search_parts = []
+        if args.index:
+            search_parts.append(f"index={args.index}")
+        else:
+            search_parts.append("index=*")
+        if args.sourcetype:
+            search_parts.append(f"sourcetype={args.sourcetype}")
+        if args.host:
+            search_parts.append(f"host={args.host}")
+
+        # Apply strategy filter
+        if args.strategy == "errors_only":
+            search_parts.append(
+                "(log_level=ERROR OR log_level=error OR severity=ERROR OR severity=error)"
+            )
+        elif args.strategy == "warnings_up":
+            search_parts.append(
+                "(log_level=ERROR OR log_level=error OR log_level=WARN OR log_level=warn OR log_level=WARNING OR severity=ERROR OR severity=WARN)"
+            )
+
+        # Handle around_time strategy
+        time_range = args.time_range
+        if args.strategy == "around_time":
+            if not args.timestamp:
+                print(
+                    "Error: --timestamp required for around_time strategy",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            # Splunk uses earliest/latest, handled in client
+            time_range = args.window * 2
+
+        search_query = " ".join(search_parts) + f" | head {args.limit}"
+
+        # Execute search
+        results = execute_search(search_query, time_range, max_results=args.limit)
+
+        # Build output
+        logs = []
+        for result in results:
+            logs.append(
+                {
+                    "timestamp": result.get("_time"),
+                    "level": result.get("log_level")
+                    or result.get("severity")
+                    or "INFO",
+                    "sourcetype": result.get("sourcetype"),
+                    "host": result.get("host"),
+                    "source": result.get("source"),
+                    "message": result.get("_raw"),
+                }
+            )
+
+        output = {
+            "strategy": args.strategy,
+            "search": search_query,
+            "count": len(logs),
+            "limit": args.limit,
+            "time_range_minutes": time_range,
+            "logs": logs,
+        }
+
+        if args.json:
+            print(json.dumps(output, indent=2))
+        else:
+            print("=" * 60)
+            print(f"SPLUNK LOG SAMPLE ({args.strategy})")
+            print("=" * 60)
+            print(f"Search: {search_query}")
+            print(f"Found: {len(logs)} logs")
+            print()
+
+            if not logs:
+                print("No logs found matching criteria.")
+            else:
+                for result in results:
+                    print(format_log_entry(result))
+                    print("-" * 40)
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-splunk/scripts/splunk_client.py
+++ b/sre-agent/.claude/skills/observability-splunk/scripts/splunk_client.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Shared Splunk client with proxy support.
+
+This module provides the Splunk client that works through the credential proxy.
+Credentials are injected transparently by the proxy layer.
+
+Uses Splunk REST API for search operations.
+"""
+
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+
+
+def get_config() -> dict[str, str | None]:
+    """Get Splunk configuration from environment.
+
+    Credentials are injected by the credential-proxy based on tenant context.
+
+    Environment variables:
+        OPENSRE_TENANT_ID - Tenant ID for credential lookup
+        OPENSRE_TEAM_ID - Team ID for credential lookup
+        SPLUNK_INDEX - Default index (e.g., main)
+    """
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+        "index": os.getenv("SPLUNK_INDEX", "main"),
+    }
+
+
+def get_api_url(endpoint: str) -> str:
+    """Build the Splunk API URL.
+
+    Supports two modes:
+    1. Proxy mode (production): Uses SPLUNK_BASE_URL
+    2. Direct mode (testing): Uses SPLUNK_URL
+
+    Args:
+        endpoint: API path (e.g., "/services/search/jobs")
+
+    Returns:
+        Full API URL
+    """
+    # Proxy mode (production)
+    base_url = os.getenv("SPLUNK_BASE_URL")
+    if base_url:
+        return f"{base_url.rstrip('/')}{endpoint}"
+
+    # Direct mode (testing/enterprise)
+    direct_url = os.getenv("SPLUNK_URL")
+    if direct_url:
+        return f"{direct_url.rstrip('/')}{endpoint}"
+
+    raise RuntimeError(
+        "Either SPLUNK_BASE_URL (proxy mode) or SPLUNK_URL (direct mode) must be set."
+    )
+
+
+def get_headers() -> dict[str, str]:
+    """Get Splunk API headers.
+
+    Supports multiple auth methods:
+    1. Bearer token - SPLUNK_TOKEN (Splunk Cloud / HEC token)
+    2. Basic auth - SPLUNK_USER + SPLUNK_PASSWORD
+    3. Proxy mode - tenant context headers
+
+    Environment variables:
+        SPLUNK_TOKEN: Bearer token (Splunk Cloud, HEC)
+        SPLUNK_USER + SPLUNK_PASSWORD: Basic auth
+    """
+    config = get_config()
+    import base64
+
+    headers = {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Accept": "application/json",
+    }
+
+    # Priority 1: Bearer token (Splunk Cloud / enterprise)
+    token = os.getenv("SPLUNK_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+        return headers
+
+    # Priority 2: Basic auth
+    user = os.getenv("SPLUNK_USER")
+    password = os.getenv("SPLUNK_PASSWORD")
+    if user and password:
+        encoded = base64.b64encode(f"{user}:{password}".encode()).decode()
+        headers["Authorization"] = f"Basic {encoded}"
+        return headers
+
+    # Priority 3: Proxy mode - use JWT for credential-resolver auth
+    if os.getenv("SPLUNK_BASE_URL"):
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            # Fallback for local dev
+            headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+            headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    return headers
+
+
+def execute_search(
+    search_query: str,
+    time_range_minutes: int = 60,
+    max_results: int = 100,
+    exec_mode: str = "blocking",
+) -> list[dict[str, Any]]:
+    """Execute a Splunk search and return results.
+
+    Args:
+        search_query: SPL search query (without 'search' prefix)
+        time_range_minutes: Time range to query (default: 60 minutes)
+        max_results: Maximum results to return (default: 100)
+        exec_mode: Execution mode - blocking, oneshot, or normal (default: blocking)
+
+    Returns:
+        List of result dictionaries
+
+    Raises:
+        httpx.HTTPStatusError: On API errors
+    """
+    now = datetime.now(timezone.utc)
+    start_time = now - timedelta(minutes=time_range_minutes)
+
+    # Ensure query starts with 'search'
+    if not search_query.strip().lower().startswith("search"):
+        search_query = f"search {search_query}"
+
+    # Create search job
+    job_url = get_api_url("/services/search/jobs")
+
+    job_params = {
+        "search": search_query,
+        "earliest_time": start_time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "latest_time": now.strftime("%Y-%m-%dT%H:%M:%S"),
+        "output_mode": "json",
+        "exec_mode": exec_mode,
+        "max_count": max_results,
+    }
+
+    _verify_tls = os.getenv("SPLUNK_VERIFY_TLS", "true").lower() not in (
+        "false",
+        "0",
+        "no",
+    )
+    with httpx.Client(timeout=120.0, verify=_verify_tls) as client:
+        # Create the job
+        response = client.post(
+            job_url,
+            headers=get_headers(),
+            data=urlencode(job_params),
+        )
+        response.raise_for_status()
+
+        job_data = response.json()
+        sid = job_data.get("sid")
+
+        if not sid:
+            raise RuntimeError("Failed to get search job SID")
+
+        # For blocking mode, results are ready immediately
+        # For normal mode, poll until done
+        if exec_mode == "normal":
+            status_url = get_api_url(f"/services/search/jobs/{sid}")
+            for _ in range(60):  # Max 60 iterations
+                status_response = client.get(
+                    status_url,
+                    headers=get_headers(),
+                    params={"output_mode": "json"},
+                )
+                status_data = status_response.json()
+                entry = status_data.get("entry", [{}])[0]
+                content = entry.get("content", {})
+
+                if content.get("isDone"):
+                    break
+                time.sleep(1)
+
+        # Fetch results
+        results_url = get_api_url(f"/services/search/jobs/{sid}/results")
+        results_response = client.get(
+            results_url,
+            headers=get_headers(),
+            params={"output_mode": "json", "count": max_results},
+        )
+        results_response.raise_for_status()
+
+        results_data = results_response.json()
+        return results_data.get("results", [])
+
+
+def format_log_entry(result: dict[str, Any], max_message_length: int = 300) -> str:
+    """Format a Splunk result for display.
+
+    Args:
+        result: Splunk result dictionary
+        max_message_length: Maximum length for message
+
+    Returns:
+        Formatted string
+    """
+    # Common Splunk field names
+    timestamp = result.get("_time", "")
+    level = (
+        result.get("log_level")
+        or result.get("level")
+        or result.get("severity")
+        or "INFO"
+    )
+    source = result.get("source", "")
+    sourcetype = result.get("sourcetype", "")
+    host = result.get("host", "")
+    message = result.get("_raw") or result.get("message") or ""
+
+    # Format timestamp
+    if "T" in str(timestamp):
+        ts = str(timestamp).split(".")[0].replace("T", " ")
+    else:
+        ts = str(timestamp)
+
+    # Truncate message
+    if len(message) > max_message_length:
+        message = message[:max_message_length] + "..."
+
+    lines = [f"[{str(level).upper()}] {ts} | {sourcetype or source}"]
+    if message:
+        lines.append(f"  {message}")
+    if host:
+        lines.append(f"  Host: {host}")
+
+    return "\n".join(lines)

--- a/sre-agent/.claude/skills/observability-victorialogs/SKILL.md
+++ b/sre-agent/.claude/skills/observability-victorialogs/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: observability-victorialogs
+description: VictoriaLogs log analysis using LogsQL. Use when querying logs stored in VictoriaLogs. Provides statistics-first investigation with server-side aggregation.
+allowed-tools: Bash(python *)
+---
+
+# VictoriaLogs Analysis
+
+Query and analyze logs from VictoriaLogs for incident investigation and debugging.
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `VICTORIALOGS_TOKEN` in environment variables - they won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+---
+
+## MANDATORY: Statistics-First Investigation
+
+**NEVER dump raw logs.** Always follow this pattern:
+
+```
+STATISTICS → FIELDS → SAMPLE → QUERY
+```
+
+1. **Statistics First** — Know volume, error rate, top streams before looking at logs
+2. **Field Discovery** — Understand what fields exist (helps build targeted queries)
+3. **Strategic Sampling** — See representative errors only (max 20 entries)
+4. **Targeted Query** — Only if needed, always with `| stats` or `| limit`
+
+## Available Scripts
+
+All scripts are in `.claude/skills/observability-victorialogs/scripts/`
+
+### PRIMARY INVESTIGATION SCRIPTS
+
+#### get_statistics.py — ALWAYS START HERE
+Comprehensive statistics using server-side LogsQL aggregation.
+```bash
+python .claude/skills/observability-victorialogs/scripts/get_statistics.py
+python .claude/skills/observability-victorialogs/scripts/get_statistics.py --query '_stream:{app="api"}'
+python .claude/skills/observability-victorialogs/scripts/get_statistics.py --time-range 120 --json
+```
+
+Output includes:
+- Total count, error count, error rate percentage
+- Logs per minute
+- Top 10 streams by volume
+- Top error patterns (normalized and deduplicated)
+- Actionable recommendation
+
+#### sample_logs.py — Strategic Sampling
+Choose the right sampling strategy based on statistics.
+```bash
+python .claude/skills/observability-victorialogs/scripts/sample_logs.py --strategy errors_only
+python .claude/skills/observability-victorialogs/scripts/sample_logs.py --query '_stream:{app="api"}' --strategy errors_only
+python .claude/skills/observability-victorialogs/scripts/sample_logs.py --strategy around_time --timestamp "2026-01-27T05:00:00Z" --window 5
+python .claude/skills/observability-victorialogs/scripts/sample_logs.py --strategy all --limit 20
+```
+
+Strategies:
+- `errors_only` — Only error/exception/fail logs (default)
+- `warnings_up` — Warning and error logs
+- `around_time` — Logs around a specific timestamp
+- `all` — All log levels
+
+#### list_fields.py — Metadata Discovery
+Discover available fields before building queries.
+```bash
+python .claude/skills/observability-victorialogs/scripts/list_fields.py
+python .claude/skills/observability-victorialogs/scripts/list_fields.py --query '_stream:{app="api"}'
+python .claude/skills/observability-victorialogs/scripts/list_fields.py --field level
+python .claude/skills/observability-victorialogs/scripts/list_fields.py --field service --limit 20 --json
+```
+
+#### query_logs.py — Raw LogsQL (escape hatch)
+Execute raw LogsQL queries. Safety limit auto-appended if missing.
+```bash
+python .claude/skills/observability-victorialogs/scripts/query_logs.py --query 'error | stats by (service) count() hits | sort by (hits) desc'
+python .claude/skills/observability-victorialogs/scripts/query_logs.py --query '_stream:{app="api"} AND timeout' --limit 10
+python .claude/skills/observability-victorialogs/scripts/query_logs.py --query 'status:>=500 | stats count() total' --json
+```
+
+---
+
+## LogsQL Quick Reference
+
+### Filters (what logs to select)
+
+```logsql
+# Word search (searches _msg field by default)
+error
+"connection timeout"
+
+# Field-specific match
+level:error
+service:payment
+status:500
+
+# Stream selector (efficient — uses indexed stream labels)
+_stream:{app="api"}
+_stream:{app="api", namespace="production"}
+
+# Negation
+NOT error
+NOT level:debug
+
+# Logical operators
+error AND timeout
+error OR exception OR fatal
+
+# Numeric comparison
+status:>=500
+duration:>1000
+
+# Regex
+_msg:~"timeout.*connection"
+service:~"payment-.*"
+```
+
+### Pipes (post-processing)
+
+```logsql
+# Limit results (ALWAYS use this or | stats)
+error | limit 20
+
+# Select specific fields
+error | fields _time, _msg, service, level
+
+# Sort
+error | sort by (_time) desc
+
+# Deduplicate
+error | uniq by (service, _msg)
+
+# Statistics (server-side aggregation — most context-efficient)
+error | stats count() total
+error | stats by (service) count() hits | sort by (hits) desc | limit 10
+* | stats by (level) count() hits
+
+# Available stats functions:
+#   count(), sum(field), avg(field), min(field), max(field),
+#   count_uniq(field), uniq_values(field)
+```
+
+### Common Patterns
+
+```logsql
+# Count errors by service
+error OR exception | stats by (service) count() errors | sort by (errors) desc
+
+# Find unique error messages
+error | stats by (_msg) count() hits | sort by (hits) desc | limit 10
+
+# Errors in a specific time window (use --start/--end in scripts)
+_stream:{app="api"} AND error | limit 20
+
+# HTTP 5xx errors
+status:>=500 | stats by (path) count() hits | sort by (hits) desc
+
+# Slow requests
+duration:>1000 | stats by (service) count() slow | sort by (slow) desc
+```
+
+---
+
+## Investigation Workflows
+
+### Standard Incident Investigation
+
+```
+┌───────────────────────────────────────────────────┐
+│ 1. STATISTICS FIRST (mandatory)                   │
+│    python get_statistics.py                       │
+│    → Know volume, error rate, top streams         │
+└───────────────────────────────────────────────────┘
+                         │
+                         ▼
+                 High Error Rate?
+           ┌─────────────┴─────────────┐
+           │                           │
+   YES (>5%)                           NO
+           │                           │
+           ▼                           ▼
+┌───────────────────────┐  ┌────────────────────────┐
+│ 2. FAST PATH          │  │ 2. DISCOVER FIELDS     │
+│    sample_logs.py     │  │    list_fields.py      │
+│    --strategy         │  │    → Understand schema │
+│    errors_only        │  │    → Build targeted    │
+│                       │  │      query             │
+└───────────────────────┘  └────────────────────────┘
+```
+
+### Quick Commands Reference
+
+| Goal | Command |
+|------|---------|
+| Start investigation | `get_statistics.py` |
+| Discover fields | `list_fields.py --query '_stream:{app="X"}'` |
+| Sample errors | `sample_logs.py --strategy errors_only` |
+| Investigate spike | `sample_logs.py --strategy around_time --timestamp T` |
+| Count by service | `query_logs.py --query 'error \| stats by (service) count() hits'` |
+
+---
+
+## Anti-Patterns to Avoid
+
+1. **NEVER run a bare query without `| limit` or `| stats`** — Scripts auto-append limits as safety net, but write efficient queries
+2. **NEVER skip `get_statistics.py`** — It's the mandatory first step
+3. **NEVER fetch all logs** — Use sampling strategies and aggregation
+4. **NEVER ignore error rate** — High error rate means investigate patterns, not dump logs
+5. **NEVER query without time bounds** — Always specify `--time-range` or use defaults

--- a/sre-agent/.claude/skills/observability-victorialogs/scripts/get_statistics.py
+++ b/sre-agent/.claude/skills/observability-victorialogs/scripts/get_statistics.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Get comprehensive log statistics from VictoriaLogs — THE MANDATORY FIRST STEP.
+
+Uses server-side LogsQL aggregation to return a compact summary. Never dumps raw logs.
+
+Output includes:
+- Total count, error count, error rate percentage
+- Logs per minute
+- Top 10 streams by volume
+- Top error patterns (normalized and deduplicated)
+- Actionable recommendation
+
+Usage:
+    python get_statistics.py
+    python get_statistics.py --query '_stream:{app="api"}'
+    python get_statistics.py --time-range 120 --json
+"""
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+
+from victorialogs_client import normalize_message, query_logs
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Get log statistics from VictoriaLogs (ALWAYS call first)"
+    )
+    parser.add_argument(
+        "--query",
+        "-q",
+        default="*",
+        help="LogsQL filter (default: * = all logs)",
+    )
+    parser.add_argument(
+        "--time-range",
+        type=int,
+        default=60,
+        help="Time range in minutes (default: 60)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        now = datetime.now(timezone.utc)
+        start = now - timedelta(minutes=args.time_range)
+        base_query = args.query
+
+        # 1. Total count (server-side aggregation)
+        total_entries = query_logs(
+            f"{base_query} | stats count() total",
+            start=start,
+            end=now,
+            limit=1,
+        )
+        total_count = 0
+        if total_entries:
+            total_count = int(total_entries[0].get("total", 0))
+
+        # 2. Error count (server-side aggregation)
+        error_entries = query_logs(
+            f"{base_query} AND (error OR exception OR fail OR fatal) | stats count() errors",
+            start=start,
+            end=now,
+            limit=1,
+        )
+        error_count = 0
+        if error_entries:
+            error_count = int(error_entries[0].get("errors", 0))
+
+        # 3. Warning count
+        warn_entries = query_logs(
+            f"{base_query} AND (warn OR warning) | stats count() warnings",
+            start=start,
+            end=now,
+            limit=1,
+        )
+        warn_count = 0
+        if warn_entries:
+            warn_count = int(warn_entries[0].get("warnings", 0))
+
+        # 4. Top streams (server-side aggregation, top 10)
+        stream_entries = query_logs(
+            f"{base_query} | stats by (_stream) count() hits | sort by (hits) desc | limit 10",
+            start=start,
+            end=now,
+            limit=10,
+        )
+        top_streams = []
+        for entry in stream_entries:
+            stream = entry.get("_stream", "unknown")
+            hits = int(entry.get("hits", 0))
+            top_streams.append({"stream": stream, "count": hits})
+
+        # 5. Top error patterns (server-side aggregation + client-side normalization)
+        error_msg_entries = query_logs(
+            f"{base_query} AND (error OR exception) | stats by (_msg) count() hits | sort by (hits) desc | limit 30",
+            start=start,
+            end=now,
+            limit=30,
+        )
+        # Normalize and re-aggregate client-side
+        pattern_counter = Counter()
+        for entry in error_msg_entries:
+            msg = entry.get("_msg", "")
+            hits = int(entry.get("hits", 1))
+            normalized = normalize_message(msg)
+            pattern_counter[normalized] += hits
+
+        top_error_patterns = [
+            {"pattern": pattern, "count": count}
+            for pattern, count in pattern_counter.most_common(10)
+        ]
+
+        # Calculate rates
+        error_rate = round(error_count / total_count * 100, 2) if total_count > 0 else 0
+        warn_rate = round(warn_count / total_count * 100, 2) if total_count > 0 else 0
+        logs_per_minute = (
+            round(total_count / args.time_range, 2) if total_count > 0 else 0
+        )
+
+        # Build recommendation
+        if total_count == 0:
+            recommendation = "No logs found in the specified time range."
+        elif error_rate > 10:
+            recommendation = f"HIGH error rate ({error_rate}%). Investigate top error patterns immediately."
+        elif error_rate > 5:
+            recommendation = (
+                f"Elevated error rate ({error_rate}%). Review error patterns."
+            )
+        elif total_count > 100000:
+            recommendation = f"High volume ({total_count:,} logs). Use stream filters to narrow down."
+        else:
+            recommendation = (
+                f"Normal volume ({total_count:,} logs). Error rate: {error_rate}%"
+            )
+
+        result = {
+            "query": base_query,
+            "time_range_minutes": args.time_range,
+            "total_count": total_count,
+            "error_count": error_count,
+            "warning_count": warn_count,
+            "error_rate_percent": error_rate,
+            "warning_rate_percent": warn_rate,
+            "logs_per_minute": logs_per_minute,
+            "top_streams": top_streams,
+            "top_error_patterns": top_error_patterns,
+            "recommendation": recommendation,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print("=" * 55)
+            print("VICTORIALOGS STATISTICS")
+            print("=" * 55)
+            print(f"Query: {base_query}")
+            print(f"Time Range: {args.time_range} minutes")
+            print()
+            print(f"Total Logs:    {total_count:,}")
+            print(f"Errors:        {error_count:,} ({error_rate}%)")
+            print(f"Warnings:      {warn_count:,} ({warn_rate}%)")
+            print(f"Logs/minute:   {logs_per_minute:.2f}")
+            print()
+
+            if top_streams:
+                print("Top Streams:")
+                for s in top_streams[:10]:
+                    print(f"  {s['stream']}: {s['count']:,}")
+                print()
+
+            if top_error_patterns:
+                print("Top Error Patterns:")
+                for p in top_error_patterns[:5]:
+                    print(f"  [{p['count']}x] {p['pattern'][:80]}")
+                print()
+
+            print(f"Recommendation: {recommendation}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-victorialogs/scripts/list_fields.py
+++ b/sre-agent/.claude/skills/observability-victorialogs/scripts/list_fields.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Discover available fields and values in VictoriaLogs.
+
+Lightweight metadata query — helps the agent understand log structure before querying.
+
+Usage:
+    python list_fields.py                                    # List all field names
+    python list_fields.py --query '_stream:{app="api"}'      # Scoped to a stream
+    python list_fields.py --field level                      # List values for 'level'
+    python list_fields.py --field service --limit 20 --json  # Top 20 service values
+
+Examples:
+    python list_fields.py
+    python list_fields.py --field level
+    python list_fields.py --query '_stream:{namespace="prod"}' --field service
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+from victorialogs_client import get_field_names, get_field_values
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Discover fields and values in VictoriaLogs"
+    )
+    parser.add_argument(
+        "--query",
+        "-q",
+        default="*",
+        help="LogsQL filter to scope results (default: * = all)",
+    )
+    parser.add_argument(
+        "--field",
+        help="Get values for this specific field (omit to list all field names)",
+    )
+    parser.add_argument(
+        "--time-range",
+        type=int,
+        default=60,
+        help="Time range in minutes (default: 60)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Max values to display (default: 50)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        now = datetime.now(timezone.utc)
+        start = now - timedelta(minutes=args.time_range)
+
+        if args.field:
+            # Get values for a specific field
+            values = get_field_values(
+                args.query, args.field, start=start, end=now, limit=args.limit
+            )
+
+            if args.json:
+                print(
+                    json.dumps(
+                        {
+                            "field": args.field,
+                            "query": args.query,
+                            "values": values,
+                            "count": len(values),
+                        },
+                        indent=2,
+                    )
+                )
+            else:
+                print(f"Values for field '{args.field}':")
+                print(f"  Query: {args.query}")
+                print(f"  Found: {len(values)} values")
+                print()
+                for v in values:
+                    value = v.get("value", v.get(args.field, str(v)))
+                    hits = v.get("hits", "")
+                    if hits:
+                        print(f"  {value} ({hits} hits)")
+                    else:
+                        print(f"  {value}")
+        else:
+            # List all field names
+            fields = get_field_names(args.query, start=start, end=now)
+
+            if args.json:
+                print(
+                    json.dumps(
+                        {
+                            "query": args.query,
+                            "fields": fields,
+                            "count": len(fields),
+                        },
+                        indent=2,
+                    )
+                )
+            else:
+                print(f"Available fields ({len(fields)}):")
+                print(f"  Query: {args.query}")
+                print()
+                for f in fields:
+                    name = f.get("value", f.get("field", str(f)))
+                    hits = f.get("hits", "")
+                    if hits:
+                        print(f"  {name} ({hits} hits)")
+                    else:
+                        print(f"  {name}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-victorialogs/scripts/query_logs.py
+++ b/sre-agent/.claude/skills/observability-victorialogs/scripts/query_logs.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Execute raw LogsQL queries against VictoriaLogs.
+
+Safety: auto-appends '| limit N' if the query doesn't contain '| limit' or '| stats'.
+Handles both log results and stats results.
+
+Usage:
+    python query_logs.py --query 'error | stats by (service) count() hits'
+    python query_logs.py --query '_stream:{app="api"} AND timeout' --limit 10
+    python query_logs.py --query 'status:>=500' --time-range 30 --json
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+from victorialogs_client import format_log_entry, query_logs
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Execute raw LogsQL queries against VictoriaLogs"
+    )
+    parser.add_argument("--query", "-q", required=True, help="LogsQL query")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Max entries to return (default: 50, auto-appended if no | limit in query)",
+    )
+    parser.add_argument(
+        "--time-range",
+        type=int,
+        default=60,
+        help="Time range in minutes (default: 60)",
+    )
+    parser.add_argument("--start", help="Start time (ISO format)")
+    parser.add_argument("--end", help="End time (ISO format)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        now = datetime.now(timezone.utc)
+
+        # Parse start/end if provided
+        if args.start:
+            start = datetime.fromisoformat(args.start.replace("Z", "+00:00"))
+        else:
+            start = now - timedelta(minutes=args.time_range)
+
+        if args.end:
+            end = datetime.fromisoformat(args.end.replace("Z", "+00:00"))
+        else:
+            end = now
+
+        # Execute query (client auto-appends | limit if needed)
+        entries = query_logs(args.query, start=start, end=end, limit=args.limit)
+
+        if args.json:
+            result = {
+                "query": args.query,
+                "count": len(entries),
+                "entries": entries,
+            }
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Query: {args.query}")
+            print(f"Results: {len(entries)}")
+            print()
+
+            if not entries:
+                print("No results found.")
+            else:
+                # Detect if this is a stats result (has aggregation fields, no _msg)
+                first = entries[0]
+                is_stats = "_msg" not in first and "_time" not in first
+
+                if is_stats:
+                    # Stats output: format as table
+                    if entries:
+                        keys = list(entries[0].keys())
+                        # Print header
+                        header = "  ".join(f"{k:>15}" for k in keys)
+                        print(header)
+                        print("-" * len(header))
+                        for entry in entries:
+                            row = "  ".join(
+                                f"{str(entry.get(k, '')):>15}" for k in keys
+                            )
+                            print(row)
+                else:
+                    # Log output: format as entries
+                    for entry in entries:
+                        print(format_log_entry(entry))
+                        print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-victorialogs/scripts/sample_logs.py
+++ b/sre-agent/.claude/skills/observability-victorialogs/scripts/sample_logs.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Sample logs from VictoriaLogs using intelligent strategies.
+
+Choose the right sampling strategy based on your investigation needs.
+Hard-capped at 50 entries max to protect the context window.
+
+Usage:
+    python sample_logs.py --strategy errors_only
+    python sample_logs.py --query '_stream:{app="api"}' --strategy errors_only
+    python sample_logs.py --strategy around_time --timestamp "2026-01-27T05:00:00Z" --window 5
+    python sample_logs.py --strategy all --limit 20
+
+Strategies:
+    errors_only   - Only error/exception/fail logs (default)
+    warnings_up   - Warning and error logs
+    around_time   - Logs around a specific timestamp
+    all           - All log levels
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+from victorialogs_client import format_log_entry, query_logs
+
+# Hard maximum to prevent context flooding
+MAX_LIMIT = 50
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Sample logs from VictoriaLogs using intelligent strategies"
+    )
+    parser.add_argument(
+        "--query",
+        "-q",
+        default="*",
+        help="LogsQL filter (default: * = all)",
+    )
+    parser.add_argument(
+        "--strategy",
+        choices=["errors_only", "warnings_up", "around_time", "all"],
+        default="errors_only",
+        help="Sampling strategy (default: errors_only)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help=f"Maximum logs to return (default: 20, max: {MAX_LIMIT})",
+    )
+    parser.add_argument(
+        "--time-range",
+        type=int,
+        default=60,
+        help="Time range in minutes (default: 60)",
+    )
+    parser.add_argument(
+        "--timestamp",
+        help="ISO timestamp for around_time strategy (e.g., 2026-01-27T05:00:00Z)",
+    )
+    parser.add_argument(
+        "--window",
+        type=int,
+        default=5,
+        help="Window in minutes for around_time strategy (default: 5)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    # Enforce hard cap
+    if args.limit > MAX_LIMIT:
+        print(
+            f"Warning: --limit clamped from {args.limit} to {MAX_LIMIT}",
+            file=sys.stderr,
+        )
+        args.limit = MAX_LIMIT
+
+    try:
+        base_query = args.query
+        now = datetime.now(timezone.utc)
+
+        # Build query based on strategy
+        if args.strategy == "errors_only":
+            logsql = f"{base_query} AND (error OR exception OR fail OR fatal)"
+        elif args.strategy == "warnings_up":
+            logsql = f"{base_query} AND (error OR warn OR exception)"
+        elif args.strategy == "around_time":
+            if not args.timestamp:
+                print(
+                    "Error: --timestamp required for around_time strategy",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            logsql = base_query
+        else:  # all
+            logsql = base_query
+
+        # Determine time range
+        if args.strategy == "around_time" and args.timestamp:
+            try:
+                target = datetime.fromisoformat(args.timestamp.replace("Z", "+00:00"))
+            except ValueError as e:
+                print(f"Error parsing timestamp: {e}", file=sys.stderr)
+                sys.exit(1)
+            window = timedelta(minutes=args.window)
+            start = target - window
+            end = target + window
+        else:
+            start = now - timedelta(minutes=args.time_range)
+            end = now
+
+        # Fetch logs (limit is enforced by client)
+        logs = query_logs(logsql, start=start, end=end, limit=args.limit)
+
+        if args.json:
+            result = {
+                "strategy": args.strategy,
+                "query": logsql,
+                "count": len(logs),
+                "limit": args.limit,
+                "time_range_minutes": args.time_range,
+                "logs": logs[: args.limit],
+            }
+            print(json.dumps(result, indent=2))
+        else:
+            print("=" * 55)
+            print(f"VICTORIALOGS SAMPLE ({args.strategy})")
+            print("=" * 55)
+            print(f"Query: {logsql}")
+            print(f"Found: {len(logs)} logs")
+            print()
+
+            if not logs:
+                print("No logs found matching criteria.")
+            else:
+                for entry in logs[: args.limit]:
+                    print(format_log_entry(entry))
+                    print("-" * 40)
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/observability-victorialogs/scripts/victorialogs_client.py
+++ b/sre-agent/.claude/skills/observability-victorialogs/scripts/victorialogs_client.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""Shared VictoriaLogs client with proxy support.
+
+This module provides the VictoriaLogs client that works through the credential proxy.
+Credentials are injected transparently by the proxy layer.
+
+VictoriaLogs uses LogsQL query language and returns JSON lines (one JSON object per line).
+"""
+
+import base64
+import json
+import os
+import re
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import httpx
+
+
+def get_config() -> dict[str, str | None]:
+    """Get VictoriaLogs configuration from environment.
+
+    Credentials are injected by the credential-proxy based on tenant context.
+    """
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+    }
+
+
+def get_api_url(endpoint: str) -> str:
+    """Build the VictoriaLogs API URL.
+
+    Supports two modes:
+    1. Proxy mode (production): Uses VICTORIALOGS_BASE_URL
+    2. Direct mode (testing): Uses VICTORIALOGS_URL
+    """
+    # Proxy mode (production)
+    base_url = os.getenv("VICTORIALOGS_BASE_URL")
+    if base_url:
+        return f"{base_url.rstrip('/')}{endpoint}"
+
+    # Direct mode (testing)
+    direct_url = os.getenv("VICTORIALOGS_URL")
+    if direct_url:
+        return f"{direct_url.rstrip('/')}{endpoint}"
+
+    raise RuntimeError(
+        "Either VICTORIALOGS_BASE_URL (proxy mode) or VICTORIALOGS_URL (direct mode) must be set."
+    )
+
+
+def get_headers() -> dict[str, str]:
+    """Get VictoriaLogs API headers.
+
+    Supports multiple auth methods:
+    1. Bearer token - VICTORIALOGS_TOKEN
+    2. Basic auth - VICTORIALOGS_USER + VICTORIALOGS_PASSWORD
+    3. Proxy mode - JWT for credential-resolver auth
+    """
+    config = get_config()
+
+    headers = {
+        "Accept": "application/json",
+    }
+
+    # Priority 1: Bearer token
+    token = os.getenv("VICTORIALOGS_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+        return headers
+
+    # Priority 2: Basic auth
+    user = os.getenv("VICTORIALOGS_USER")
+    password = os.getenv("VICTORIALOGS_PASSWORD")
+    if user and password:
+        encoded = base64.b64encode(f"{user}:{password}".encode()).decode()
+        headers["Authorization"] = f"Basic {encoded}"
+        return headers
+
+    # Priority 3: Proxy mode - use JWT for credential-resolver auth
+    if os.getenv("VICTORIALOGS_BASE_URL"):
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            # Fallback for local dev
+            headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+            headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    return headers
+
+
+def _has_pipe(query: str, pipe_name: str) -> bool:
+    """Check if a LogsQL query already contains a specific pipe.
+
+    Handles edge cases where pipe keywords might appear inside quoted strings.
+    """
+    # Simple heuristic: check if pipe appears after a | character
+    parts = query.split("|")
+    for part in parts[1:]:  # Skip the filter part (before first |)
+        stripped = part.strip().lower()
+        if stripped.startswith(pipe_name):
+            return True
+    return False
+
+
+def _ensure_limit(query: str, limit: int) -> str:
+    """Ensure a LogsQL query has a limit to prevent unbounded results.
+
+    Auto-appends '| limit N' if the query doesn't already contain
+    '| limit' or '| stats' pipes.
+    """
+    if _has_pipe(query, "limit") or _has_pipe(query, "stats"):
+        return query
+    return f"{query} | limit {limit}"
+
+
+def _parse_jsonlines(text: str) -> list[dict]:
+    """Parse JSON lines response from VictoriaLogs.
+
+    VictoriaLogs returns one JSON object per line, not a JSON array.
+    """
+    entries = []
+    for line in text.strip().split("\n"):
+        line = line.strip()
+        if line:
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return entries
+
+
+def query_logs(
+    query: str,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    limit: int = 100,
+) -> list[dict]:
+    """Execute a LogsQL query and return log entries.
+
+    Auto-appends '| limit' if the query doesn't contain '| limit' or '| stats'.
+
+    Args:
+        query: LogsQL query string
+        start: Start time (default: 1 hour ago)
+        end: End time (default: now)
+        limit: Maximum entries to return (safety limit)
+
+    Returns:
+        List of log entry dicts
+    """
+    now = datetime.now(timezone.utc)
+    if end is None:
+        end = now
+    if start is None:
+        start = now - timedelta(hours=1)
+
+    safe_query = _ensure_limit(query, limit)
+
+    params = {
+        "query": safe_query,
+        "start": start.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "end": end.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+    url = get_api_url(f"/select/logsql/query?{urlencode(params)}")
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+        return _parse_jsonlines(response.text)
+
+
+def query_hits(
+    query: str,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    step: str = "5m",
+) -> dict:
+    """Get log hit counts over time buckets.
+
+    Returns compact counts per time bucket, not raw logs.
+
+    Args:
+        query: LogsQL query string
+        start: Start time (default: 1 hour ago)
+        end: End time (default: now)
+        step: Time bucket size (default: 5m)
+
+    Returns:
+        Hits response with time buckets and counts
+    """
+    now = datetime.now(timezone.utc)
+    if end is None:
+        end = now
+    if start is None:
+        start = now - timedelta(hours=1)
+
+    params = {
+        "query": query,
+        "start": start.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "end": end.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "step": step,
+    }
+
+    url = get_api_url(f"/select/logsql/hits?{urlencode(params)}")
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+        return response.json()
+
+
+def query_stats(
+    query: str,
+    start: datetime | None = None,
+    end: datetime | None = None,
+) -> dict:
+    """Execute an instant stats query.
+
+    Args:
+        query: LogsQL query with | stats pipe
+        start: Start time (default: 1 hour ago)
+        end: End time (default: now)
+
+    Returns:
+        Stats response
+    """
+    now = datetime.now(timezone.utc)
+    if end is None:
+        end = now
+    if start is None:
+        start = now - timedelta(hours=1)
+
+    params = {
+        "query": query,
+        "start": start.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "end": end.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+    url = get_api_url(f"/select/logsql/stats_query?{urlencode(params)}")
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+        return response.json()
+
+
+def get_field_names(
+    query: str = "*",
+    start: datetime | None = None,
+    end: datetime | None = None,
+) -> list[dict]:
+    """Get all field names in logs matching query.
+
+    Args:
+        query: LogsQL filter (default: * = all)
+        start: Start time (default: 1 hour ago)
+        end: End time (default: now)
+
+    Returns:
+        List of dicts with field name and hit count
+    """
+    now = datetime.now(timezone.utc)
+    if end is None:
+        end = now
+    if start is None:
+        start = now - timedelta(hours=1)
+
+    params = {
+        "query": query,
+        "start": start.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "end": end.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+    url = get_api_url(f"/select/logsql/stream_field_names?{urlencode(params)}")
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+        return _parse_jsonlines(response.text)
+
+
+def get_field_values(
+    query: str,
+    field: str,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    limit: int = 50,
+) -> list[dict]:
+    """Get distinct values for a specific field.
+
+    Args:
+        query: LogsQL filter
+        field: Field name to get values for
+        start: Start time (default: 1 hour ago)
+        end: End time (default: now)
+        limit: Max values to return
+
+    Returns:
+        List of dicts with field value and hit count
+    """
+    now = datetime.now(timezone.utc)
+    if end is None:
+        end = now
+    if start is None:
+        start = now - timedelta(hours=1)
+
+    params = {
+        "query": query,
+        "field": field,
+        "start": start.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "end": end.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "limit": str(limit),
+    }
+
+    url = get_api_url(f"/select/logsql/stream_field_values?{urlencode(params)}")
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+        return _parse_jsonlines(response.text)
+
+
+def get_stream_ids(
+    query: str = "*",
+    start: datetime | None = None,
+    end: datetime | None = None,
+    limit: int = 20,
+) -> list[dict]:
+    """Get stream IDs matching query.
+
+    Args:
+        query: LogsQL filter (default: * = all)
+        start: Start time (default: 1 hour ago)
+        end: End time (default: now)
+        limit: Max streams to return
+
+    Returns:
+        List of dicts with stream_id and hit count
+    """
+    now = datetime.now(timezone.utc)
+    if end is None:
+        end = now
+    if start is None:
+        start = now - timedelta(hours=1)
+
+    params = {
+        "query": query,
+        "start": start.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "end": end.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "limit": str(limit),
+    }
+
+    url = get_api_url(f"/select/logsql/stream_ids?{urlencode(params)}")
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(url, headers=get_headers())
+        response.raise_for_status()
+        return _parse_jsonlines(response.text)
+
+
+def format_log_entry(entry: dict, max_length: int = 200) -> str:
+    """Format a log entry for human-readable display.
+
+    Truncates message to max_length to avoid flooding the context window.
+
+    Args:
+        entry: Log entry dict from VictoriaLogs
+        max_length: Maximum message length
+
+    Returns:
+        Formatted string
+    """
+    # Extract key fields
+    timestamp = entry.get("_time", "")
+    if timestamp:
+        # Truncate nanoseconds for readability
+        timestamp = timestamp[:19]
+
+    stream = entry.get("_stream", "")
+    msg = entry.get("_msg", "")
+    level = entry.get("level", entry.get("severity", ""))
+
+    # Truncate message
+    if len(msg) > max_length:
+        msg = msg[: max_length - 3] + "..."
+
+    # Build context
+    context_parts = []
+    if level:
+        context_parts.append(level.upper())
+    if stream:
+        context_parts.append(stream)
+
+    context = " ".join(context_parts)
+
+    if context:
+        return f"[{timestamp}] {context}\n  {msg}"
+    else:
+        return f"[{timestamp}] {msg}"
+
+
+def normalize_message(msg: str) -> str:
+    """Normalize a log message for pattern grouping.
+
+    Removes UUIDs, IPs, numbers, and timestamps to group similar messages.
+    """
+    # Remove UUIDs
+    normalized = re.sub(
+        r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
+        "<UUID>",
+        msg,
+    )
+    # Remove IPs
+    normalized = re.sub(r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b", "<IP>", normalized)
+    # Remove numbers (but keep common status codes context)
+    normalized = re.sub(r"\b\d+\b", "<N>", normalized)
+    # Truncate for grouping
+    return normalized[:100]

--- a/sre-agent/.claude/skills/observability/SKILL.md
+++ b/sre-agent/.claude/skills/observability/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: observability
+description: Log, metric, and trace analysis methodology. Use when analyzing logs, investigating errors, querying metrics, or correlating signals across observability backends (Coralogix, Datadog, CloudWatch).
+---
+
+# Observability Analysis
+
+## Core Principle: Statistics Before Samples
+
+**NEVER start by reading raw logs.** Always begin with aggregated statistics:
+
+1. **Volume**: How many logs in the time window?
+2. **Distribution**: Which services/levels/error types?
+3. **Trends**: Is it increasing, stable, or decreasing?
+4. **THEN sample**: Get specific entries after understanding the landscape
+
+## Available Backends
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for API keys in environment variables - they won't be there. Just use the backend scripts directly; authentication is handled transparently.
+
+Available backends (invoke with `/skill-name`):
+- **Coralogix** (DataPrime) - `/observability-coralogix`
+- **Datadog** - `/observability-datadog`
+- **Honeycomb** - `/observability-honeycomb`
+- **Splunk** (SPL) - `/observability-splunk`
+- **Elasticsearch/OpenSearch** - `/observability-elasticsearch`
+- **Jaeger** (Tracing) - `/observability-jaeger`
+
+To check if a backend is working, try a simple query rather than checking env vars.
+
+### Backend-Specific Skills
+- **Coralogix**: `/observability-coralogix` - DataPrime syntax, log/trace analysis
+- **Datadog**: `/observability-datadog` - DQL syntax, metrics and APM
+- **Honeycomb**: `/observability-honeycomb` - High-cardinality analysis, distributed tracing
+- **Splunk**: `/observability-splunk` - SPL syntax, saved searches
+- **Elasticsearch**: `/observability-elasticsearch` - Lucene/Query DSL
+- **Jaeger**: `/observability-jaeger` - Distributed tracing, latency analysis
+
+## Analysis Framework
+
+### Step 1: Get the Big Picture
+- Total log volume
+- Error rate and distribution
+- Which services are most affected
+
+### Step 2: Identify Patterns
+- Error clustering (many errors in short time)
+- Temporal patterns (started at X time)
+- Service correlation (Service A errors → Service B errors)
+
+### Step 3: Sample Strategically
+- Sample from error peaks
+- Get examples of each distinct error type
+- Compare against baseline period
+
+## Output Format
+
+When reporting observability findings, use this structure:
+
+```
+## Log Analysis Summary
+
+### Time Window
+- Start: [timestamp]
+- End: [timestamp]
+- Duration: X hours
+
+### Statistics
+- Total logs: X events
+- Error count: Y events (Z%)
+- Services affected: N services
+- Error rate trend: [increasing/stable/decreasing]
+
+### Top Error Services
+1. [service1]: N errors
+2. [service2]: M errors
+
+### Error Patterns
+- Primary error type: [description]
+- First occurrence: [timestamp]
+- Correlation: [deployment/traffic/external event]
+
+### Sample Errors
+[Quote 2-3 representative error messages with context]
+
+### Root Cause Hypothesis
+[Based on patterns observed]
+
+### Confidence Level
+[High/Medium/Low with explanation]
+```

--- a/sre-agent/.claude/skills/platform-vercel/SKILL.md
+++ b/sre-agent/.claude/skills/platform-vercel/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: platform-vercel
+description: Query Vercel deployments, projects, and build logs. Use when investigating Vercel deployment failures, runtime errors, or build issues.
+allowed-tools: Bash(python *)
+---
+
+# Vercel Platform
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `VERCEL_TOKEN` in environment variables -- it won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `VERCEL_TEAM_ID` - Vercel team ID (optional, for team-scoped requests)
+
+---
+
+## Available Scripts
+
+All scripts are in `.claude/skills/platform-vercel/scripts/`
+
+### list_projects.py - List Vercel Projects
+```bash
+python .claude/skills/platform-vercel/scripts/list_projects.py [--limit 20]
+
+# Examples:
+python .claude/skills/platform-vercel/scripts/list_projects.py
+python .claude/skills/platform-vercel/scripts/list_projects.py --limit 50 --json
+```
+
+### get_project.py - Get Project Details
+```bash
+python .claude/skills/platform-vercel/scripts/get_project.py --project PROJECT_ID_OR_NAME
+
+# Examples:
+python .claude/skills/platform-vercel/scripts/get_project.py --project my-webapp
+python .claude/skills/platform-vercel/scripts/get_project.py --project prj_abc123 --json
+```
+
+### list_deployments.py - List Deployments
+```bash
+python .claude/skills/platform-vercel/scripts/list_deployments.py [--project PROJECT] [--state STATE] [--target TARGET] [--limit 20]
+
+# Examples:
+python .claude/skills/platform-vercel/scripts/list_deployments.py --project my-webapp
+python .claude/skills/platform-vercel/scripts/list_deployments.py --project my-webapp --state ERROR
+python .claude/skills/platform-vercel/scripts/list_deployments.py --project my-webapp --target production --limit 5
+```
+
+### get_deployment.py - Get Deployment Details
+```bash
+python .claude/skills/platform-vercel/scripts/get_deployment.py --deployment DEPLOYMENT_ID_OR_URL
+
+# Examples:
+python .claude/skills/platform-vercel/scripts/get_deployment.py --deployment dpl_abc123
+python .claude/skills/platform-vercel/scripts/get_deployment.py --deployment my-webapp-abc123.vercel.app --json
+```
+
+### get_deployment_events.py - Get Build Logs / Deployment Events
+```bash
+python .claude/skills/platform-vercel/scripts/get_deployment_events.py --deployment DEPLOYMENT_ID [--limit 50]
+
+# Examples:
+python .claude/skills/platform-vercel/scripts/get_deployment_events.py --deployment dpl_abc123
+python .claude/skills/platform-vercel/scripts/get_deployment_events.py --deployment dpl_abc123 --limit 100 --json
+```
+
+### create_deployment.py - Create a New Deployment
+```bash
+python .claude/skills/platform-vercel/scripts/create_deployment.py --name PROJECT_NAME --repo OWNER/REPO --ref BRANCH_OR_SHA [--target preview]
+
+# Examples:
+python .claude/skills/platform-vercel/scripts/create_deployment.py --name my-webapp --repo acme/my-webapp --ref main --target production
+python .claude/skills/platform-vercel/scripts/create_deployment.py --name my-webapp --repo acme/my-webapp --ref fix/login-bug
+```
+
+---
+
+## Investigation Workflow
+
+### Deployment Failure Investigation
+```
+1. list_deployments.py --project PROJECT --state ERROR
+2. get_deployment.py --deployment DEPLOYMENT_ID
+3. get_deployment_events.py --deployment DEPLOYMENT_ID
+4. Correlate with recent commits via deployment's git metadata
+```
+
+### Production Regression Investigation
+```
+1. list_deployments.py --project PROJECT --target production --limit 5
+2. get_deployment.py --deployment LATEST_DEPLOYMENT_ID
+3. Compare git SHAs between current and previous production deployment
+4. get_deployment_events.py --deployment DEPLOYMENT_ID (check build output)
+```
+
+### Build Timeout / Slow Build Investigation
+```
+1. list_deployments.py --project PROJECT --limit 10
+2. get_deployment_events.py --deployment DEPLOYMENT_ID --limit 200
+3. Look for long gaps between event timestamps in the build log
+```
+
+---
+
+## Quick Commands Reference
+
+| Goal | Command |
+|------|---------|
+| List all projects | `list_projects.py` |
+| Get project config | `get_project.py --project NAME` |
+| Recent deployments | `list_deployments.py --project NAME` |
+| Failed deployments | `list_deployments.py --project NAME --state ERROR` |
+| Production deploys | `list_deployments.py --project NAME --target production` |
+| Deployment details | `get_deployment.py --deployment ID` |
+| Build logs | `get_deployment_events.py --deployment ID` |
+| Trigger deploy | `create_deployment.py --name NAME --repo OWNER/REPO --ref BRANCH` |
+
+---
+
+## Common Patterns
+
+### Check if a deployment is still building
+```bash
+python .claude/skills/platform-vercel/scripts/get_deployment.py --deployment dpl_abc123 --json
+# Look at "state" field: BUILDING, READY, ERROR, CANCELED, QUEUED
+```
+
+### Find the deployment for a specific commit
+```bash
+python .claude/skills/platform-vercel/scripts/list_deployments.py --project my-webapp --json
+# Search the JSON output for the commit SHA in meta.githubCommitSha
+```
+
+### Get build errors from a failed deployment
+```bash
+python .claude/skills/platform-vercel/scripts/get_deployment.py --deployment dpl_abc123
+# Check errorCode and errorMessage fields
+python .claude/skills/platform-vercel/scripts/get_deployment_events.py --deployment dpl_abc123
+# Read the full build log for error details
+```
+
+---
+
+## Anti-Patterns
+
+- **Do NOT** try to read `VERCEL_TOKEN` from the environment. The credential proxy injects it.
+- **Do NOT** use `curl` to hit the Vercel API directly. Always use the scripts which handle auth and proxy routing.
+- **Do NOT** poll deployment status in a tight loop. Check once, report the state, and let the user decide when to re-check.
+- **Do NOT** create production deployments without explicit user confirmation. Default to `preview` target.

--- a/sre-agent/.claude/skills/platform-vercel/scripts/create_deployment.py
+++ b/sre-agent/.claude/skills/platform-vercel/scripts/create_deployment.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Create a new Vercel deployment.
+
+Usage:
+    python create_deployment.py --name PROJECT_NAME --repo OWNER/REPO --ref BRANCH_OR_SHA [--target preview] [--json]
+
+Examples:
+    python create_deployment.py --name my-webapp --repo acme/my-webapp --ref main --target production
+    python create_deployment.py --name my-webapp --repo acme/my-webapp --ref fix/login-bug
+    python create_deployment.py --name my-webapp --repo acme/my-webapp --ref abc123def --json
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from vercel_client import create_deployment, format_deployment
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create a Vercel deployment")
+    parser.add_argument("--name", required=True, help="Project name")
+    parser.add_argument("--repo", required=True, help="Git repository (OWNER/REPO)")
+    parser.add_argument("--ref", required=True, help="Git branch, tag, or commit SHA")
+    parser.add_argument(
+        "--target",
+        default="preview",
+        choices=["production", "preview"],
+        help="Deployment target (default: preview)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        git_source = {
+            "type": "github",
+            "repo": args.repo,
+            "ref": args.ref,
+        }
+
+        deployment = create_deployment(
+            name=args.name,
+            git_source=git_source,
+            target=args.target,
+        )
+
+        if args.json:
+            result = {
+                "ok": True,
+                "deployment": deployment,
+            }
+            print(json.dumps(result, indent=2))
+        else:
+            print("Deployment created successfully!\n")
+            print(format_deployment(deployment))
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/platform-vercel/scripts/get_deployment.py
+++ b/sre-agent/.claude/skills/platform-vercel/scripts/get_deployment.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Get details of a specific Vercel deployment.
+
+Usage:
+    python get_deployment.py --deployment DEPLOYMENT_ID_OR_URL [--json]
+
+Examples:
+    python get_deployment.py --deployment dpl_abc123
+    python get_deployment.py --deployment my-webapp-abc123.vercel.app
+    python get_deployment.py --deployment dpl_abc123 --json
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from vercel_client import format_deployment, get_deployment
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Vercel deployment details")
+    parser.add_argument(
+        "--deployment", required=True, help="Deployment ID (dpl_...) or deployment URL"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        deployment = get_deployment(args.deployment)
+
+        if args.json:
+            result = {
+                "ok": True,
+                "deployment": deployment,
+            }
+            print(json.dumps(result, indent=2))
+        else:
+            print(format_deployment(deployment))
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/platform-vercel/scripts/get_deployment_events.py
+++ b/sre-agent/.claude/skills/platform-vercel/scripts/get_deployment_events.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Get build log events for a Vercel deployment.
+
+Usage:
+    python get_deployment_events.py --deployment DEPLOYMENT_ID [--limit 50] [--json]
+
+Examples:
+    python get_deployment_events.py --deployment dpl_abc123
+    python get_deployment_events.py --deployment dpl_abc123 --limit 100
+    python get_deployment_events.py --deployment dpl_abc123 --json
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from vercel_client import get_deployment_events
+
+
+def _format_event(event: dict) -> str:
+    """Format a single deployment event for human-readable output."""
+    created = event.get("created", "")
+    event_type = event.get("type", "")
+    payload = event.get("payload", {})
+
+    # Build log events have text in payload
+    text = ""
+    if isinstance(payload, dict):
+        text = payload.get("text", payload.get("message", ""))
+    elif isinstance(payload, str):
+        text = payload
+
+    # Format timestamp if it's epoch millis
+    ts_str = ""
+    if isinstance(created, (int, float)):
+        from datetime import datetime, timezone
+
+        dt = datetime.fromtimestamp(created / 1000, tz=timezone.utc)
+        ts_str = dt.strftime("%H:%M:%S")
+    elif created:
+        ts_str = str(created)
+
+    if text:
+        return f"[{ts_str}] {text}"
+    return f"[{ts_str}] ({event_type})"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Vercel deployment build logs")
+    parser.add_argument("--deployment", required=True, help="Deployment ID")
+    parser.add_argument(
+        "--limit", type=int, default=50, help="Max events to return (default: 50)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        events = get_deployment_events(args.deployment, limit=args.limit)
+
+        if args.json:
+            result = {
+                "ok": True,
+                "deployment_id": args.deployment,
+                "events": events,
+                "count": len(events),
+            }
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Deployment Events ({args.deployment}): {len(events)} entries\n")
+            for event in events:
+                print(_format_event(event))
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/platform-vercel/scripts/get_project.py
+++ b/sre-agent/.claude/skills/platform-vercel/scripts/get_project.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Get details of a Vercel project.
+
+Usage:
+    python get_project.py --project PROJECT_ID_OR_NAME [--json]
+
+Examples:
+    python get_project.py --project my-webapp
+    python get_project.py --project prj_abc123 --json
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from vercel_client import format_project, get_project
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Vercel project details")
+    parser.add_argument("--project", required=True, help="Project ID or name")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        project = get_project(args.project)
+
+        if args.json:
+            result = {
+                "ok": True,
+                "project": project,
+            }
+            print(json.dumps(result, indent=2))
+        else:
+            print(format_project(project))
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/platform-vercel/scripts/list_deployments.py
+++ b/sre-agent/.claude/skills/platform-vercel/scripts/list_deployments.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""List Vercel deployments with optional filters.
+
+Usage:
+    python list_deployments.py [--project PROJECT] [--state STATE] [--target TARGET] [--limit 20] [--json]
+
+Examples:
+    python list_deployments.py --project my-webapp
+    python list_deployments.py --project my-webapp --state ERROR
+    python list_deployments.py --project my-webapp --target production --limit 5
+    python list_deployments.py --project my-webapp --json
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from vercel_client import format_deployment, list_deployments
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Vercel deployments")
+    parser.add_argument("--project", help="Filter by project ID or name")
+    parser.add_argument(
+        "--state",
+        choices=["BUILDING", "READY", "ERROR", "CANCELED", "QUEUED"],
+        help="Filter by deployment state",
+    )
+    parser.add_argument(
+        "--target",
+        choices=["production", "preview"],
+        help="Filter by deployment target",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=20, help="Max deployments to return (default: 20)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        deployments = list_deployments(
+            project_id=args.project,
+            state=args.state,
+            target=args.target,
+            limit=args.limit,
+        )
+
+        if args.json:
+            result = {
+                "ok": True,
+                "deployments": deployments,
+                "count": len(deployments),
+            }
+            print(json.dumps(result, indent=2))
+        else:
+            filters = []
+            if args.project:
+                filters.append(f"project={args.project}")
+            if args.state:
+                filters.append(f"state={args.state}")
+            if args.target:
+                filters.append(f"target={args.target}")
+            filter_str = f" ({', '.join(filters)})" if filters else ""
+
+            print(f"Vercel Deployments{filter_str}: {len(deployments)}\n")
+            for d in deployments:
+                print(format_deployment(d))
+                print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/platform-vercel/scripts/list_projects.py
+++ b/sre-agent/.claude/skills/platform-vercel/scripts/list_projects.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""List Vercel projects.
+
+Usage:
+    python list_projects.py [--limit 20] [--json]
+
+Examples:
+    python list_projects.py
+    python list_projects.py --limit 50
+    python list_projects.py --json
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from vercel_client import format_project, list_projects
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Vercel projects")
+    parser.add_argument(
+        "--limit", type=int, default=20, help="Max projects to return (default: 20)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        projects = list_projects(limit=args.limit)
+
+        if args.json:
+            result = {
+                "ok": True,
+                "projects": projects,
+                "count": len(projects),
+            }
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Vercel Projects: {len(projects)}\n")
+            for p in projects:
+                print(format_project(p))
+                print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/platform-vercel/scripts/vercel_client.py
+++ b/sre-agent/.claude/skills/platform-vercel/scripts/vercel_client.py
@@ -1,0 +1,336 @@
+"""Vercel API client for deployment and project operations.
+
+Supports credential proxy mode (production) and direct token mode (local dev).
+Credentials are injected automatically by the proxy -- scripts should NOT
+check for VERCEL_TOKEN in environment variables.
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+def get_config() -> dict[str, Any]:
+    """Load configuration from standard locations."""
+    config = {}
+
+    config_paths = [
+        Path.home() / ".opensre" / "config.json",
+        Path("/etc/opensre/config.json"),
+    ]
+
+    for path in config_paths:
+        if path.exists():
+            with open(path) as f:
+                config = json.load(f)
+                break
+
+    if os.getenv("TENANT_ID"):
+        config["tenant_id"] = os.getenv("TENANT_ID")
+    if os.getenv("TEAM_ID"):
+        config["team_id"] = os.getenv("TEAM_ID")
+
+    return config
+
+
+def get_api_url(endpoint: str) -> str:
+    """Get the Vercel API URL, routing through credential proxy in production."""
+    base_url = os.getenv("VERCEL_BASE_URL")
+    if not base_url:
+        base_url = "https://api.vercel.com"
+    return f"{base_url.rstrip('/')}{endpoint}"
+
+
+def get_headers() -> dict[str, str]:
+    """Get headers for Vercel API requests."""
+    config = get_config()
+
+    headers = {
+        "Content-Type": "application/json",
+    }
+
+    sandbox_jwt = os.getenv("SANDBOX_JWT")
+    if sandbox_jwt:
+        headers["X-Sandbox-JWT"] = sandbox_jwt
+    else:
+        headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+        headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    # Direct token mode for local development only
+    token = os.getenv("VERCEL_TOKEN")
+    if token and not os.getenv("VERCEL_BASE_URL"):
+        headers["Authorization"] = f"Bearer {token}"
+
+    return headers
+
+
+def _inject_team_id(params: dict[str, Any] | None) -> dict[str, Any]:
+    """Inject teamId query parameter if VERCEL_TEAM_ID is set."""
+    if params is None:
+        params = {}
+    team_id = os.getenv("VERCEL_TEAM_ID")
+    if team_id and "teamId" not in params:
+        params["teamId"] = team_id
+    return params
+
+
+def api_request(
+    method: str,
+    endpoint: str,
+    params: dict[str, Any] | None = None,
+    json_data: dict[str, Any] | list | None = None,
+) -> dict[str, Any] | list:
+    """Make a request to the Vercel API."""
+    url = get_api_url(endpoint)
+    headers = get_headers()
+    params = _inject_team_id(params)
+
+    with httpx.Client(timeout=60.0) as client:
+        response = client.request(
+            method=method,
+            url=url,
+            headers=headers,
+            params=params,
+            json=json_data,
+        )
+
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"Vercel API error {response.status_code}: {response.text}"
+            )
+
+        return response.json()
+
+
+# =========================================================================
+# Read operations
+# =========================================================================
+
+
+def list_projects(limit: int = 20) -> list[dict[str, Any]]:
+    """List all projects.
+
+    Returns:
+        List of project objects.
+    """
+    result = api_request("GET", "/v9/projects", params={"limit": limit})
+    return result.get("projects", [])
+
+
+def get_project(project_id: str) -> dict[str, Any]:
+    """Get a single project by ID or name.
+
+    Args:
+        project_id: Project ID (prj_...) or project name.
+    """
+    return api_request("GET", f"/v9/projects/{project_id}")
+
+
+def list_deployments(
+    project_id: str | None = None,
+    state: str | None = None,
+    target: str | None = None,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """List deployments with optional filters.
+
+    Args:
+        project_id: Filter by project ID or name.
+        state: Filter by state (BUILDING, READY, ERROR, CANCELED, QUEUED).
+        target: Filter by target (production, preview).
+        limit: Maximum number of deployments to return.
+
+    Returns:
+        List of deployment objects.
+    """
+    params: dict[str, Any] = {"limit": limit}
+    if project_id:
+        params["projectId"] = project_id
+    if state:
+        params["state"] = state
+    if target:
+        params["target"] = target
+
+    result = api_request("GET", "/v6/deployments", params=params)
+    return result.get("deployments", [])
+
+
+def get_deployment(deployment_id: str) -> dict[str, Any]:
+    """Get a single deployment by ID or URL.
+
+    Args:
+        deployment_id: Deployment ID (dpl_...) or deployment URL.
+    """
+    return api_request("GET", f"/v13/deployments/{deployment_id}")
+
+
+def get_deployment_events(deployment_id: str, limit: int = 50) -> list[dict[str, Any]]:
+    """Get build log events for a deployment.
+
+    Args:
+        deployment_id: Deployment ID.
+        limit: Maximum number of events to return.
+
+    Returns:
+        List of deployment event objects (build log lines).
+    """
+    result = api_request(
+        "GET",
+        f"/v3/deployments/{deployment_id}/events",
+        params={"limit": limit},
+    )
+    # The events endpoint returns a list directly
+    if isinstance(result, list):
+        return result
+    return result.get("events", result.get("items", []))
+
+
+# =========================================================================
+# Write operations
+# =========================================================================
+
+
+def create_deployment(
+    name: str,
+    git_source: dict[str, Any],
+    target: str = "preview",
+) -> dict[str, Any]:
+    """Create a new deployment.
+
+    Args:
+        name: Project name.
+        git_source: Git source configuration, e.g.:
+            {
+                "type": "github",
+                "repo": "owner/repo",
+                "ref": "main"
+            }
+        target: Deployment target -- "production" or "preview".
+
+    Returns:
+        Created deployment object.
+    """
+    payload: dict[str, Any] = {
+        "name": name,
+        "target": target,
+        "gitSource": git_source,
+    }
+
+    return api_request("POST", "/v13/deployments", json_data=payload)
+
+
+# =========================================================================
+# Formatting helpers
+# =========================================================================
+
+
+def format_project(project: dict[str, Any]) -> str:
+    """Format project details for human-readable display."""
+    name = project.get("name", "unknown")
+    project_id = project.get("id", "")
+    framework = project.get("framework") or "unknown"
+    node_version = project.get("nodeVersion") or "default"
+
+    # Git repo link
+    repo_link = ""
+    link = project.get("link", {})
+    if link:
+        link_type = link.get("type", "")
+        org = link.get("org", link.get("owner", ""))
+        repo = link.get("repo", "")
+        if org and repo:
+            repo_link = f"{org}/{repo} ({link_type})"
+
+    # Domains
+    aliases = project.get("alias", [])
+    if isinstance(aliases, list):
+        domains = ", ".join(
+            a.get("domain", str(a)) if isinstance(a, dict) else str(a)
+            for a in aliases[:5]
+        )
+    else:
+        domains = ""
+
+    # Targets / latest deployments
+    targets = project.get("targets", {})
+    prod_url = ""
+    if targets and isinstance(targets, dict):
+        prod = targets.get("production", {})
+        if isinstance(prod, dict):
+            prod_url = prod.get("url", "")
+
+    lines = [
+        f"Project: {name} ({project_id})",
+        f"Framework: {framework} | Node: {node_version}",
+    ]
+    if repo_link:
+        lines.append(f"Git Repo: {repo_link}")
+    if domains:
+        lines.append(f"Domains: {domains}")
+    if prod_url:
+        lines.append(f"Production URL: https://{prod_url}")
+
+    return "\n".join(lines)
+
+
+def format_deployment(deployment: dict[str, Any]) -> str:
+    """Format deployment details for human-readable display."""
+    dep_id = deployment.get("uid", deployment.get("id", ""))
+    name = deployment.get("name", "")
+    state = deployment.get("state", deployment.get("readyState", "UNKNOWN"))
+    url = deployment.get("url", "")
+    target = deployment.get("target") or "preview"
+    created = deployment.get("createdAt", deployment.get("created", ""))
+
+    # Git metadata
+    meta = deployment.get("meta", {})
+    branch = meta.get("githubCommitRef", meta.get("gitlabCommitRef", ""))
+    commit_sha = meta.get("githubCommitSha", meta.get("gitlabCommitSha", ""))
+    commit_msg = meta.get("githubCommitMessage", meta.get("gitlabCommitMessage", ""))
+
+    # Error info
+    error_code = deployment.get("errorCode", "")
+    error_message = deployment.get("errorMessage", "")
+
+    # Build timestamps
+    building_at = deployment.get("buildingAt", "")
+    ready = deployment.get("ready", "")
+
+    lines = [
+        f"Deployment: {dep_id}",
+        f"Project: {name} | Target: {target} | State: {state}",
+    ]
+    if url:
+        lines.append(f"URL: https://{url}")
+    if branch:
+        lines.append(f"Branch: {branch}")
+    if commit_sha:
+        short_sha = commit_sha[:8] if len(commit_sha) > 8 else commit_sha
+        lines.append(
+            f"Commit: {short_sha} - {commit_msg}"
+            if commit_msg
+            else f"Commit: {short_sha}"
+        )
+    if created:
+        lines.append(f"Created: {_format_timestamp(created)}")
+    if building_at and ready:
+        lines.append(
+            f"Build: {_format_timestamp(building_at)} -> {_format_timestamp(ready)}"
+        )
+    if error_code:
+        lines.append(f"Error: [{error_code}] {error_message}")
+
+    return "\n".join(lines)
+
+
+def _format_timestamp(ts: Any) -> str:
+    """Format a Vercel timestamp (milliseconds since epoch or ISO string)."""
+    if isinstance(ts, (int, float)):
+        from datetime import datetime, timezone
+
+        dt = datetime.fromtimestamp(ts / 1000, tz=timezone.utc)
+        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+    return str(ts)

--- a/sre-agent/.claude/skills/project-clickup/SKILL.md
+++ b/sre-agent/.claude/skills/project-clickup/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: project-clickup
+description: ClickUp project management integration for incident tracking and task management
+allowed-tools:
+  - Bash(python *)
+---
+
+# ClickUp Project Management
+
+Query and manage tasks in ClickUp for incident tracking and project management.
+
+## Authentication
+
+This skill uses credentials managed by the credential-proxy service. In production, credentials are injected automatically via JWT authentication.
+
+For local development, set:
+- `CLICKUP_API_TOKEN` - Your ClickUp API token (Personal Access Token)
+- `CLICKUP_TEAM_ID` - Your workspace/team ID (optional, auto-detected if not set)
+
+## Available Scripts
+
+### list_spaces.py - Discover Workspace Structure
+
+List all spaces, folders, and lists in the workspace:
+
+```bash
+# List spaces
+python list_spaces.py
+
+# Include lists and folders
+python list_spaces.py --include-lists
+
+# JSON output
+python list_spaces.py --json
+```
+
+### search_tasks.py - Search for Tasks
+
+Search across all tasks in the workspace:
+
+```bash
+# Search by query
+python search_tasks.py --query "payment error"
+
+# Filter by status
+python search_tasks.py --query "incident" --status "investigating"
+
+# Recently updated
+python search_tasks.py --updated-since 24h
+
+# Combined filters
+python search_tasks.py --query "api" --status "open" --updated-since 7d --json
+```
+
+Options:
+- `--query, -q` - Search text (matches name and description)
+- `--status, -s` - Filter by status (can repeat for multiple)
+- `--assignee, -a` - Filter by assignee ID
+- `--list-id` - Filter by list ID
+- `--space-id` - Filter by space ID
+- `--updated-since` - Tasks updated since (e.g., "1h", "24h", "7d")
+- `--created-since` - Tasks created since
+- `--include-closed` - Include closed tasks
+- `--limit` - Maximum results (default: 50)
+- `--json` - Output as JSON
+
+### get_task.py - Get Task Details
+
+Retrieve full details for a specific task:
+
+```bash
+# Basic details
+python get_task.py abc123
+
+# Include comments
+python get_task.py abc123 --include-comments
+
+# Include subtasks
+python get_task.py abc123 --include-subtasks
+
+# Full details as JSON
+python get_task.py abc123 --include-comments --include-subtasks --json
+```
+
+Options:
+- `--include-comments, -c` - Include task comments
+- `--include-subtasks, -s` - Include subtasks
+- `--json` - Output as JSON
+
+### add_comment.py - Add Task Comment
+
+Add investigation findings to a task:
+
+```bash
+# Simple comment
+python add_comment.py abc123 --message "Found root cause in logs"
+
+# Markdown comment
+python add_comment.py abc123 -m "## Investigation Summary\n- Error in payment service\n- Caused by config change"
+```
+
+Options:
+- `--message, -m` - Comment text (supports markdown)
+- `--json` - Output as JSON
+
+## ClickUp Hierarchy
+
+Understanding ClickUp's structure helps with navigation:
+
+```
+Workspace (Team)
+└── Space
+    ├── Folder (optional)
+    │   └── List
+    │       └── Task
+    │           └── Subtask
+    └── List (folderless)
+        └── Task
+```
+
+## Investigation Workflow
+
+### 1. Discover Structure
+
+First, find where incidents are tracked:
+
+```bash
+python list_spaces.py --include-lists
+```
+
+Look for spaces/lists like "Incidents", "SRE", "On-Call", etc.
+
+### 2. Search for Related Incidents
+
+Search for incidents related to your investigation:
+
+```bash
+python search_tasks.py --query "payment" --status "investigating"
+```
+
+### 3. Get Incident Details
+
+Review the full incident context:
+
+```bash
+python get_task.py abc123 --include-comments
+```
+
+### 4. Document Findings
+
+Add your investigation findings:
+
+```bash
+python add_comment.py abc123 --message "Root cause: Database connection pool exhausted"
+```
+
+## Task Properties
+
+### Status
+Tasks have configurable statuses. Common incident statuses:
+- `to do` / `open` - New incident
+- `investigating` - Active investigation
+- `in progress` - Remediation underway
+- `resolved` / `complete` - Incident resolved
+- `closed` - Post-mortem complete
+
+### Priority
+- 1 = Urgent
+- 2 = High
+- 3 = Normal
+- 4 = Low
+
+### Custom Fields
+Teams often use custom fields for:
+- Severity (P0, P1, P2, etc.)
+- Affected services
+- Impact scope
+- Customer impact
+- Root cause category
+
+## Integration with Other Skills
+
+ClickUp integrates with the investigation workflow:
+
+1. **Start**: Check ClickUp for existing incident tickets
+2. **Investigate**: Use observability skills to find root cause
+3. **Document**: Add findings to ClickUp task as comments
+4. **Correlate**: Link with git log and curl $GITHUB_BASE_URL for change analysis
+
+## Tips
+
+- **Use task IDs** - Copy task IDs from ClickUp URLs (format: `abc123`)
+- **Search broadly first** - Start with general queries, then filter
+- **Check comments** - Previous investigation notes may have clues
+- **Document as you go** - Add comments with findings for team visibility

--- a/sre-agent/.claude/skills/project-clickup/scripts/__init__.py
+++ b/sre-agent/.claude/skills/project-clickup/scripts/__init__.py
@@ -1,0 +1,1 @@
+# ClickUp project management scripts for SRE Agent

--- a/sre-agent/.claude/skills/project-clickup/scripts/add_comment.py
+++ b/sre-agent/.claude/skills/project-clickup/scripts/add_comment.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Add a comment to a ClickUp task.
+
+Use this to document investigation findings on incident tasks.
+
+Usage:
+    python add_comment.py TASK_ID --message "Comment text"
+
+Examples:
+    python add_comment.py abc123 --message "Found root cause in logs"
+    python add_comment.py abc123 -m "Restarting service to mitigate"
+    python add_comment.py abc123 --message "## Investigation Summary\\n- Found error in API logs"
+"""
+
+import argparse
+import json
+import sys
+
+from clickup_client import create_task_comment
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Add comment to ClickUp task")
+    parser.add_argument("task_id", help="Task ID to comment on")
+    parser.add_argument(
+        "--message", "-m", required=True, help="Comment text (supports markdown)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Create comment
+        comment = create_task_comment(args.task_id, args.message)
+
+        if args.json:
+            print(json.dumps(comment, indent=2))
+        else:
+            print("Comment added successfully!")
+            print()
+            print(f"Task ID: {args.task_id}")
+            print(f"Comment ID: {comment.get('id', 'N/A')}")
+            print()
+            print("Comment text:")
+            print("-" * 40)
+            print(args.message)
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/project-clickup/scripts/clickup_client.py
+++ b/sre-agent/.claude/skills/project-clickup/scripts/clickup_client.py
@@ -1,0 +1,569 @@
+"""ClickUp API client for SRE Agent.
+
+Supports two authentication modes:
+1. Proxy mode (production): Routes through credential-resolver
+2. Direct mode (local dev): Uses CLICKUP_API_TOKEN environment variable
+
+Environment variables:
+    CREDENTIAL_PROXY_URL: Proxy URL for production (e.g., http://credential-resolver:8002)
+    CLICKUP_API_TOKEN: API token for direct mode
+    CLICKUP_TEAM_ID: Team/Workspace ID (required for most operations)
+"""
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+def get_config() -> dict[str, str | None]:
+    """Get ClickUp configuration from environment."""
+    return {
+        "proxy_url": os.environ.get("CREDENTIAL_PROXY_URL"),
+        "api_token": os.environ.get("CLICKUP_API_TOKEN"),
+        "team_id": os.environ.get("CLICKUP_TEAM_ID"),
+    }
+
+
+def get_api_url(path: str) -> str:
+    """Get the full API URL for a ClickUp endpoint.
+
+    In proxy mode, routes through credential-resolver.
+    In direct mode, uses ClickUp API directly.
+
+    Args:
+        path: API path (e.g., "team/{team_id}/space")
+
+    Returns:
+        Full URL for the API request
+    """
+    config = get_config()
+    proxy_url = config.get("proxy_url")
+
+    if proxy_url:
+        # Proxy mode: route through credential-resolver
+        base = proxy_url.rstrip("/")
+        return f"{base}/clickup/api/v2/{path.lstrip('/')}"
+    else:
+        # Direct mode: use ClickUp API directly
+        return f"https://api.clickup.com/api/v2/{path.lstrip('/')}"
+
+
+def get_headers() -> dict[str, str]:
+    """Get HTTP headers for ClickUp API requests.
+
+    In proxy mode, uses JWT for credential injection.
+    In direct mode, uses API token directly.
+
+    Returns:
+        Dictionary of HTTP headers
+    """
+    config = get_config()
+    headers = {
+        "Content-Type": "application/json",
+    }
+
+    # In direct mode, add Authorization header
+    if not config.get("proxy_url"):
+        api_token = config.get("api_token")
+        if not api_token:
+            raise ValueError(
+                "CLICKUP_API_TOKEN environment variable required in direct mode"
+            )
+        headers["Authorization"] = api_token
+
+    return headers
+
+
+def make_request(
+    path: str,
+    method: str = "GET",
+    data: dict | None = None,
+    params: dict | None = None,
+) -> dict[str, Any]:
+    """Make an HTTP request to the ClickUp API.
+
+    Args:
+        path: API path
+        method: HTTP method (GET, POST, PUT, DELETE)
+        data: Request body for POST/PUT
+        params: Query parameters
+
+    Returns:
+        JSON response as dictionary
+    """
+    url = get_api_url(path)
+
+    # Add query parameters
+    if params:
+        query_string = "&".join(f"{k}={v}" for k, v in params.items() if v is not None)
+        if query_string:
+            url = f"{url}?{query_string}"
+
+    headers = get_headers()
+
+    # Prepare request
+    body = None
+    if data:
+        body = json.dumps(data).encode("utf-8")
+
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as response:
+            response_data = response.read().decode("utf-8")
+            if response_data:
+                return json.loads(response_data)
+            return {}
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode("utf-8") if e.fp else ""
+        raise RuntimeError(f"ClickUp API error {e.code}: {error_body}") from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"ClickUp connection error: {e.reason}") from e
+
+
+def get_team_id() -> str:
+    """Get the team/workspace ID.
+
+    Returns:
+        Team ID from environment or first available team
+    """
+    config = get_config()
+    team_id = config.get("team_id")
+
+    if team_id:
+        return team_id
+
+    # Try to get from API
+    teams = list_teams()
+    if teams:
+        return teams[0]["id"]
+
+    raise ValueError(
+        "CLICKUP_TEAM_ID environment variable required or no teams accessible"
+    )
+
+
+def list_teams() -> list[dict[str, Any]]:
+    """List all teams/workspaces accessible to the user.
+
+    Returns:
+        List of team objects
+    """
+    response = make_request("team")
+    return response.get("teams", [])
+
+
+def list_spaces(team_id: str | None = None) -> list[dict[str, Any]]:
+    """List all spaces in a team.
+
+    Args:
+        team_id: Team ID (uses default if not provided)
+
+    Returns:
+        List of space objects
+    """
+    if not team_id:
+        team_id = get_team_id()
+
+    response = make_request(f"team/{team_id}/space")
+    return response.get("spaces", [])
+
+
+def list_folders(space_id: str) -> list[dict[str, Any]]:
+    """List all folders in a space.
+
+    Args:
+        space_id: Space ID
+
+    Returns:
+        List of folder objects
+    """
+    response = make_request(f"space/{space_id}/folder")
+    return response.get("folders", [])
+
+
+def list_lists(
+    space_id: str | None = None, folder_id: str | None = None
+) -> list[dict[str, Any]]:
+    """List all lists in a space or folder.
+
+    Args:
+        space_id: Space ID (for folderless lists)
+        folder_id: Folder ID
+
+    Returns:
+        List of list objects
+    """
+    if folder_id:
+        response = make_request(f"folder/{folder_id}/list")
+    elif space_id:
+        response = make_request(f"space/{space_id}/list")
+    else:
+        raise ValueError("Either space_id or folder_id required")
+
+    return response.get("lists", [])
+
+
+def get_task(task_id: str, include_subtasks: bool = False) -> dict[str, Any]:
+    """Get a task by ID.
+
+    Args:
+        task_id: Task ID
+        include_subtasks: Whether to include subtasks
+
+    Returns:
+        Task object
+    """
+    params = {}
+    if include_subtasks:
+        params["include_subtasks"] = "true"
+
+    return make_request(f"task/{task_id}", params=params)
+
+
+def get_tasks(
+    list_id: str,
+    archived: bool = False,
+    page: int = 0,
+    order_by: str | None = None,
+    reverse: bool = False,
+    subtasks: bool = False,
+    statuses: list[str] | None = None,
+    include_closed: bool = False,
+    assignees: list[str] | None = None,
+    due_date_gt: int | None = None,
+    due_date_lt: int | None = None,
+    date_created_gt: int | None = None,
+    date_created_lt: int | None = None,
+    date_updated_gt: int | None = None,
+    date_updated_lt: int | None = None,
+) -> list[dict[str, Any]]:
+    """Get tasks from a list.
+
+    Args:
+        list_id: List ID
+        archived: Include archived tasks
+        page: Page number (0-indexed)
+        order_by: Order field (id, created, updated, due_date)
+        reverse: Reverse sort order
+        subtasks: Include subtasks
+        statuses: Filter by status names
+        include_closed: Include closed tasks
+        assignees: Filter by assignee user IDs
+        due_date_gt: Due date greater than (Unix ms)
+        due_date_lt: Due date less than (Unix ms)
+        date_created_gt: Created date greater than (Unix ms)
+        date_created_lt: Created date less than (Unix ms)
+        date_updated_gt: Updated date greater than (Unix ms)
+        date_updated_lt: Updated date less than (Unix ms)
+
+    Returns:
+        List of task objects
+    """
+    params = {
+        "archived": str(archived).lower(),
+        "page": str(page),
+        "subtasks": str(subtasks).lower(),
+        "include_closed": str(include_closed).lower(),
+    }
+
+    if order_by:
+        params["order_by"] = order_by
+    if reverse:
+        params["reverse"] = "true"
+    if statuses:
+        params["statuses[]"] = ",".join(statuses)
+    if assignees:
+        params["assignees[]"] = ",".join(assignees)
+    if due_date_gt:
+        params["due_date_gt"] = str(due_date_gt)
+    if due_date_lt:
+        params["due_date_lt"] = str(due_date_lt)
+    if date_created_gt:
+        params["date_created_gt"] = str(date_created_gt)
+    if date_created_lt:
+        params["date_created_lt"] = str(date_created_lt)
+    if date_updated_gt:
+        params["date_updated_gt"] = str(date_updated_gt)
+    if date_updated_lt:
+        params["date_updated_lt"] = str(date_updated_lt)
+
+    response = make_request(f"list/{list_id}/task", params=params)
+    return response.get("tasks", [])
+
+
+def search_tasks(
+    team_id: str | None = None,
+    query: str | None = None,
+    statuses: list[str] | None = None,
+    include_closed: bool = True,
+    assignees: list[str] | None = None,
+    list_ids: list[str] | None = None,
+    space_ids: list[str] | None = None,
+    folder_ids: list[str] | None = None,
+    date_created_gt: int | None = None,
+    date_created_lt: int | None = None,
+    date_updated_gt: int | None = None,
+    date_updated_lt: int | None = None,
+    order_by: str | None = None,
+    reverse: bool = False,
+    page: int = 0,
+) -> list[dict[str, Any]]:
+    """Search for tasks across the team.
+
+    Args:
+        team_id: Team ID (uses default if not provided)
+        query: Search query string
+        statuses: Filter by status names
+        include_closed: Include closed tasks
+        assignees: Filter by assignee user IDs
+        list_ids: Filter by list IDs
+        space_ids: Filter by space IDs
+        folder_ids: Filter by folder IDs
+        date_created_gt: Created after (Unix ms)
+        date_created_lt: Created before (Unix ms)
+        date_updated_gt: Updated after (Unix ms)
+        date_updated_lt: Updated before (Unix ms)
+        order_by: Sort field
+        reverse: Reverse sort order
+        page: Page number
+
+    Returns:
+        List of task objects
+    """
+    if not team_id:
+        team_id = get_team_id()
+
+    params = {
+        "page": str(page),
+        "include_closed": str(include_closed).lower(),
+    }
+
+    if query:
+        # Note: ClickUp uses a filtered team tasks endpoint
+        # The search is done via custom_task_ids or through filtering
+        pass  # Query filtering happens client-side or via specific endpoints
+
+    if statuses:
+        for status in statuses:
+            params["statuses[]"] = status
+    if assignees:
+        for assignee in assignees:
+            params["assignees[]"] = assignee
+    if list_ids:
+        for list_id in list_ids:
+            params["list_ids[]"] = list_id
+    if space_ids:
+        for space_id in space_ids:
+            params["space_ids[]"] = space_id
+    if folder_ids:
+        for folder_id in folder_ids:
+            params["folder_ids[]"] = folder_id
+    if date_created_gt:
+        params["date_created_gt"] = str(date_created_gt)
+    if date_created_lt:
+        params["date_created_lt"] = str(date_created_lt)
+    if date_updated_gt:
+        params["date_updated_gt"] = str(date_updated_gt)
+    if date_updated_lt:
+        params["date_updated_lt"] = str(date_updated_lt)
+    if order_by:
+        params["order_by"] = order_by
+    if reverse:
+        params["reverse"] = "true"
+
+    response = make_request(f"team/{team_id}/task", params=params)
+    tasks = response.get("tasks", [])
+
+    # Client-side query filtering if provided
+    if query:
+        query_lower = query.lower()
+        tasks = [
+            t
+            for t in tasks
+            if query_lower in t.get("name", "").lower()
+            or query_lower in (t.get("description") or "").lower()
+        ]
+
+    return tasks
+
+
+def get_task_comments(task_id: str) -> list[dict[str, Any]]:
+    """Get comments on a task.
+
+    Args:
+        task_id: Task ID
+
+    Returns:
+        List of comment objects
+    """
+    response = make_request(f"task/{task_id}/comment")
+    return response.get("comments", [])
+
+
+def create_task_comment(task_id: str, comment_text: str) -> dict[str, Any]:
+    """Create a comment on a task.
+
+    Args:
+        task_id: Task ID
+        comment_text: Comment text (supports markdown)
+
+    Returns:
+        Created comment object
+    """
+    data = {"comment_text": comment_text}
+    return make_request(f"task/{task_id}/comment", method="POST", data=data)
+
+
+def create_task(
+    list_id: str,
+    name: str,
+    description: str | None = None,
+    status: str | None = None,
+    priority: int | None = None,
+    assignees: list[str] | None = None,
+    tags: list[str] | None = None,
+    due_date: int | None = None,
+    custom_fields: list[dict] | None = None,
+) -> dict[str, Any]:
+    """Create a new task.
+
+    Args:
+        list_id: List ID to create task in
+        name: Task name
+        description: Task description (markdown)
+        status: Status name
+        priority: Priority (1=urgent, 2=high, 3=normal, 4=low)
+        assignees: List of assignee user IDs
+        tags: List of tag names
+        due_date: Due date (Unix ms)
+        custom_fields: List of custom field values
+
+    Returns:
+        Created task object
+    """
+    data = {"name": name}
+
+    if description:
+        data["description"] = description
+    if status:
+        data["status"] = status
+    if priority:
+        data["priority"] = priority
+    if assignees:
+        data["assignees"] = assignees
+    if tags:
+        data["tags"] = tags
+    if due_date:
+        data["due_date"] = due_date
+    if custom_fields:
+        data["custom_fields"] = custom_fields
+
+    return make_request(f"list/{list_id}/task", method="POST", data=data)
+
+
+def update_task(
+    task_id: str,
+    name: str | None = None,
+    description: str | None = None,
+    status: str | None = None,
+    priority: int | None = None,
+    assignees: dict | None = None,
+    due_date: int | None = None,
+) -> dict[str, Any]:
+    """Update a task.
+
+    Args:
+        task_id: Task ID
+        name: New task name
+        description: New description
+        status: New status name
+        priority: New priority
+        assignees: Assignee changes {"add": [...], "rem": [...]}
+        due_date: New due date (Unix ms)
+
+    Returns:
+        Updated task object
+    """
+    data = {}
+
+    if name:
+        data["name"] = name
+    if description:
+        data["description"] = description
+    if status:
+        data["status"] = status
+    if priority:
+        data["priority"] = priority
+    if assignees:
+        data["assignees"] = assignees
+    if due_date:
+        data["due_date"] = due_date
+
+    return make_request(f"task/{task_id}", method="PUT", data=data)
+
+
+def format_task(task: dict[str, Any], verbose: bool = False) -> str:
+    """Format a task for display.
+
+    Args:
+        task: Task object
+        verbose: Include full details
+
+    Returns:
+        Formatted string
+    """
+    lines = []
+
+    name = task.get("name", "Untitled")
+    task_id = task.get("id", "")
+    status = task.get("status", {}).get("status", "Unknown")
+    priority = task.get("priority")
+
+    priority_str = ""
+    if priority:
+        priority_map = {1: "URGENT", 2: "HIGH", 3: "NORMAL", 4: "LOW"}
+        priority_str = f" [{priority_map.get(priority.get('id'), 'NORMAL')}]"
+
+    lines.append(f"{name}{priority_str}")
+    lines.append(f"  ID: {task_id}")
+    lines.append(f"  Status: {status}")
+
+    if verbose:
+        # Assignees
+        assignees = task.get("assignees", [])
+        if assignees:
+            names = [a.get("username", a.get("email", "Unknown")) for a in assignees]
+            lines.append(f"  Assignees: {', '.join(names)}")
+
+        # Due date
+        due_date = task.get("due_date")
+        if due_date:
+            from datetime import datetime
+
+            dt = datetime.fromtimestamp(int(due_date) / 1000)
+            lines.append(f"  Due: {dt.strftime('%Y-%m-%d %H:%M')}")
+
+        # Description
+        description = task.get("description")
+        if description:
+            # Truncate long descriptions
+            desc_preview = (
+                description[:200] + "..." if len(description) > 200 else description
+            )
+            lines.append(f"  Description: {desc_preview}")
+
+        # Tags
+        tags = task.get("tags", [])
+        if tags:
+            tag_names = [t.get("name", "") for t in tags]
+            lines.append(f"  Tags: {', '.join(tag_names)}")
+
+        # URL
+        url = task.get("url")
+        if url:
+            lines.append(f"  URL: {url}")
+
+    return "\n".join(lines)

--- a/sre-agent/.claude/skills/project-clickup/scripts/get_task.py
+++ b/sre-agent/.claude/skills/project-clickup/scripts/get_task.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Get detailed information about a ClickUp task.
+
+Use this to view full task details including description, comments, and subtasks.
+
+Usage:
+    python get_task.py TASK_ID [options]
+
+Examples:
+    python get_task.py abc123
+    python get_task.py abc123 --include-comments
+    python get_task.py abc123 --include-subtasks --json
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+
+from clickup_client import get_task, get_task_comments
+
+
+def format_comment(comment: dict) -> str:
+    """Format a comment for display."""
+    user = comment.get("user", {})
+    username = user.get("username", user.get("email", "Unknown"))
+    date = comment.get("date")
+    text = comment.get("comment_text", "")
+
+    date_str = ""
+    if date:
+        dt = datetime.fromtimestamp(int(date) / 1000)
+        date_str = dt.strftime("%Y-%m-%d %H:%M")
+
+    return f"  [{date_str}] {username}:\n    {text}"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get ClickUp task details")
+    parser.add_argument("task_id", help="Task ID to retrieve")
+    parser.add_argument(
+        "--include-comments", "-c", action="store_true", help="Include task comments"
+    )
+    parser.add_argument(
+        "--include-subtasks", "-s", action="store_true", help="Include subtasks"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Get task
+        task = get_task(args.task_id, include_subtasks=args.include_subtasks)
+
+        # Get comments if requested
+        comments = []
+        if args.include_comments:
+            comments = get_task_comments(args.task_id)
+
+        if args.json:
+            result = {"task": task}
+            if args.include_comments:
+                result["comments"] = comments
+            print(json.dumps(result, indent=2))
+        else:
+            print("=" * 60)
+            print("CLICKUP TASK DETAILS")
+            print("=" * 60)
+            print()
+
+            # Basic info
+            print(f"Name: {task.get('name', 'Untitled')}")
+            print(f"ID: {task.get('id', '')}")
+            print(f"URL: {task.get('url', '')}")
+            print()
+
+            # Status and priority
+            status = task.get("status", {}).get("status", "Unknown")
+            print(f"Status: {status}")
+
+            priority = task.get("priority")
+            if priority:
+                priority_map = {1: "Urgent", 2: "High", 3: "Normal", 4: "Low"}
+                print(f"Priority: {priority_map.get(priority.get('id'), 'Normal')}")
+
+            # Assignees
+            assignees = task.get("assignees", [])
+            if assignees:
+                names = [
+                    a.get("username", a.get("email", "Unknown")) for a in assignees
+                ]
+                print(f"Assignees: {', '.join(names)}")
+
+            # Dates
+            created = task.get("date_created")
+            if created:
+                dt = datetime.fromtimestamp(int(created) / 1000)
+                print(f"Created: {dt.strftime('%Y-%m-%d %H:%M')}")
+
+            updated = task.get("date_updated")
+            if updated:
+                dt = datetime.fromtimestamp(int(updated) / 1000)
+                print(f"Updated: {dt.strftime('%Y-%m-%d %H:%M')}")
+
+            due_date = task.get("due_date")
+            if due_date:
+                dt = datetime.fromtimestamp(int(due_date) / 1000)
+                print(f"Due: {dt.strftime('%Y-%m-%d %H:%M')}")
+
+            # Tags
+            tags = task.get("tags", [])
+            if tags:
+                tag_names = [t.get("name", "") for t in tags]
+                print(f"Tags: {', '.join(tag_names)}")
+
+            # Custom fields
+            custom_fields = task.get("custom_fields", [])
+            if custom_fields:
+                print()
+                print("Custom Fields:")
+                for cf in custom_fields:
+                    name = cf.get("name", "")
+                    value = cf.get("value")
+                    if value is not None:
+                        print(f"  {name}: {value}")
+
+            # Description
+            description = task.get("description")
+            if description:
+                print()
+                print("Description:")
+                print("-" * 40)
+                print(description)
+
+            # Subtasks
+            subtasks = task.get("subtasks", [])
+            if subtasks:
+                print()
+                print(f"Subtasks ({len(subtasks)}):")
+                print("-" * 40)
+                for st in subtasks:
+                    st_status = st.get("status", {}).get("status", "?")
+                    print(
+                        f"  [{st_status}] {st.get('name', 'Untitled')} ({st.get('id')})"
+                    )
+
+            # Comments
+            if args.include_comments:
+                print()
+                print(f"Comments ({len(comments)}):")
+                print("-" * 40)
+                if not comments:
+                    print("  No comments.")
+                else:
+                    for comment in comments:
+                        print()
+                        print(format_comment(comment))
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/project-clickup/scripts/list_spaces.py
+++ b/sre-agent/.claude/skills/project-clickup/scripts/list_spaces.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""List ClickUp spaces and their structure.
+
+Use this to discover available spaces, folders, and lists for task queries.
+
+Usage:
+    python list_spaces.py [--json]
+
+Examples:
+    python list_spaces.py
+    python list_spaces.py --json
+    python list_spaces.py --include-lists
+"""
+
+import argparse
+import json
+import sys
+
+from clickup_client import list_folders, list_lists, list_spaces, list_teams
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List ClickUp spaces and structure")
+    parser.add_argument(
+        "--include-lists", "-l", action="store_true", help="Include lists in output"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Get teams
+        teams = list_teams()
+
+        if not teams:
+            print("No teams/workspaces found.", file=sys.stderr)
+            sys.exit(1)
+
+        result = []
+
+        for team in teams:
+            team_data = {
+                "id": team.get("id"),
+                "name": team.get("name"),
+                "spaces": [],
+            }
+
+            # Get spaces for this team
+            spaces = list_spaces(team.get("id"))
+
+            for space in spaces:
+                space_data = {
+                    "id": space.get("id"),
+                    "name": space.get("name"),
+                    "private": space.get("private", False),
+                }
+
+                if args.include_lists:
+                    space_data["folders"] = []
+                    space_data["lists"] = []
+
+                    # Get folders
+                    folders = list_folders(space.get("id"))
+                    for folder in folders:
+                        folder_data = {
+                            "id": folder.get("id"),
+                            "name": folder.get("name"),
+                            "lists": [],
+                        }
+
+                        # Get lists in folder
+                        folder_lists = list_lists(folder_id=folder.get("id"))
+                        for lst in folder_lists:
+                            folder_data["lists"].append(
+                                {
+                                    "id": lst.get("id"),
+                                    "name": lst.get("name"),
+                                    "task_count": lst.get("task_count"),
+                                }
+                            )
+
+                        space_data["folders"].append(folder_data)
+
+                    # Get folderless lists
+                    folderless_lists = list_lists(space_id=space.get("id"))
+                    for lst in folderless_lists:
+                        space_data["lists"].append(
+                            {
+                                "id": lst.get("id"),
+                                "name": lst.get("name"),
+                                "task_count": lst.get("task_count"),
+                            }
+                        )
+
+                team_data["spaces"].append(space_data)
+
+            result.append(team_data)
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print("=" * 60)
+            print("CLICKUP WORKSPACE STRUCTURE")
+            print("=" * 60)
+            print()
+
+            for team in result:
+                print(f"Team: {team['name']} (ID: {team['id']})")
+                print("-" * 40)
+
+                if not team["spaces"]:
+                    print("  No spaces found.")
+                else:
+                    for space in team["spaces"]:
+                        private = " [Private]" if space.get("private") else ""
+                        print(f"  Space: {space['name']}{private}")
+                        print(f"    ID: {space['id']}")
+
+                        if args.include_lists:
+                            # Folders
+                            for folder in space.get("folders", []):
+                                print(
+                                    f"    Folder: {folder['name']} (ID: {folder['id']})"
+                                )
+                                for lst in folder.get("lists", []):
+                                    count = lst.get("task_count", "?")
+                                    print(f"      List: {lst['name']} ({count} tasks)")
+                                    print(f"        ID: {lst['id']}")
+
+                            # Folderless lists
+                            for lst in space.get("lists", []):
+                                count = lst.get("task_count", "?")
+                                print(f"    List: {lst['name']} ({count} tasks)")
+                                print(f"      ID: {lst['id']}")
+
+                        print()
+
+                print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/project-clickup/scripts/search_tasks.py
+++ b/sre-agent/.claude/skills/project-clickup/scripts/search_tasks.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Search for tasks in ClickUp.
+
+Use this to find tasks by name, description, or other criteria.
+
+Usage:
+    python search_tasks.py [--query QUERY] [--status STATUS] [options]
+
+Examples:
+    python search_tasks.py --query "payment"
+    python search_tasks.py --query "incident" --status "investigating"
+    python search_tasks.py --updated-since 24h --json
+"""
+
+import argparse
+import json
+import sys
+import time
+
+from clickup_client import format_task, search_tasks
+
+
+def parse_time_range(time_str: str) -> int:
+    """Parse time range string to Unix milliseconds.
+
+    Args:
+        time_str: Time string like "1h", "24h", "7d"
+
+    Returns:
+        Unix timestamp in milliseconds
+    """
+    now = int(time.time() * 1000)
+
+    if time_str.endswith("h"):
+        hours = int(time_str[:-1])
+        return now - (hours * 60 * 60 * 1000)
+    elif time_str.endswith("d"):
+        days = int(time_str[:-1])
+        return now - (days * 24 * 60 * 60 * 1000)
+    elif time_str.endswith("m"):
+        minutes = int(time_str[:-1])
+        return now - (minutes * 60 * 1000)
+    else:
+        raise ValueError(f"Invalid time format: {time_str}. Use 1h, 24h, 7d, etc.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search ClickUp tasks")
+    parser.add_argument(
+        "--query", "-q", help="Search query (matches name and description)"
+    )
+    parser.add_argument(
+        "--status", "-s", action="append", help="Filter by status (can repeat)"
+    )
+    parser.add_argument(
+        "--assignee", "-a", action="append", help="Filter by assignee ID (can repeat)"
+    )
+    parser.add_argument(
+        "--list-id", action="append", help="Filter by list ID (can repeat)"
+    )
+    parser.add_argument(
+        "--space-id", action="append", help="Filter by space ID (can repeat)"
+    )
+    parser.add_argument(
+        "--updated-since",
+        help="Only tasks updated since (e.g., '1h', '24h', '7d')",
+    )
+    parser.add_argument(
+        "--created-since",
+        help="Only tasks created since (e.g., '1h', '24h', '7d')",
+    )
+    parser.add_argument(
+        "--include-closed", action="store_true", help="Include closed tasks"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=50, help="Maximum results (default: 50)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        # Build search parameters
+        params = {
+            "include_closed": args.include_closed,
+        }
+
+        if args.query:
+            params["query"] = args.query
+        if args.status:
+            params["statuses"] = args.status
+        if args.assignee:
+            params["assignees"] = args.assignee
+        if args.list_id:
+            params["list_ids"] = args.list_id
+        if args.space_id:
+            params["space_ids"] = args.space_id
+        if args.updated_since:
+            params["date_updated_gt"] = parse_time_range(args.updated_since)
+        if args.created_since:
+            params["date_created_gt"] = parse_time_range(args.created_since)
+
+        # Search
+        tasks = search_tasks(**params)
+
+        # Limit results
+        tasks = tasks[: args.limit]
+
+        if args.json:
+            print(json.dumps(tasks, indent=2))
+        else:
+            print("=" * 60)
+            print("CLICKUP TASK SEARCH")
+            print("=" * 60)
+            print()
+
+            if args.query:
+                print(f"Query: {args.query}")
+            if args.status:
+                print(f"Status filter: {', '.join(args.status)}")
+            if args.updated_since:
+                print(f"Updated since: {args.updated_since}")
+            print()
+
+            if not tasks:
+                print("No tasks found matching criteria.")
+            else:
+                print(f"Found {len(tasks)} task(s):")
+                print("-" * 40)
+
+                for task in tasks:
+                    print()
+                    print(format_task(task, verbose=True))
+                    print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/project-jira/SKILL.md
+++ b/sre-agent/.claude/skills/project-jira/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: project-jira
+description: Jira issue tracking and incident management. Use when creating, searching, or updating Jira issues. Supports JQL queries for incident ticket analysis and alert fatigue tracking.
+allowed-tools: Bash(python *)
+---
+
+# Jira Integration
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `JIRA_API_TOKEN` or `JIRA_EMAIL` in environment variables - they won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `JIRA_URL` - Jira instance URL (e.g., `https://your-company.atlassian.net`)
+
+---
+
+## Available Scripts
+
+All scripts are in `.claude/skills/project-jira/scripts/`
+
+### search_issues.py - Search with JQL
+Powerful search using Jira Query Language. Best for finding incident tickets, patterns, action items.
+```bash
+python .claude/skills/project-jira/scripts/search_issues.py --jql "JQL_QUERY" [--max-results N]
+
+# Examples:
+python .claude/skills/project-jira/scripts/search_issues.py --jql "type = Bug AND status != Done AND created >= -7d"
+python .claude/skills/project-jira/scripts/search_issues.py --jql "labels = incident AND created >= -30d" --max-results 50
+```
+
+### get_issue.py - Get Issue Details
+```bash
+python .claude/skills/project-jira/scripts/get_issue.py --issue-key PROJ-123
+```
+
+### create_issue.py - Create New Issue
+```bash
+python .claude/skills/project-jira/scripts/create_issue.py --project PROJ --summary "Title" --description "Details" [--type Bug] [--priority High] [--labels "incident,p1"]
+```
+
+### update_issue.py - Update Existing Issue
+```bash
+python .claude/skills/project-jira/scripts/update_issue.py --issue-key PROJ-123 [--summary "New title"] [--status "In Progress"] [--priority High]
+```
+
+### add_comment.py - Add Comment
+```bash
+python .claude/skills/project-jira/scripts/add_comment.py --issue-key PROJ-123 --comment "Investigation findings..."
+```
+
+### list_issues.py - List Project Issues
+```bash
+python .claude/skills/project-jira/scripts/list_issues.py --project PROJ [--max-results 20]
+```
+
+---
+
+## JQL Quick Reference
+
+### Common Patterns
+```
+# Recent bugs
+type = Bug AND created >= -7d ORDER BY created DESC
+
+# Open incidents
+type = Incident AND status != Done
+
+# By label
+labels IN ("incident", "p1", "alert-tuning")
+
+# Text search
+summary ~ "high CPU" OR description ~ "timeout"
+
+# Stale issues
+updated <= -90d AND status != Done
+```
+
+### Operators
+| Operator | Meaning | Example |
+|----------|---------|---------|
+| = | Equals | `status = Done` |
+| != | Not equals | `status != Done` |
+| ~ | Contains text | `summary ~ "error"` |
+| IN | In list | `status IN ("Open", "In Progress")` |
+| >= | Greater/equal | `created >= -7d` |
+| ORDER BY | Sort | `ORDER BY created DESC` |
+
+---
+
+## Investigation Workflow
+
+### Incident Ticket Analysis
+```
+1. Search for related incidents:
+   search_issues.py --jql "type = Incident AND created >= -30d"
+
+2. Get details of specific incident:
+   get_issue.py --issue-key INC-456
+
+3. Add investigation findings:
+   add_comment.py --issue-key INC-456 --comment "Root cause: ..."
+
+4. Update status:
+   update_issue.py --issue-key INC-456 --status "Resolved"
+```

--- a/sre-agent/.claude/skills/project-jira/scripts/add_comment.py
+++ b/sre-agent/.claude/skills/project-jira/scripts/add_comment.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Add a comment to a Jira issue.
+
+Usage:
+    python add_comment.py --issue-key PROJ-123 --comment "Investigation findings..."
+"""
+
+import argparse
+import json
+import sys
+
+from jira_client import jira_request, make_adf_text
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Add comment to a Jira issue")
+    parser.add_argument("--issue-key", required=True, help="Issue key (e.g., PROJ-123)")
+    parser.add_argument("--comment", required=True, help="Comment text")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        data = jira_request(
+            "POST",
+            f"/issue/{args.issue_key}/comment",
+            json_body={"body": make_adf_text(args.comment)},
+        )
+        author = data.get("author", {})
+        result = {
+            "ok": True,
+            "id": data.get("id"),
+            "issue_key": args.issue_key,
+            "author": author.get("displayName"),
+            "created": data.get("created"),
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Comment added to {args.issue_key}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/project-jira/scripts/create_issue.py
+++ b/sre-agent/.claude/skills/project-jira/scripts/create_issue.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Create a new Jira issue.
+
+Usage:
+    python create_issue.py --project PROJ --summary "Title" --description "Details"
+    python create_issue.py --project PROJ --summary "Bug" --type Bug --priority High --labels "incident,p1"
+"""
+
+import argparse
+import json
+import sys
+
+from jira_client import get_browse_url, jira_request, make_adf_text
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create a new Jira issue")
+    parser.add_argument("--project", required=True, help="Project key (e.g., PROJ)")
+    parser.add_argument("--summary", required=True, help="Issue summary/title")
+    parser.add_argument("--description", default="", help="Issue description")
+    parser.add_argument(
+        "--type", default="Task", help="Issue type (Task, Bug, Story, Epic)"
+    )
+    parser.add_argument("--priority", default="", help="Priority (High, Medium, Low)")
+    parser.add_argument("--labels", default="", help="Comma-separated labels")
+    parser.add_argument("--assignee", default="", help="Assignee account ID")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        fields = {
+            "project": {"key": args.project},
+            "summary": args.summary,
+            "issuetype": {"name": args.type},
+        }
+        if args.description:
+            fields["description"] = make_adf_text(args.description)
+        if args.priority:
+            fields["priority"] = {"name": args.priority}
+        if args.labels:
+            fields["labels"] = [l.strip() for l in args.labels.split(",")]
+
+        data = jira_request("POST", "/issue", json_body={"fields": fields})
+        issue_key = data["key"]
+
+        if args.assignee:
+            try:
+                jira_request(
+                    "PUT",
+                    f"/issue/{issue_key}/assignee",
+                    json_body={"accountId": args.assignee},
+                )
+            except Exception:
+                pass
+
+        browse_url = get_browse_url()
+        result = {
+            "ok": True,
+            "key": issue_key,
+            "id": data.get("id"),
+            "summary": args.summary,
+            "type": args.type,
+        }
+        if browse_url:
+            result["url"] = f"{browse_url}/browse/{issue_key}"
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Created: {issue_key} - {args.summary}")
+            if result.get("url"):
+                print(f"URL: {result['url']}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/project-jira/scripts/get_issue.py
+++ b/sre-agent/.claude/skills/project-jira/scripts/get_issue.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Get details of a specific Jira issue.
+
+Usage:
+    python get_issue.py --issue-key PROJ-123
+"""
+
+import argparse
+import json
+import sys
+
+from jira_client import extract_adf_text, get_browse_url, jira_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Jira issue details")
+    parser.add_argument("--issue-key", required=True, help="Issue key (e.g., PROJ-123)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        data = jira_request("GET", f"/issue/{args.issue_key}")
+        fields = data.get("fields", {})
+        browse_url = get_browse_url()
+        desc = extract_adf_text(fields.get("description"))
+
+        result = {
+            "ok": True,
+            "key": data["key"],
+            "id": data["id"],
+            "summary": fields.get("summary"),
+            "description": desc,
+            "status": (
+                fields.get("status", {}).get("name") if fields.get("status") else None
+            ),
+            "type": (
+                fields.get("issuetype", {}).get("name")
+                if fields.get("issuetype")
+                else None
+            ),
+            "priority": (
+                fields.get("priority", {}).get("name")
+                if fields.get("priority")
+                else None
+            ),
+            "assignee": (
+                fields.get("assignee", {}).get("displayName")
+                if fields.get("assignee")
+                else None
+            ),
+            "reporter": (
+                fields.get("reporter", {}).get("displayName")
+                if fields.get("reporter")
+                else None
+            ),
+            "created": fields.get("created"),
+            "updated": fields.get("updated"),
+            "labels": fields.get("labels", []),
+        }
+        if browse_url:
+            result["url"] = f"{browse_url}/browse/{data['key']}"
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Issue: {result['key']} - {result.get('summary', '')}")
+            if result.get("url"):
+                print(f"URL: {result['url']}")
+            print(
+                f"Status: {result.get('status', '?')} | Type: {result.get('type', '?')} | Priority: {result.get('priority', '?')}"
+            )
+            print(
+                f"Assignee: {result.get('assignee', 'Unassigned')} | Reporter: {result.get('reporter', '?')}"
+            )
+            if result.get("labels"):
+                print(f"Labels: {', '.join(result['labels'])}")
+            if desc:
+                print(f"\nDescription:\n{desc}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/project-jira/scripts/jira_client.py
+++ b/sre-agent/.claude/skills/project-jira/scripts/jira_client.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Shared Jira API client with proxy support.
+
+Uses Jira Cloud REST API v3 (Atlassian Document Format for descriptions).
+Credentials are injected transparently by the proxy layer.
+"""
+
+import base64
+import os
+from typing import Any
+
+import httpx
+
+
+def get_config() -> dict[str, str | None]:
+    """Get Jira configuration from environment."""
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+        "jira_url": os.getenv("JIRA_URL", ""),
+    }
+
+
+def get_base_url() -> str:
+    """Get Jira REST API base URL.
+
+    Supports two modes:
+    1. Proxy mode (production): Uses JIRA_BASE_URL
+    2. Direct mode (testing): Uses JIRA_URL + /rest/api/3
+    """
+    proxy_url = os.getenv("JIRA_BASE_URL")
+    if proxy_url:
+        return proxy_url.rstrip("/")
+
+    jira_url = os.getenv("JIRA_URL")
+    if jira_url:
+        return f"{jira_url.rstrip('/')}/rest/api/3"
+
+    raise RuntimeError(
+        "Either JIRA_BASE_URL (proxy mode) or JIRA_URL (direct mode) must be set."
+    )
+
+
+def get_headers() -> dict[str, str]:
+    """Get Jira API headers.
+
+    In proxy mode: includes tenant context for credential lookup.
+    In direct mode: includes Basic auth with email + API token.
+    """
+    config = get_config()
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    email = os.getenv("JIRA_EMAIL")
+    api_token = os.getenv("JIRA_API_TOKEN")
+    if email and api_token:
+        credentials = base64.b64encode(f"{email}:{api_token}".encode()).decode()
+        headers["Authorization"] = f"Basic {credentials}"
+    else:
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+            headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    return headers
+
+
+def get_browse_url() -> str | None:
+    """Get the Jira browse URL for constructing issue links."""
+    if os.getenv("JIRA_BASE_URL"):
+        return None
+    jira_url = os.getenv("JIRA_URL", "")
+    return jira_url.rstrip("/") if jira_url else None
+
+
+def jira_request(
+    method: str,
+    path: str,
+    params: dict | None = None,
+    json_body: dict | None = None,
+) -> dict | list | None:
+    """Make a request to Jira REST API."""
+    base_url = get_base_url()
+    url = f"{base_url}/{path.lstrip('/')}"
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.request(
+            method,
+            url,
+            headers=get_headers(),
+            params=params,
+            json=json_body,
+        )
+        response.raise_for_status()
+        if response.status_code == 204:
+            return None
+        return response.json()
+
+
+def make_adf_text(text: str) -> dict:
+    """Create Atlassian Document Format (ADF) for a text block."""
+    return {
+        "type": "doc",
+        "version": 1,
+        "content": [{"type": "paragraph", "content": [{"type": "text", "text": text}]}],
+    }
+
+
+def extract_adf_text(adf: Any) -> str:
+    """Extract plain text from Atlassian Document Format."""
+    if isinstance(adf, str):
+        return adf
+    if not isinstance(adf, dict):
+        return ""
+    parts = []
+    for block in adf.get("content", []):
+        for inline in block.get("content", []):
+            if inline.get("type") == "text":
+                parts.append(inline.get("text", ""))
+        parts.append("\n")
+    return "\n".join(parts).strip()

--- a/sre-agent/.claude/skills/project-jira/scripts/list_issues.py
+++ b/sre-agent/.claude/skills/project-jira/scripts/list_issues.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""List recent issues in a Jira project.
+
+Usage:
+    python list_issues.py --project PROJ
+    python list_issues.py --project PROJ --max-results 30
+"""
+
+import argparse
+import json
+import sys
+
+from jira_client import get_browse_url, jira_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List issues in a Jira project")
+    parser.add_argument("--project", required=True, help="Project key (e.g., PROJ)")
+    parser.add_argument(
+        "--max-results", type=int, default=20, help="Maximum results (default: 20)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        jql = f"project = {args.project} ORDER BY created DESC"
+        data = jira_request(
+            "GET",
+            "/search",
+            params={
+                "jql": jql,
+                "maxResults": args.max_results,
+                "fields": "summary,status,issuetype,assignee,created",
+            },
+        )
+
+        browse_url = get_browse_url()
+        issues = []
+        for item in data.get("issues", []):
+            fields = item.get("fields", {})
+            issue = {
+                "key": item["key"],
+                "summary": fields.get("summary"),
+                "status": (
+                    fields.get("status", {}).get("name")
+                    if fields.get("status")
+                    else None
+                ),
+                "type": (
+                    fields.get("issuetype", {}).get("name")
+                    if fields.get("issuetype")
+                    else None
+                ),
+                "assignee": (
+                    fields.get("assignee", {}).get("displayName")
+                    if fields.get("assignee")
+                    else None
+                ),
+                "created": fields.get("created"),
+            }
+            if browse_url:
+                issue["url"] = f"{browse_url}/browse/{item['key']}"
+            issues.append(issue)
+
+        result = {
+            "ok": True,
+            "project": args.project,
+            "issues": issues,
+            "count": len(issues),
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Project: {args.project} ({len(issues)} issues)")
+            for issue in issues:
+                print(
+                    f"  [{issue.get('status', '?')}] {issue['key']} - {issue.get('summary', '')}"
+                )
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/project-jira/scripts/search_issues.py
+++ b/sre-agent/.claude/skills/project-jira/scripts/search_issues.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Search Jira issues using JQL.
+
+Usage:
+    python search_issues.py --jql "type = Bug AND created >= -7d"
+    python search_issues.py --jql "labels = incident" --max-results 50
+"""
+
+import argparse
+import json
+import sys
+
+from jira_client import extract_adf_text, get_browse_url, jira_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search Jira issues using JQL")
+    parser.add_argument("--jql", required=True, help="JQL query string")
+    parser.add_argument(
+        "--max-results", type=int, default=50, help="Maximum results (default: 50)"
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        data = jira_request(
+            "GET",
+            "/search",
+            params={
+                "jql": args.jql,
+                "maxResults": args.max_results,
+                "fields": "summary,status,issuetype,priority,assignee,reporter,created,updated,labels,description",
+            },
+        )
+
+        browse_url = get_browse_url()
+        issues = []
+        for item in data.get("issues", []):
+            f = item.get("fields", {})
+            desc = extract_adf_text(f.get("description"))
+            if len(desc) > 500:
+                desc = desc[:500] + "..."
+
+            issue = {
+                "key": item["key"],
+                "summary": f.get("summary"),
+                "status": f.get("status", {}).get("name") if f.get("status") else None,
+                "type": (
+                    f.get("issuetype", {}).get("name") if f.get("issuetype") else None
+                ),
+                "priority": (
+                    f.get("priority", {}).get("name") if f.get("priority") else None
+                ),
+                "assignee": (
+                    f.get("assignee", {}).get("displayName")
+                    if f.get("assignee")
+                    else None
+                ),
+                "created": f.get("created"),
+                "updated": f.get("updated"),
+                "labels": f.get("labels", []),
+            }
+            if desc:
+                issue["description_snippet"] = desc
+            if browse_url:
+                issue["url"] = f"{browse_url}/browse/{item['key']}"
+            issues.append(issue)
+
+        status_counts = {}
+        priority_counts = {}
+        for issue in issues:
+            s = issue.get("status")
+            if s:
+                status_counts[s] = status_counts.get(s, 0) + 1
+            p = issue.get("priority")
+            if p:
+                priority_counts[p] = priority_counts.get(p, 0) + 1
+
+        result = {
+            "ok": True,
+            "jql": args.jql,
+            "total": data.get("total", len(issues)),
+            "count": len(issues),
+            "summary": {"by_status": status_counts, "by_priority": priority_counts},
+            "issues": issues,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"JQL: {args.jql}")
+            print(
+                f"Found: {data.get('total', len(issues))} issues (showing {len(issues)})"
+            )
+            if status_counts:
+                print(
+                    f"By status: {', '.join(f'{k}: {v}' for k, v in status_counts.items())}"
+                )
+            print()
+            for issue in issues:
+                print(
+                    f"  [{issue.get('status', '?')}] {issue['key']} - {issue.get('summary', '')}"
+                )
+                print(
+                    f"    Priority: {issue.get('priority', '?')} | Assignee: {issue.get('assignee', 'Unassigned')}"
+                )
+                if issue.get("labels"):
+                    print(f"    Labels: {', '.join(issue['labels'])}")
+                print()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/project-jira/scripts/update_issue.py
+++ b/sre-agent/.claude/skills/project-jira/scripts/update_issue.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Update an existing Jira issue.
+
+Usage:
+    python update_issue.py --issue-key PROJ-123 --status "In Progress"
+    python update_issue.py --issue-key PROJ-123 --summary "New title" --priority High
+"""
+
+import argparse
+import json
+import sys
+
+from jira_client import jira_request, make_adf_text
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Update a Jira issue")
+    parser.add_argument("--issue-key", required=True, help="Issue key (e.g., PROJ-123)")
+    parser.add_argument("--summary", default="", help="New summary")
+    parser.add_argument("--description", default="", help="New description")
+    parser.add_argument("--status", default="", help="New status (triggers transition)")
+    parser.add_argument("--priority", default="", help="New priority")
+    parser.add_argument("--assignee", default="", help="New assignee account ID")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        fields = {}
+        if args.summary:
+            fields["summary"] = args.summary
+        if args.description:
+            fields["description"] = make_adf_text(args.description)
+        if args.priority:
+            fields["priority"] = {"name": args.priority}
+
+        if fields:
+            jira_request(
+                "PUT", f"/issue/{args.issue_key}", json_body={"fields": fields}
+            )
+
+        if args.assignee:
+            jira_request(
+                "PUT",
+                f"/issue/{args.issue_key}/assignee",
+                json_body={"accountId": args.assignee},
+            )
+
+        if args.status:
+            transitions = jira_request("GET", f"/issue/{args.issue_key}/transitions")
+            for transition in transitions.get("transitions", []):
+                if transition["name"].lower() == args.status.lower():
+                    jira_request(
+                        "POST",
+                        f"/issue/{args.issue_key}/transitions",
+                        json_body={"transition": {"id": transition["id"]}},
+                    )
+                    break
+            else:
+                available = [t["name"] for t in transitions.get("transitions", [])]
+                print(
+                    f"Warning: Status '{args.status}' not found. Available: {', '.join(available)}",
+                    file=sys.stderr,
+                )
+
+        result = {"ok": True, "key": args.issue_key, "updated": True}
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Updated: {args.issue_key}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/project-linear/SKILL.md
+++ b/sre-agent/.claude/skills/project-linear/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: project-linear
+description: Linear issue tracking and project management. Use for creating issues, searching issues, and managing projects. Supports GraphQL queries with team and state filtering.
+allowed-tools: Bash(python *)
+---
+
+# Linear Integration
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Just run the scripts directly.
+
+## Priority Levels
+
+| Value | Level |
+|-------|-------|
+| 0 | No priority |
+| 1 | Urgent |
+| 2 | High |
+| 3 | Medium |
+| 4 | Low |
+
+## Available Scripts
+
+All scripts are in `.claude/skills/project-linear/scripts/`
+
+### create_issue.py
+```bash
+python .claude/skills/project-linear/scripts/create_issue.py --title "Fix auth bug" [--description "Details..."] [--team-id ID] [--priority 2] [--assignee-id ID] [--labels "label1,label2"]
+```
+
+### create_project.py
+```bash
+python .claude/skills/project-linear/scripts/create_project.py --name "Q1 Reliability" [--description "..."] [--team-id ID]
+```
+
+### get_issue.py
+```bash
+python .claude/skills/project-linear/scripts/get_issue.py --issue-id TEAM-123
+```
+
+### list_issues.py
+```bash
+python .claude/skills/project-linear/scripts/list_issues.py [--team-id ID] [--state "In Progress"] [--max-results 50]
+```

--- a/sre-agent/.claude/skills/project-linear/scripts/create_issue.py
+++ b/sre-agent/.claude/skills/project-linear/scripts/create_issue.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Create a new Linear issue."""
+
+import argparse
+import json
+import sys
+
+from linear_client import graphql_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create Linear issue")
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--description", default="")
+    parser.add_argument("--team-id", help="Team ID")
+    parser.add_argument(
+        "--priority",
+        type=int,
+        default=0,
+        help="0=None, 1=Urgent, 2=High, 3=Medium, 4=Low",
+    )
+    parser.add_argument("--assignee-id", help="Assignee user ID")
+    parser.add_argument("--labels", help="Comma-separated label IDs")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        mutation = """mutation CreateIssue($input: IssueCreateInput!) { issueCreate(input: $input) { success issue { id identifier title url } } }"""
+        input_data = {
+            "title": args.title,
+            "description": args.description,
+            "priority": args.priority,
+        }
+        if args.team_id:
+            input_data["teamId"] = args.team_id
+        if args.assignee_id:
+            input_data["assigneeId"] = args.assignee_id
+        if args.labels:
+            input_data["labelIds"] = [l.strip() for l in args.labels.split(",")]
+
+        data = graphql_request(mutation, {"input": input_data})
+        issue = data["issueCreate"]["issue"]
+        result = {
+            "id": issue["id"],
+            "identifier": issue["identifier"],
+            "title": issue["title"],
+            "url": issue["url"],
+            "success": True,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Created: {issue['identifier']} - {issue['title']}")
+            print(f"URL: {issue['url']}")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/project-linear/scripts/create_project.py
+++ b/sre-agent/.claude/skills/project-linear/scripts/create_project.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Create a new Linear project."""
+
+import argparse
+import json
+import sys
+
+from linear_client import graphql_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create Linear project")
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--description", default="")
+    parser.add_argument("--team-id", help="Team ID")
+    parser.add_argument("--lead-id", help="Project lead user ID")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        mutation = """mutation CreateProject($input: ProjectCreateInput!) { projectCreate(input: $input) { success project { id name url } } }"""
+        input_data = {"name": args.name, "description": args.description}
+        if args.team_id:
+            input_data["teamIds"] = [args.team_id]
+        if args.lead_id:
+            input_data["leadId"] = args.lead_id
+
+        data = graphql_request(mutation, {"input": input_data})
+        project = data["projectCreate"]["project"]
+        result = {
+            "id": project["id"],
+            "name": project["name"],
+            "url": project["url"],
+            "success": True,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Created project: {project['name']}\nURL: {project['url']}")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/project-linear/scripts/get_issue.py
+++ b/sre-agent/.claude/skills/project-linear/scripts/get_issue.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Get details of a Linear issue."""
+
+import argparse
+import json
+import sys
+
+from linear_client import graphql_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Linear issue")
+    parser.add_argument(
+        "--issue-id", required=True, help="Issue ID or identifier (e.g. TEAM-123)"
+    )
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        query = """query GetIssue($id: String!) { issue(id: $id) { id identifier title description state { name } assignee { name } priority createdAt updatedAt url } }"""
+        data = graphql_request(query, {"id": args.issue_id})
+        issue = data["issue"]
+        result = {
+            "id": issue["id"],
+            "identifier": issue["identifier"],
+            "title": issue["title"],
+            "description": issue.get("description", ""),
+            "state": issue["state"]["name"] if issue.get("state") else None,
+            "assignee": issue["assignee"]["name"] if issue.get("assignee") else None,
+            "priority": issue.get("priority"),
+            "created_at": issue.get("createdAt"),
+            "updated_at": issue.get("updatedAt"),
+            "url": issue["url"],
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"{result['identifier']} - {result['title']}")
+            print(
+                f"State: {result.get('state', '?')} | Priority: {result.get('priority', '?')} | Assignee: {result.get('assignee', 'Unassigned')}"
+            )
+            if result.get("description"):
+                print(f"Description: {result['description'][:200]}")
+            print(f"URL: {result['url']}")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/project-linear/scripts/linear_client.py
+++ b/sre-agent/.claude/skills/project-linear/scripts/linear_client.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Shared Linear GraphQL client with proxy support."""
+
+import os
+
+import httpx
+
+
+def get_graphql_url() -> str:
+    proxy_url = os.getenv("LINEAR_BASE_URL")
+    if proxy_url:
+        return proxy_url.rstrip("/")
+    return "https://api.linear.app/graphql"
+
+
+def get_headers() -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    api_key = os.getenv("LINEAR_API_KEY")
+    if api_key:
+        headers["Authorization"] = api_key
+    else:
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            headers["X-Tenant-Id"] = os.getenv("OPENSRE_TENANT_ID", "local")
+            headers["X-Team-Id"] = os.getenv("OPENSRE_TEAM_ID", "local")
+    return headers
+
+
+def graphql_request(query, variables=None):
+    url = get_graphql_url()
+    body = {"query": query}
+    if variables:
+        body["variables"] = variables
+    with httpx.Client(timeout=30.0) as client:
+        response = client.post(url, headers=get_headers(), json=body)
+        response.raise_for_status()
+        data = response.json()
+        if "errors" in data:
+            raise Exception(f"GraphQL errors: {data['errors']}")
+        return data.get("data", {})

--- a/sre-agent/.claude/skills/project-linear/scripts/list_issues.py
+++ b/sre-agent/.claude/skills/project-linear/scripts/list_issues.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""List Linear issues with optional filters."""
+
+import argparse
+import json
+import sys
+
+from linear_client import graphql_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Linear issues")
+    parser.add_argument("--team-id", help="Filter by team ID")
+    parser.add_argument("--state", help="Filter by state name")
+    parser.add_argument("--max-results", type=int, default=50)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        query = """query ListIssues($first: Int!) { issues(first: $first) { nodes { id identifier title state { name } assignee { name } priority createdAt url } } }"""
+        data = graphql_request(query, {"first": args.max_results})
+        issues = []
+        for issue in data["issues"]["nodes"]:
+            state = issue["state"]["name"] if issue.get("state") else None
+            if args.state and state != args.state:
+                continue
+            issues.append(
+                {
+                    "id": issue["id"],
+                    "identifier": issue["identifier"],
+                    "title": issue["title"],
+                    "state": state,
+                    "assignee": (
+                        issue["assignee"]["name"] if issue.get("assignee") else None
+                    ),
+                    "priority": issue.get("priority"),
+                    "created_at": issue.get("createdAt"),
+                    "url": issue["url"],
+                }
+            )
+
+        if args.json:
+            print(json.dumps(issues, indent=2))
+        else:
+            print(f"Issues: {len(issues)}")
+            for i in issues:
+                print(f"  [{i.get('state', '?')}] {i['identifier']} - {i['title']}")
+                print(
+                    f"    Priority: {i.get('priority', '?')} | Assignee: {i.get('assignee', 'Unassigned')}"
+                )
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/remediation/SKILL.md
+++ b/sre-agent/.claude/skills/remediation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: remediation
+description: Safe remediation actions for Kubernetes. Use when proposing or executing pod restarts, deployment scaling, or rollbacks. Always use dry-run first.
+---
+
+# Remediation Actions
+
+## Safety Principles
+
+1. **ALWAYS dry-run first** - All scripts support `--dry-run` flag
+2. **Confirm before executing** - Show what will happen, ask for confirmation
+3. **Document the action** - Log what was done and why
+4. **Have a rollback plan** - Know how to undo the action
+
+## Available Scripts
+
+All scripts are in `.claude/skills/remediation/scripts/`
+
+### restart_pod.py - Restart a pod by deleting it
+```bash
+# Dry run (shows what would happen)
+python .claude/skills/remediation/scripts/restart_pod.py <pod-name> -n <namespace> --dry-run
+
+# Execute
+python .claude/skills/remediation/scripts/restart_pod.py <pod-name> -n <namespace>
+```
+
+### scale_deployment.py - Scale a deployment
+```bash
+# Dry run
+python .claude/skills/remediation/scripts/scale_deployment.py <deployment> -n <namespace> --replicas N --dry-run
+
+# Execute
+python .claude/skills/remediation/scripts/scale_deployment.py <deployment> -n <namespace> --replicas N
+```
+
+### rollback_deployment.py - Rollback to previous revision
+```bash
+# Dry run (shows current and target revision)
+python .claude/skills/remediation/scripts/rollback_deployment.py <deployment> -n <namespace> --dry-run
+
+# Execute
+python .claude/skills/remediation/scripts/rollback_deployment.py <deployment> -n <namespace>
+```
+
+## Remediation Workflow
+
+1. **Diagnose first** - Use k8s-debugger to understand the issue
+2. **Propose action** - State what you plan to do and why
+3. **Dry run** - Show what will happen
+4. **Get confirmation** - Ask user to confirm
+5. **Execute** - Run the action
+6. **Verify** - Check that the issue is resolved
+
+## Common Remediation Scenarios
+
+### Pod stuck in CrashLoopBackOff
+```bash
+# 1. Check events
+python .claude/skills/infrastructure/kubernetes/scripts/get_events.py <pod> -n <namespace>
+
+# 2. If fixable by restart, dry-run first
+python .claude/skills/remediation/scripts/restart_pod.py <pod> -n <namespace> --dry-run
+
+# 3. Execute restart
+python .claude/skills/remediation/scripts/restart_pod.py <pod> -n <namespace>
+```
+
+### Deployment stuck with bad image
+```bash
+# 1. Check history
+python .claude/skills/infrastructure/kubernetes/scripts/get_history.py <deployment> -n <namespace>
+
+# 2. Dry-run rollback
+python .claude/skills/remediation/scripts/rollback_deployment.py <deployment> -n <namespace> --dry-run
+
+# 3. Execute rollback
+python .claude/skills/remediation/scripts/rollback_deployment.py <deployment> -n <namespace>
+```
+
+### Service under high load
+```bash
+# 1. Check current state
+python .claude/skills/infrastructure/kubernetes/scripts/describe_deployment.py <deployment> -n <namespace>
+
+# 2. Dry-run scale up
+python .claude/skills/remediation/scripts/scale_deployment.py <deployment> -n <namespace> --replicas 5 --dry-run
+
+# 3. Execute scale
+python .claude/skills/remediation/scripts/scale_deployment.py <deployment> -n <namespace> --replicas 5
+```
+
+## Output Format
+
+When proposing remediation, use this structure:
+
+```
+## Proposed Remediation
+
+**Action**: [e.g., Restart pod, Scale deployment, Rollback]
+**Target**: [resource name and namespace]
+**Reason**: [why this action will help]
+**Risk**: [potential side effects]
+
+### Dry Run Output
+[output from --dry-run]
+
+### Confirmation Required
+Please confirm you want to proceed with this action.
+```

--- a/sre-agent/.claude/skills/remediation/scripts/restart_pod.py
+++ b/sre-agent/.claude/skills/remediation/scripts/restart_pod.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Restart a Kubernetes pod by deleting it (deployment will recreate).
+
+Usage:
+    python restart_pod.py <pod-name> -n <namespace> [--dry-run]
+
+Examples:
+    # Dry run
+    python restart_pod.py payment-7f8b9c6d5-x2k4m -n otel-demo --dry-run
+
+    # Execute
+    python restart_pod.py payment-7f8b9c6d5-x2k4m -n otel-demo
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from kubernetes import client
+from kubernetes import config as k8s_config
+from kubernetes.client.rest import ApiException
+
+_RFC1123_RE = re.compile(r"^[a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?$")
+
+
+def _validate_k8s_name(value: str, label: str) -> str:
+    """Validate a Kubernetes resource name against RFC 1123."""
+    if not _RFC1123_RE.match(value):
+        raise ValueError(
+            f"Invalid {label} name '{value}': must be lowercase alphanumeric/hyphens, 1-63 chars"
+        )
+    return value
+
+
+def get_k8s_client():
+    """Get Kubernetes API client.
+
+    Prefers in-cluster service account auth (correct RBAC identity)
+    over kubeconfig (which may resolve to the EC2 node IAM identity).
+    """
+    in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    kubeconfig = Path.home() / ".kube" / "config"
+
+    if in_cluster.exists():
+        k8s_config.load_incluster_config()
+        print("[k8s-auth] Using in-cluster service account", file=sys.stderr)
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
+        print("[k8s-auth] Using kubeconfig (fallback)", file=sys.stderr)
+    else:
+        print(
+            "Error: Kubernetes not configured. No in-cluster token or ~/.kube/config.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return client.CoreV1Api()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Restart a Kubernetes pod")
+    parser.add_argument("pod_name", help="Name of the pod to restart")
+    parser.add_argument(
+        "-n", "--namespace", default="default", help="Kubernetes namespace"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would happen without executing",
+    )
+    args = parser.parse_args()
+
+    try:
+        _validate_k8s_name(args.pod_name, "pod")
+        _validate_k8s_name(args.namespace, "namespace")
+        core_v1 = get_k8s_client()
+
+        # First, verify the pod exists
+        pod = core_v1.read_namespaced_pod(name=args.pod_name, namespace=args.namespace)
+
+        # Get owner reference to check if managed by deployment
+        owner_refs = pod.metadata.owner_references or []
+        managed_by = None
+        for ref in owner_refs:
+            if ref.kind in ("ReplicaSet", "DaemonSet", "StatefulSet"):
+                managed_by = f"{ref.kind}/{ref.name}"
+                break
+
+        print(f"Pod: {args.pod_name}")
+        print(f"Namespace: {args.namespace}")
+        print(f"Status: {pod.status.phase}")
+        print(f"Managed by: {managed_by or 'None (standalone pod)'}")
+        print()
+
+        if args.dry_run:
+            print("🔍 DRY RUN - No changes will be made")
+            print("-" * 40)
+            print(f"Would delete pod: {args.pod_name}")
+            if managed_by:
+                print(
+                    f"The {managed_by.split('/')[0]} will create a new pod automatically."
+                )
+            else:
+                print(
+                    "⚠️  WARNING: This is a standalone pod - it will NOT be recreated!"
+                )
+            print()
+            print("To execute this action, run without --dry-run")
+        else:
+            if not managed_by:
+                print(
+                    "⚠️  WARNING: This is a standalone pod - it will NOT be recreated!"
+                )
+                print("Are you sure you want to delete it?")
+                # In non-interactive mode, we should not proceed with standalone pods
+                print(
+                    "Aborting: Standalone pod deletion requires explicit confirmation."
+                )
+                sys.exit(1)
+
+            print("🔄 Deleting pod...")
+            core_v1.delete_namespaced_pod(
+                name=args.pod_name,
+                namespace=args.namespace,
+            )
+            print(f"✅ Pod {args.pod_name} deleted successfully.")
+            print(f"   A new pod will be created by {managed_by}.")
+            print()
+            print("Use list_pods.py to verify the new pod is running.")
+
+    except ApiException as e:
+        if e.status == 404:
+            print(
+                f"Error: Pod {args.pod_name} not found in namespace {args.namespace}",
+                file=sys.stderr,
+            )
+        else:
+            print(f"Error: Kubernetes API error: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/remediation/scripts/rollback_deployment.py
+++ b/sre-agent/.claude/skills/remediation/scripts/rollback_deployment.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Rollback a Kubernetes deployment to previous revision.
+
+Usage:
+    python rollback_deployment.py <deployment> -n <namespace> [--revision N] [--dry-run]
+
+Examples:
+    # Dry run (rollback to previous)
+    python rollback_deployment.py payment -n otel-demo --dry-run
+
+    # Execute rollback to previous
+    python rollback_deployment.py payment -n otel-demo
+
+    # Rollback to specific revision
+    python rollback_deployment.py payment -n otel-demo --revision 2
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# RFC 1123 label: lowercase alphanumeric + hyphens, 1-63 chars, must start/end with alphanum
+_RFC1123_RE = re.compile(r"^[a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?$")
+
+
+def _validate_k8s_name(value: str, label: str) -> str:
+    """Validate a Kubernetes resource name against RFC 1123."""
+    if not _RFC1123_RE.match(value):
+        print(
+            f"Error: Invalid {label} name '{value}'. "
+            f"Must be lowercase alphanumeric/hyphens, 1-63 chars.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return value
+
+
+from kubernetes import client
+from kubernetes import config as k8s_config
+from kubernetes.client.rest import ApiException
+
+
+def get_k8s_clients():
+    """Get Kubernetes API clients.
+
+    Prefers in-cluster service account auth (correct RBAC identity)
+    over kubeconfig (which may resolve to the EC2 node IAM identity).
+    """
+    in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    kubeconfig = Path.home() / ".kube" / "config"
+
+    if in_cluster.exists():
+        k8s_config.load_incluster_config()
+        print("[k8s-auth] Using in-cluster service account", file=sys.stderr)
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
+        print("[k8s-auth] Using kubeconfig (fallback)", file=sys.stderr)
+    else:
+        print(
+            "Error: Kubernetes not configured. No in-cluster token or ~/.kube/config.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return client.AppsV1Api()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Rollback a Kubernetes deployment")
+    parser.add_argument("deployment", help="Deployment name")
+    parser.add_argument(
+        "-n", "--namespace", default="default", help="Kubernetes namespace"
+    )
+    parser.add_argument(
+        "--revision", type=int, help="Target revision (default: previous)"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would happen without executing",
+    )
+    args = parser.parse_args()
+
+    # Validate inputs before passing to kubectl/K8s API
+    _validate_k8s_name(args.deployment, "deployment")
+    _validate_k8s_name(args.namespace, "namespace")
+
+    try:
+        apps_v1 = get_k8s_clients()
+
+        # Get current deployment
+        deployment = apps_v1.read_namespaced_deployment(
+            name=args.deployment,
+            namespace=args.namespace,
+        )
+
+        current_revision = deployment.metadata.annotations.get(
+            "deployment.kubernetes.io/revision", "unknown"
+        )
+
+        # Get replica sets to find revisions
+        selector = deployment.spec.selector.match_labels
+        label_selector = ",".join([f"{k}={v}" for k, v in selector.items()])
+
+        rs_list = apps_v1.list_namespaced_replica_set(
+            namespace=args.namespace,
+            label_selector=label_selector,
+        )
+
+        # Build revision history
+        revisions = []
+        for rs in rs_list.items:
+            rev = rs.metadata.annotations.get("deployment.kubernetes.io/revision", "0")
+            revisions.append(
+                {
+                    "revision": int(rev),
+                    "name": rs.metadata.name,
+                    "replicas": rs.spec.replicas,
+                    "image": (
+                        rs.spec.template.spec.containers[0].image
+                        if rs.spec.template.spec.containers
+                        else "unknown"
+                    ),
+                }
+            )
+
+        revisions.sort(key=lambda x: x["revision"], reverse=True)
+
+        print(f"Deployment: {args.deployment}")
+        print(f"Namespace: {args.namespace}")
+        print(f"Current revision: {current_revision}")
+        print()
+
+        print("Revision history:")
+        for rev in revisions[:5]:
+            marker = " (current)" if str(rev["revision"]) == current_revision else ""
+            print(f"  {rev['revision']}: {rev['image']}{marker}")
+        print()
+
+        # Determine target revision
+        if args.revision:
+            target_revision = args.revision
+        else:
+            # Find previous revision
+            current_rev_int = int(current_revision) if current_revision.isdigit() else 0
+            previous_revs = [r for r in revisions if r["revision"] < current_rev_int]
+            if not previous_revs:
+                print(
+                    "Error: No previous revision available for rollback.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            target_revision = previous_revs[0]["revision"]
+
+        # Find target revision info
+        target_info = next(
+            (r for r in revisions if r["revision"] == target_revision), None
+        )
+        if not target_info:
+            print(f"Error: Revision {target_revision} not found.", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"Target revision: {target_revision}")
+        print(f"Target image: {target_info['image']}")
+        print()
+
+        if args.dry_run:
+            print("🔍 DRY RUN - No changes will be made")
+            print("-" * 40)
+            print(
+                f"Would rollback from revision {current_revision} to {target_revision}"
+            )
+            print(f"Image would change to: {target_info['image']}")
+            print()
+            print("To execute this action, run without --dry-run")
+        else:
+            print(f"🔄 Rolling back to revision {target_revision}...")
+
+            # Use kubectl-style rollback by patching annotations
+            # This triggers a new rollout to the previous revision's spec
+            {
+                "spec": {
+                    "template": {
+                        "metadata": {
+                            "annotations": {
+                                "kubectl.kubernetes.io/restartedAt": str(
+                                    target_revision
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            # Actually, the proper way is to use rollout undo via subprocess
+            # since the API doesn't have a direct rollback endpoint
+            import subprocess
+
+            result = subprocess.run(
+                [
+                    "kubectl",
+                    "rollout",
+                    "undo",
+                    f"deployment/{args.deployment}",
+                    "-n",
+                    args.namespace,
+                    f"--to-revision={target_revision}",
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            if result.returncode == 0:
+                print(f"✅ Rollback initiated to revision {target_revision}")
+                print(result.stdout)
+                print()
+                print("Use describe_deployment.py to monitor rollout progress.")
+            else:
+                print("Error: Rollback failed", file=sys.stderr)
+                print(result.stderr, file=sys.stderr)
+                sys.exit(1)
+
+    except ApiException as e:
+        if e.status == 404:
+            print(
+                f"Error: Deployment {args.deployment} not found in namespace {args.namespace}",
+                file=sys.stderr,
+            )
+        else:
+            print(f"Error: Kubernetes API error: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/remediation/scripts/scale_deployment.py
+++ b/sre-agent/.claude/skills/remediation/scripts/scale_deployment.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Scale a Kubernetes deployment.
+
+Usage:
+    python scale_deployment.py <deployment> -n <namespace> --replicas N [--dry-run]
+
+Examples:
+    # Dry run
+    python scale_deployment.py payment -n otel-demo --replicas 3 --dry-run
+
+    # Execute
+    python scale_deployment.py payment -n otel-demo --replicas 3
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from kubernetes import client
+from kubernetes import config as k8s_config
+from kubernetes.client.rest import ApiException
+
+_RFC1123_RE = re.compile(r"^[a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?$")
+_MAX_REPLICAS = 50
+
+
+def _validate_k8s_name(value: str, label: str) -> str:
+    """Validate a Kubernetes resource name against RFC 1123."""
+    if not _RFC1123_RE.match(value):
+        raise ValueError(
+            f"Invalid {label} name '{value}': must be lowercase alphanumeric/hyphens, 1-63 chars"
+        )
+    return value
+
+
+def get_k8s_client():
+    """Get Kubernetes API client.
+
+    Prefers in-cluster service account auth (correct RBAC identity)
+    over kubeconfig (which may resolve to the EC2 node IAM identity).
+    """
+    in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    kubeconfig = Path.home() / ".kube" / "config"
+
+    if in_cluster.exists():
+        k8s_config.load_incluster_config()
+        print("[k8s-auth] Using in-cluster service account", file=sys.stderr)
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
+        print("[k8s-auth] Using kubeconfig (fallback)", file=sys.stderr)
+    else:
+        print(
+            "Error: Kubernetes not configured. No in-cluster token or ~/.kube/config.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return client.AppsV1Api()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Scale a Kubernetes deployment")
+    parser.add_argument("deployment", help="Deployment name")
+    parser.add_argument(
+        "-n", "--namespace", default="default", help="Kubernetes namespace"
+    )
+    parser.add_argument(
+        "--replicas", type=int, required=True, help="Target replica count"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would happen without executing",
+    )
+    parser.add_argument(
+        "--confirm-zero",
+        action="store_true",
+        help="Required flag when scaling to 0 replicas",
+    )
+    args = parser.parse_args()
+
+    if args.replicas < 0:
+        print("Error: Replicas must be >= 0", file=sys.stderr)
+        sys.exit(1)
+    if args.replicas > _MAX_REPLICAS:
+        print(
+            f"Error: Replicas must be <= {_MAX_REPLICAS} to prevent resource exhaustion.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        _validate_k8s_name(args.deployment, "deployment")
+        _validate_k8s_name(args.namespace, "namespace")
+        apps_v1 = get_k8s_client()
+
+        # Get current deployment state
+        deployment = apps_v1.read_namespaced_deployment(
+            name=args.deployment,
+            namespace=args.namespace,
+        )
+
+        current_replicas = deployment.spec.replicas
+        ready_replicas = deployment.status.ready_replicas or 0
+
+        print(f"Deployment: {args.deployment}")
+        print(f"Namespace: {args.namespace}")
+        print(f"Current replicas: {current_replicas} ({ready_replicas} ready)")
+        print(f"Target replicas: {args.replicas}")
+        print()
+
+        if current_replicas == args.replicas:
+            print("ℹ️  Deployment is already at the target replica count.")
+            sys.exit(0)
+
+        action = "scale up" if args.replicas > current_replicas else "scale down"
+
+        if args.dry_run:
+            print("🔍 DRY RUN - No changes will be made")
+            print("-" * 40)
+            print(f"Would {action} from {current_replicas} to {args.replicas} replicas")
+
+            if args.replicas == 0:
+                print("⚠️  WARNING: Scaling to 0 will make the service unavailable!")
+            elif args.replicas > 10:
+                print(
+                    "⚠️  NOTE: Scaling to >10 replicas - ensure cluster has capacity."
+                )
+
+            print()
+            print("To execute this action, run without --dry-run")
+        else:
+            if args.replicas == 0 and not args.confirm_zero:
+                print(
+                    "Error: Scaling to 0 replicas requires --confirm-zero flag.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            if args.replicas == 0:
+                print("⚠️  WARNING: Scaling to 0 will make the service unavailable!")
+
+            print(
+                f"🔄 Scaling deployment from {current_replicas} to {args.replicas}..."
+            )
+
+            # Patch the deployment
+            apps_v1.patch_namespaced_deployment_scale(
+                name=args.deployment,
+                namespace=args.namespace,
+                body={"spec": {"replicas": args.replicas}},
+            )
+
+            print(f"✅ Deployment scaled to {args.replicas} replicas.")
+            print()
+            print("Use describe_deployment.py to monitor rollout progress.")
+
+    except ApiException as e:
+        if e.status == 404:
+            print(
+                f"Error: Deployment {args.deployment} not found in namespace {args.namespace}",
+                file=sys.stderr,
+            )
+        else:
+            print(f"Error: Kubernetes API error: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/runtime-config-flagd/SKILL.md
+++ b/sre-agent/.claude/skills/runtime-config-flagd/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: runtime-config-flagd
+description: Feature flag management via flagd (OpenFeature). Use to list, inspect, and toggle feature flags in the OTel Demo environment. Flags control incident injection scenarios (payment failures, CPU spikes, memory leaks, etc.) and can be toggled for remediation.
+category: runtime-config
+required_integrations:
+  - kubernetes
+---
+
+# Feature Flag Management (flagd)
+
+## How It Works
+
+The OpenTelemetry Demo uses [flagd](https://flagd.dev/) as its feature flag provider. Flags are stored in a Kubernetes ConfigMap and loaded by the flagd service. Services check flags at runtime via the OpenFeature SDK to decide whether to inject failures.
+
+**Flag lifecycle:**
+1. Flag definitions live in a ConfigMap (`flagd-config` in `otel-demo` namespace)
+2. flagd watches the ConfigMap and hot-reloads on changes
+3. Services evaluate flags via gRPC and behave accordingly
+4. To remediate an incident, set the flag's default variant to `off`
+
+## Available Scripts
+
+All scripts are in `.claude/skills/runtime-config-flagd/scripts/`
+
+### list_scenarios.py - List Incident Scenarios (START HERE)
+Shows all available incident scenarios with their current status.
+```bash
+python .claude/skills/runtime-config-flagd/scripts/list_scenarios.py
+
+# Only show currently active scenarios
+python .claude/skills/runtime-config-flagd/scripts/list_scenarios.py --active-only
+
+# JSON output
+python .claude/skills/runtime-config-flagd/scripts/list_scenarios.py --json
+```
+
+Output includes: flag name, current state (active/inactive), affected service, effect description, detection method, and remediation steps.
+
+### list_flags.py - List All Feature Flags
+```bash
+python .claude/skills/runtime-config-flagd/scripts/list_flags.py
+
+# Show full variant details
+python .claude/skills/runtime-config-flagd/scripts/list_flags.py --verbose
+
+# Only incident-related flags
+python .claude/skills/runtime-config-flagd/scripts/list_flags.py --incidents-only
+```
+
+### get_flag.py - Inspect a Specific Flag
+```bash
+python .claude/skills/runtime-config-flagd/scripts/get_flag.py <flag_key>
+
+# Examples:
+python .claude/skills/runtime-config-flagd/scripts/get_flag.py paymentServiceFailure
+python .claude/skills/runtime-config-flagd/scripts/get_flag.py adServiceHighCpu --json
+```
+
+### set_flag.py - Toggle a Flag (Remediation)
+```bash
+# ALWAYS dry-run first
+python .claude/skills/runtime-config-flagd/scripts/set_flag.py <flag_key> <variant> --dry-run
+
+# Then apply
+python .claude/skills/runtime-config-flagd/scripts/set_flag.py <flag_key> <variant>
+
+# Examples:
+python .claude/skills/runtime-config-flagd/scripts/set_flag.py paymentServiceFailure off --dry-run
+python .claude/skills/runtime-config-flagd/scripts/set_flag.py paymentServiceFailure off
+python .claude/skills/runtime-config-flagd/scripts/set_flag.py adServiceHighCpu off
+python .claude/skills/runtime-config-flagd/scripts/set_flag.py emailMemoryLeak off
+```
+
+## Incident Scenarios Reference
+
+| Scenario | Flag | Service | Effect | Remediation |
+|----------|------|---------|--------|-------------|
+| Payment Failure | `paymentServiceFailure` | payment (Node.js) | Configurable % of requests fail | Set to `off` |
+| Payment Unreachable | `paymentServiceUnreachable` | payment | Complete unavailability | Set to `off` |
+| High CPU | `adServiceHighCpu` | ad (Java) | CPU spike 80-100% | Set to `off` |
+| GC Pressure | `adServiceManualGc` | ad (Java) | Frequent full GC pauses | Set to `off` |
+| Ad Failure | `adServiceFailure` | ad (Java) | Ad service errors | Set to `off` |
+| Memory Leak | `emailMemoryLeak` | email (Ruby) | OOM after minutes | Set to `off` + restart pod |
+| Latency Spike | `imageSlowLoad` | image-provider | 5-10s delay | Set to `off` |
+| Kafka Lag | `kafkaQueueProblems` | checkout/accounting | Consumer lag | Set to `off` |
+| Cache Failure | `recommendationServiceCacheFailure` | recommendation | Cache miss storm | Set to `off` |
+| Catalog Failure | `productCatalogFailure` | product-catalog | Product query errors | Set to `off` |
+| Cart Failure | `cartServiceFailure` | cart (.NET) | Cart ops fail | Set to `off` |
+| Traffic Spike | `loadgeneratorFloodHomepage` | all services | Request flood | Set to `off` |
+| LLM Inaccuracy | `llmInaccurateResponse` | product-reviews | Wrong AI content | Set to `off` |
+| LLM Rate Limit | `llmRateLimitError` | product-reviews | 429 errors | Set to `off` |
+
+## Flag Variant Reference
+
+Flags have different variant types:
+
+**Boolean flags** (on/off):
+- `adServiceHighCpu`, `adServiceManualGc`, `adServiceFailure`, `paymentServiceUnreachable`, `cartServiceFailure`
+- `recommendationServiceCacheFailure`, `productCatalogFailure`
+- `llmInaccurateResponse`, `llmRateLimitError`
+- Variants: `on` (true), `off` (false)
+
+**Percentage flags** (graduated failure rate):
+- `paymentServiceFailure`: `off` (0), `10%` (0.1), `25%` (0.25), `50%` (0.5), `75%` (0.75), `90%` (0.95), `100%` (1)
+
+**Intensity flags** (graduated effect):
+- `emailMemoryLeak`: `off` (0), `1x` (1), `10x` (10), `100x` (100), `1000x` (1000), `10000x` (10000)
+- `imageSlowLoad`: `off` (0), `5sec` (5000ms), `10sec` (10000ms)
+
+**Numeric flags**:
+- `kafkaQueueProblems`: `off` (0), `on` (100)
+- `loadgeneratorFloodHomepage`: `off` (0), `on` (100)
+
+## Version Compatibility
+
+| Flag | otel-demo Version | Notes |
+|------|------------------|-------|
+| All flags except below | v1.11.1+ | Standard deployment |
+| `emailMemoryLeak` | > v1.11.1 | Not in v1.11.1 ConfigMap |
+| `llmInaccurateResponse` | > v1.11.1 | Requires product-reviews LLM |
+| `llmRateLimitError` | > v1.11.1 | Requires product-reviews LLM |
+
+> Note: `loadgeneratorFloodHomepage` uses a lowercase 'g' in loadgenerator.
+
+## Remediation Workflow
+
+1. **Identify the scenario** - Use `list_scenarios.py --active-only` to see active incidents
+2. **Confirm the flag** - Use `get_flag.py <flag_key>` to verify current state
+3. **Dry-run** - Use `set_flag.py <flag_key> off --dry-run` to preview change
+4. **Apply** - Use `set_flag.py <flag_key> off` to disable the incident
+5. **Verify** - Check metrics/logs to confirm the issue is resolving
+6. **Post-remediation** - Some scenarios (memory leak) may also require a pod restart
+
+## Safety
+
+- **ALWAYS dry-run first** before setting flags
+- Setting a flag to `off` is always safe — it restores normal behavior
+- Setting a flag to `on` or a non-zero variant **injects failures** — only do this intentionally
+- Flag changes take effect within seconds (flagd hot-reload)
+- For `emailMemoryLeak`, after setting to `off` you may also need to restart the email pod to reclaim leaked memory
+
+## Quick Commands
+
+| Goal | Command |
+|------|---------|
+| See active incidents | `list_scenarios.py --active-only` |
+| Check a specific flag | `get_flag.py paymentServiceFailure` |
+| Disable payment failure | `set_flag.py paymentServiceFailure off` |
+| Enable payment failure at 50% | `set_flag.py paymentServiceFailure 50%` |
+| Disable all CPU spikes | `set_flag.py adServiceHighCpu off` |
+| See all flags verbose | `list_flags.py --verbose` |

--- a/sre-agent/.claude/skills/runtime-config-flagd/scripts/__init__.py
+++ b/sre-agent/.claude/skills/runtime-config-flagd/scripts/__init__.py
@@ -1,0 +1,1 @@
+# flagd runtime config scripts package

--- a/sre-agent/.claude/skills/runtime-config-flagd/scripts/flagd_client.py
+++ b/sre-agent/.claude/skills/runtime-config-flagd/scripts/flagd_client.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Shared flagd client for reading and writing feature flags via Kubernetes ConfigMap.
+
+The OpenTelemetry Demo uses flagd with a ConfigMap-backed JSON file as its flag source.
+Flags are read/written by manipulating the ConfigMap directly, which triggers flagd's
+file-watcher to hot-reload.
+
+Environment variables:
+    FLAGD_NAMESPACE  - K8s namespace where flagd runs (default: otel-demo)
+    FLAGD_CONFIGMAP  - ConfigMap name containing flags (default: flagd-config)
+    FLAGD_KEY        - Key within ConfigMap holding the JSON (default: demo.flagd.json)
+"""
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+from typing import Any
+
+_RFC1123_RE = re.compile(r"^[a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?$")
+
+
+def _validate_k8s_name(value: str, label: str) -> str:
+    """Validate a Kubernetes resource name against RFC 1123."""
+    if not _RFC1123_RE.match(value):
+        raise ValueError(
+            f"Invalid {label} name '{value}': must be lowercase alphanumeric/hyphens, 1-63 chars"
+        )
+    return value
+
+
+def get_config() -> dict[str, str]:
+    """Get flagd configuration from environment."""
+    ns = os.getenv("FLAGD_NAMESPACE", "otel-demo")
+    cm = os.getenv("FLAGD_CONFIGMAP", "flagd-config")
+    _validate_k8s_name(ns, "namespace")
+    _validate_k8s_name(cm, "configmap")
+    return {
+        "namespace": ns,
+        "configmap": cm,
+        "key": os.getenv("FLAGD_KEY", "demo.flagd.json"),
+    }
+
+
+_SA_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+_SA_CA_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+
+def _run_kubectl(args: list[str], input_data: str | None = None) -> str:
+    """Run a kubectl command and return stdout.
+
+    When running in-cluster (SA token mounted), creates a temporary kubeconfig
+    file with the SA token instead of passing --token on the command line.
+    Command-line args are visible via /proc/*/cmdline, so tokens must not
+    appear there.
+
+    Args:
+        args: kubectl arguments (without 'kubectl' prefix)
+        input_data: Optional stdin data
+
+    Returns:
+        Command stdout
+
+    Raises:
+        RuntimeError: If kubectl fails
+    """
+    cmd = ["kubectl"]
+    env = os.environ.copy()
+
+    if os.path.exists(_SA_TOKEN_PATH):
+        # In-cluster: build a temp kubeconfig with SA token (avoids exposing
+        # the token on the command line via /proc/*/cmdline)
+        with open(_SA_TOKEN_PATH) as f:
+            token = f.read().strip()
+        kubeconfig_data = json.dumps(
+            {
+                "apiVersion": "v1",
+                "kind": "Config",
+                "clusters": [
+                    {
+                        "name": "in-cluster",
+                        "cluster": {
+                            "server": "https://kubernetes.default.svc",
+                            "certificate-authority": _SA_CA_PATH,
+                        },
+                    }
+                ],
+                "users": [
+                    {
+                        "name": "sa-user",
+                        "user": {"token": token},
+                    }
+                ],
+                "contexts": [
+                    {
+                        "name": "default",
+                        "context": {"cluster": "in-cluster", "user": "sa-user"},
+                    }
+                ],
+                "current-context": "default",
+            }
+        )
+        # Write to temp file; pass via KUBECONFIG env var
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".kubeconfig", delete=False)
+        try:
+            tmp.write(kubeconfig_data)
+            tmp.close()
+            os.chmod(tmp.name, 0o600)
+            env["KUBECONFIG"] = tmp.name
+            cmd += args
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                input=input_data,
+                env=env,
+            )
+        finally:
+            os.unlink(tmp.name)
+    else:
+        cmd += args
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            input=input_data,
+        )
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"kubectl failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def get_flags_json() -> dict[str, Any]:
+    """Read the full flags JSON from the ConfigMap.
+
+    Returns:
+        Parsed flag configuration dict with 'flags' key
+    """
+    config = get_config()
+    # Use -o json and extract in Python to avoid jsonpath issues with dots in key names
+    raw = _run_kubectl(
+        [
+            "get",
+            "configmap",
+            config["configmap"],
+            "-n",
+            config["namespace"],
+            "-o",
+            "json",
+        ]
+    )
+
+    cm = json.loads(raw)
+    data = cm.get("data", {})
+    flag_json_str = data.get(config["key"])
+
+    if not flag_json_str:
+        raise RuntimeError(
+            f"ConfigMap {config['configmap']} in namespace {config['namespace']} "
+            f"has no data at key '{config['key']}'"
+        )
+
+    return json.loads(flag_json_str)
+
+
+def get_all_flags() -> dict[str, dict[str, Any]]:
+    """Get all flags with their current configuration.
+
+    Returns:
+        Dict mapping flag_key -> {variants, defaultVariant, state, ...}
+    """
+    data = get_flags_json()
+    return data.get("flags", {})
+
+
+def get_flag(flag_key: str) -> dict[str, Any] | None:
+    """Get a single flag's configuration.
+
+    Args:
+        flag_key: The flag key (e.g., 'paymentFailure')
+
+    Returns:
+        Flag configuration dict, or None if not found
+    """
+    flags = get_all_flags()
+    return flags.get(flag_key)
+
+
+def set_flag_variant(
+    flag_key: str, variant: str, dry_run: bool = False
+) -> dict[str, Any]:
+    """Set a flag's default variant.
+
+    This patches the ConfigMap which triggers flagd's hot-reload.
+
+    Args:
+        flag_key: The flag key (e.g., 'paymentFailure')
+        variant: The variant to set as default (e.g., 'off', 'on', '50%')
+        dry_run: If True, show what would change without applying
+
+    Returns:
+        Dict with old and new values
+
+    Raises:
+        ValueError: If flag_key or variant is invalid
+    """
+    config = get_config()
+    data = get_flags_json()
+    flags = data.get("flags", {})
+
+    if not flags:
+        raise ValueError(f"No flags found in ConfigMap '{config['configmap']}'")
+
+    if flag_key not in flags:
+        available = ", ".join(sorted(flags.keys()))
+        raise ValueError(f"Unknown flag '{flag_key}'. Available: {available}")
+
+    flag = flags[flag_key]
+    variants = flag.get("variants", {})
+    available_variants = list(variants.keys())
+
+    if variant not in available_variants:
+        raise ValueError(
+            f"Invalid variant '{variant}' for flag '{flag_key}'. "
+            f"Available: {', '.join(available_variants)}"
+        )
+
+    old_variant = flag.get("defaultVariant", "unknown")
+
+    result = {
+        "flag": flag_key,
+        "old_variant": old_variant,
+        "new_variant": variant,
+        "old_value": variants.get(old_variant),
+        "new_value": variants.get(variant),
+        "dry_run": dry_run,
+    }
+
+    if dry_run:
+        return result
+
+    # Update the flag
+    flags[flag_key]["defaultVariant"] = variant
+    updated_json = json.dumps(data, indent=2)
+
+    # Patch the ConfigMap via stdin to handle large JSON and special characters safely
+    patch = json.dumps({"data": {config["key"]: updated_json}})
+    _run_kubectl(
+        [
+            "patch",
+            "configmap",
+            config["configmap"],
+            "-n",
+            config["namespace"],
+            "--type=merge",
+            "-p",
+            patch,
+        ]
+    )
+
+    return result

--- a/sre-agent/.claude/skills/runtime-config-flagd/scripts/get_flag.py
+++ b/sre-agent/.claude/skills/runtime-config-flagd/scripts/get_flag.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Get a specific feature flag's configuration and current value.
+
+Usage:
+    python get_flag.py <flag_key>
+    python get_flag.py paymentFailure --json
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from flagd_client import get_flag
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get a feature flag's value")
+    parser.add_argument("flag_key", help="Flag key (e.g., paymentFailure)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        flag = get_flag(args.flag_key)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if flag is None:
+        print(f"Flag '{args.flag_key}' not found.", file=sys.stderr)
+        sys.exit(1)
+
+    if args.json:
+        print(json.dumps({args.flag_key: flag}, indent=2))
+        return
+
+    default = flag.get("defaultVariant", "unknown")
+    variants = flag.get("variants", {})
+    current_value = variants.get(default, "?")
+    state = flag.get("state", "ENABLED")
+
+    print("=" * 50)
+    print(f"FLAG: {args.flag_key}")
+    print("=" * 50)
+    print(f"  Current variant: {default}")
+    print(f"  Current value:   {current_value}")
+    print(f"  State:           {state}")
+    print("\n  Available variants:")
+    for name, value in variants.items():
+        marker = " <-- current" if name == default else ""
+        print(f"    {name}: {value}{marker}")
+    print("=" * 50)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/runtime-config-flagd/scripts/list_flags.py
+++ b/sre-agent/.claude/skills/runtime-config-flagd/scripts/list_flags.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""List all feature flags and their current configuration.
+
+Usage:
+    python list_flags.py [--verbose]
+    python list_flags.py --incidents-only
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from flagd_client import get_all_flags
+
+# Flags that correspond to incident scenarios
+INCIDENT_FLAGS = {
+    "adServiceHighCpu",
+    "adServiceManualGc",
+    "adServiceFailure",
+    "emailMemoryLeak",  # requires otel-demo > v1.11.1
+    "paymentServiceFailure",
+    "paymentServiceUnreachable",
+    "cartServiceFailure",
+    "imageSlowLoad",
+    "kafkaQueueProblems",
+    "loadgeneratorFloodHomepage",
+    "recommendationServiceCacheFailure",
+    "productCatalogFailure",
+    "llmInaccurateResponse",  # requires otel-demo > v1.11.1
+    "llmRateLimitError",  # requires otel-demo > v1.11.1
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List all feature flags")
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show full variant details",
+    )
+    parser.add_argument(
+        "--incidents-only",
+        action="store_true",
+        help="Only show incident-related flags",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    try:
+        flags = get_all_flags()
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.incidents_only:
+        flags = {k: v for k, v in flags.items() if k in INCIDENT_FLAGS}
+
+    if args.json:
+        print(json.dumps(flags, indent=2))
+        return
+
+    # Summary output
+    active_count = 0
+    print("=" * 70)
+    print("FEATURE FLAGS")
+    print("=" * 70)
+
+    for name, config in sorted(flags.items()):
+        default = config.get("defaultVariant", "unknown")
+        variants = config.get("variants", {})
+        current_value = variants.get(default, "?")
+        state = config.get("state", "ENABLED")
+        is_incident = name in INCIDENT_FLAGS
+
+        # Determine if flag is "active" (not in its safe/off state)
+        is_active = False
+        if isinstance(current_value, bool):
+            is_active = current_value is True
+        elif isinstance(current_value, (int, float)):
+            is_active = current_value != 0
+
+        marker = ""
+        if is_incident and is_active:
+            marker = " [ACTIVE INCIDENT]"
+            active_count += 1
+        elif is_incident:
+            marker = " [incident]"
+
+        print(f"\n  {name}{marker}")
+        print(f"    Default: {default} (value: {current_value})")
+
+        if args.verbose:
+            variant_strs = [f"{k}={v}" for k, v in variants.items()]
+            print(f"    Variants: {', '.join(variant_strs)}")
+            if state != "ENABLED":
+                print(f"    State: {state}")
+
+    print(f"\n{'=' * 70}")
+    print(f"Total: {len(flags)} flags")
+    if active_count > 0:
+        print(f"ACTIVE INCIDENTS: {active_count}")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/runtime-config-flagd/scripts/list_scenarios.py
+++ b/sre-agent/.claude/skills/runtime-config-flagd/scripts/list_scenarios.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""List available incident scenarios and their current status.
+
+Each scenario maps to a flagd feature flag in the OTel Demo.
+
+Usage:
+    python list_scenarios.py
+    python list_scenarios.py --active-only
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from flagd_client import get_all_flags
+
+# Scenario definitions: flag_key -> scenario metadata
+SCENARIOS = {
+    "paymentServiceFailure": {
+        "name": "Service Failure (Payment)",
+        "service": "payment (Node.js)",
+        "effect": "Configurable % of payment requests return errors",
+        "detection": "HTTP 5xx error rate spike on payment service",
+        "promql": 'rate(http_server_request_duration_seconds_count{service_name="payment",http_response_status_code=~"5.."}[5m])',
+        "remediation": "Set flag to 'off' (variant: off, value: 0)",
+    },
+    "paymentServiceUnreachable": {
+        "name": "Service Unreachable (Payment)",
+        "service": "payment (Node.js)",
+        "effect": "Payment service becomes completely unreachable",
+        "detection": 'up{service_name="payment"} == 0',
+        "promql": 'up{service_name="payment"}',
+        "remediation": "Set flag to 'off'",
+    },
+    "adServiceHighCpu": {
+        "name": "High CPU Load (Ad Service)",
+        "service": "ad (Java)",
+        "effect": "CPU spikes to 80-100%, latency increases",
+        "detection": "CPU utilization spike, increased response latency",
+        "promql": 'rate(process_cpu_seconds_total{service_name="ad"}[1m])',
+        "remediation": "Set flag to 'off'",
+    },
+    "adServiceManualGc": {
+        "name": "GC Pressure (Ad Service)",
+        "service": "ad (Java)",
+        "effect": "Frequent full GC pauses causing latency spikes",
+        "detection": "JVM GC pause frequency and duration increase",
+        "promql": 'rate(jvm_gc_pause_seconds_count{service_name="ad"}[1m])',
+        "remediation": "Set flag to 'off'",
+    },
+    "adServiceFailure": {
+        "name": "Ad Service Failure",
+        "service": "ad (Java)",
+        "effect": "Ad service returns errors",
+        "detection": "Error rate spike on ad service",
+        "promql": 'rate(http_server_request_duration_seconds_count{service_name="ad",http_response_status_code=~"5.."}[5m])',
+        "remediation": "Set flag to 'off'",
+    },
+    "emailMemoryLeak": {  # requires otel-demo > v1.11.1
+        "name": "Memory Leak (Email Service)",
+        "service": "email (Ruby)",
+        "effect": "Gradual memory growth, eventual OOM kill",
+        "detection": "Rising memory usage, pod restarts with OOMKilled",
+        "promql": 'process_resident_memory_bytes{service_name="email"}',
+        "remediation": "Set flag to 'off', then restart the email pod",
+    },
+    "imageSlowLoad": {
+        "name": "Latency Spike (Image Provider)",
+        "service": "image-provider (Nginx)",
+        "effect": "5-10 second delays added to image responses",
+        "detection": "High p99 latency on image requests",
+        "promql": 'histogram_quantile(0.99, rate(http_server_request_duration_seconds_bucket{service_name="image-provider"}[5m]))',
+        "remediation": "Set flag to 'off'",
+    },
+    "kafkaQueueProblems": {
+        "name": "Kafka Queue Problems",
+        "service": "checkout/accounting/fraud-detection",
+        "effect": "Consumer lag increases, async processing delays",
+        "detection": "Kafka consumer lag growth",
+        "promql": 'kafka_consumer_lag{topic="orders"}',
+        "remediation": "Set flag to 'off'",
+    },
+    "recommendationServiceCacheFailure": {
+        "name": "Cache Failure (Recommendation)",
+        "service": "recommendation (Python)",
+        "effect": "Cache misses increase, all requests hit backend",
+        "detection": "Increased latency on recommendation service, cache miss rate",
+        "promql": "rate(recommendation_cache_miss_total[5m])",
+        "remediation": "Set flag to 'off'",
+    },
+    "productCatalogFailure": {
+        "name": "Product Catalog Failure",
+        "service": "product-catalog (Go)",
+        "effect": "Specific product queries fail with errors",
+        "detection": "Error spans in traces for product-catalog",
+        "promql": 'rate(http_server_request_duration_seconds_count{service_name="product-catalog",http_response_status_code=~"5.."}[5m])',
+        "remediation": "Set flag to 'off'",
+    },
+    "cartServiceFailure": {
+        "name": "Cart Service Failure",
+        "service": "cart (.NET)",
+        "effect": "Cart operations fail",
+        "detection": "Error rate on cart service",
+        "promql": 'rate(http_server_request_duration_seconds_count{service_name="cart",http_response_status_code=~"5.."}[5m])',
+        "remediation": "Set flag to 'off'",
+    },
+    "loadgeneratorFloodHomepage": {
+        "name": "Traffic Spike (Load Generator)",
+        "service": "All services (via load generator)",
+        "effect": "Massive request flood across all services",
+        "detection": "Request rate spike across all services",
+        "promql": "sum(rate(http_server_request_duration_seconds_count[1m]))",
+        "remediation": "Set flag to 'off'",
+    },
+    "llmInaccurateResponse": {  # requires otel-demo > v1.11.1
+        "name": "LLM Inaccuracy (Product Reviews)",
+        "service": "product-reviews (Go)",
+        "effect": "AI-generated product summaries return incorrect content",
+        "detection": "Data quality issue - check review content manually",
+        "promql": "",
+        "remediation": "Set flag to 'off'",
+    },
+    "llmRateLimitError": {  # requires otel-demo > v1.11.1
+        "name": "LLM Rate Limit (Product Reviews)",
+        "service": "product-reviews (Go)",
+        "effect": "Intermittent 429 rate limit errors from LLM",
+        "detection": "429 status codes in product-reviews logs",
+        "promql": 'rate(http_client_request_duration_seconds_count{service_name="product-reviews",http_response_status_code="429"}[5m])',
+        "remediation": "Set flag to 'off'",
+    },
+}
+
+
+def _is_flag_active(flag_config: dict) -> bool:
+    """Check if a flag is in an active (non-off) state."""
+    default = flag_config.get("defaultVariant", "off")
+    variants = flag_config.get("variants", {})
+    value = variants.get(default, 0)
+
+    if isinstance(value, bool):
+        return value is True
+    if isinstance(value, (int, float)):
+        return value != 0
+    return default != "off"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List incident scenarios")
+    parser.add_argument(
+        "--active-only",
+        action="store_true",
+        help="Only show currently active scenarios",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        flags = get_all_flags()
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    results = []
+    for flag_key, scenario in SCENARIOS.items():
+        flag_config = flags.get(flag_key, {})
+        default = flag_config.get("defaultVariant", "off")
+        variants = flag_config.get("variants", {})
+        current_value = variants.get(default, "?")
+        active = _is_flag_active(flag_config)
+
+        entry = {
+            "flag": flag_key,
+            "active": active,
+            "current_variant": default,
+            "current_value": current_value,
+            "available_variants": list(variants.keys()),
+            **scenario,
+        }
+
+        if args.active_only and not active:
+            continue
+
+        results.append(entry)
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+        return
+
+    print("=" * 80)
+    print("INCIDENT SCENARIOS (OTel Demo)")
+    print("=" * 80)
+
+    active_count = sum(1 for r in results if r["active"])
+
+    for entry in results:
+        status = "ACTIVE" if entry["active"] else "inactive"
+        print(f"\n  [{status:>8}] {entry['name']}")
+        print(
+            f"            Flag: {entry['flag']} = {entry['current_variant']} ({entry['current_value']})"
+        )
+        print(f"            Service: {entry['service']}")
+        print(f"            Effect: {entry['effect']}")
+        if entry["active"]:
+            print(f"            Remediation: {entry['remediation']}")
+
+    print(f"\n{'=' * 80}")
+    print(f"Total: {len(results)} scenarios, {active_count} active")
+    print("=" * 80)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/runtime-config-flagd/scripts/set_flag.py
+++ b/sre-agent/.claude/skills/runtime-config-flagd/scripts/set_flag.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Set a feature flag's default variant.
+
+Patches the flagd ConfigMap in Kubernetes, triggering hot-reload.
+
+Usage:
+    python set_flag.py <flag_key> <variant> [--dry-run]
+
+Examples:
+    python set_flag.py paymentFailure off
+    python set_flag.py paymentFailure 50% --dry-run
+    python set_flag.py adHighCpu on
+    python set_flag.py emailMemoryLeak off
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from flagd_client import set_flag_variant
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Set a feature flag's default variant")
+    parser.add_argument("flag_key", help="Flag key (e.g., paymentFailure)")
+    parser.add_argument("variant", help="Variant to set (e.g., off, on, 50%%)")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would change without applying",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        result = set_flag_variant(args.flag_key, args.variant, dry_run=args.dry_run)
+    except (ValueError, RuntimeError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return
+
+    prefix = "[DRY RUN] " if result["dry_run"] else ""
+    print("=" * 60)
+    print(f"{prefix}FLAG UPDATE")
+    print("=" * 60)
+    print(f"  Flag:      {result['flag']}")
+    print(f"  Previous:  {result['old_variant']} (value: {result['old_value']})")
+    print(f"  New:       {result['new_variant']} (value: {result['new_value']})")
+    if result["dry_run"]:
+        print("\n  This is a dry run. No changes were made.")
+        print("  Run without --dry-run to apply.")
+    else:
+        print("\n  ConfigMap updated. flagd will hot-reload within seconds.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/streaming-kafka/SKILL.md
+++ b/sre-agent/.claude/skills/streaming-kafka/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: streaming-kafka
+description: Kafka topic and consumer group management. Use when investigating Kafka topics, consumer lag, broker health, or consumer group status.
+allowed-tools: Bash(python *)
+---
+
+# Kafka Streaming
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `KAFKA_SASL_PASSWORD` in environment variables - it won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `KAFKA_BOOTSTRAP_SERVERS` - Kafka broker addresses
+- `KAFKA_SECURITY_PROTOCOL` - Security protocol (PLAINTEXT, SSL, SASL_SSL, SASL_PLAINTEXT)
+
+---
+
+## MANDATORY: Broker-First Investigation
+
+**Start with broker info, then check topics and consumer groups.**
+
+```
+BROKER INFO → LIST TOPICS → DESCRIBE TOPIC → CHECK CONSUMER LAG
+```
+
+## Available Scripts
+
+All scripts are in `.claude/skills/streaming-kafka/scripts/`
+
+### get_broker_info.py - ALWAYS START HERE
+```bash
+python .claude/skills/streaming-kafka/scripts/get_broker_info.py
+```
+
+### list_topics.py - List Topics
+```bash
+python .claude/skills/streaming-kafka/scripts/list_topics.py [--include-internal]
+```
+
+### describe_topic.py - Topic Details with Offsets
+```bash
+python .claude/skills/streaming-kafka/scripts/describe_topic.py --topic TOPIC_NAME
+```
+
+### list_consumer_groups.py - List Consumer Groups
+```bash
+python .claude/skills/streaming-kafka/scripts/list_consumer_groups.py
+```
+
+### describe_consumer_group.py - Consumer Group Details
+```bash
+python .claude/skills/streaming-kafka/scripts/describe_consumer_group.py --group GROUP_ID
+```
+
+### get_consumer_lag.py - Consumer Lag with Health Assessment
+```bash
+python .claude/skills/streaming-kafka/scripts/get_consumer_lag.py --group GROUP_ID [--topic TOPIC]
+```
+
+---
+
+## Consumer Lag Health Levels
+| Total Lag | Health |
+|-----------|--------|
+| 0 | healthy |
+| < 1,000 | minor_lag |
+| < 100,000 | lagging |
+| >= 100,000 | severely_lagging |
+
+---
+
+## Investigation Workflow
+
+### Consumer Lag Investigation
+```
+1. get_broker_info.py (verify cluster health)
+2. list_consumer_groups.py (find the group)
+3. get_consumer_lag.py --group <group-id> (check lag)
+4. describe_topic.py --topic <topic> (check partition details)
+```
+
+### Topic Issue Investigation
+```
+1. list_topics.py
+2. describe_topic.py --topic <topic> (partitions, configs, offsets)
+3. Check under-replicated partitions in output
+```

--- a/sre-agent/.claude/skills/streaming-kafka/scripts/describe_consumer_group.py
+++ b/sre-agent/.claude/skills/streaming-kafka/scripts/describe_consumer_group.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Get detailed information about a Kafka consumer group."""
+
+import argparse
+import sys
+
+from kafka_client import format_output, get_admin_client
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Describe Kafka consumer group")
+    parser.add_argument("--group", required=True, help="Consumer group ID")
+    args = parser.parse_args()
+
+    try:
+        admin = get_admin_client()
+
+        describe_futures = admin.describe_consumer_groups([args.group])
+
+        group_info = None
+        for gid, future in describe_futures.items():
+            try:
+                group_info = future.result()
+            except Exception as e:
+                print(format_output({"error": f"Failed to describe group: {e}"}))
+                sys.exit(1)
+
+        if not group_info:
+            print(format_output({"error": f"Consumer group '{args.group}' not found"}))
+            sys.exit(1)
+
+        members = []
+        for member in group_info.members:
+            assignment = []
+            if hasattr(member, "assignment") and member.assignment:
+                for tp in member.assignment.topic_partitions:
+                    assignment.append({"topic": tp.topic, "partition": tp.partition})
+
+            members.append(
+                {
+                    "member_id": member.member_id,
+                    "client_id": member.client_id,
+                    "host": member.host,
+                    "assignment": assignment,
+                }
+            )
+
+        print(
+            format_output(
+                {
+                    "group_id": args.group,
+                    "state": str(group_info.state),
+                    "coordinator": {
+                        "id": (
+                            group_info.coordinator.id
+                            if group_info.coordinator
+                            else None
+                        ),
+                        "host": (
+                            group_info.coordinator.host
+                            if group_info.coordinator
+                            else None
+                        ),
+                    },
+                    "protocol_type": group_info.protocol_type,
+                    "protocol": group_info.protocol,
+                    "member_count": len(members),
+                    "members": members,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e), "group": args.group}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/streaming-kafka/scripts/describe_topic.py
+++ b/sre-agent/.claude/skills/streaming-kafka/scripts/describe_topic.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Get detailed information about a Kafka topic."""
+
+import argparse
+import sys
+
+from kafka_client import format_output, get_admin_client, get_consumer
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Describe Kafka topic")
+    parser.add_argument("--topic", required=True, help="Topic name")
+    args = parser.parse_args()
+
+    try:
+        from confluent_kafka import TopicPartition
+        from confluent_kafka.admin import ConfigResource, ResourceType
+
+        admin = get_admin_client()
+        metadata = admin.list_topics(topic=args.topic, timeout=10)
+
+        if args.topic not in metadata.topics:
+            print(format_output({"error": f"Topic '{args.topic}' not found"}))
+            sys.exit(1)
+
+        topic_metadata = metadata.topics[args.topic]
+
+        partitions = []
+        for partition_id, partition_metadata in topic_metadata.partitions.items():
+            partitions.append(
+                {
+                    "id": partition_id,
+                    "leader": partition_metadata.leader,
+                    "replicas": list(partition_metadata.replicas),
+                    "isrs": list(partition_metadata.isrs),
+                    "in_sync": len(partition_metadata.isrs)
+                    == len(partition_metadata.replicas),
+                }
+            )
+
+        # Get topic config
+        config_resource = ConfigResource(ResourceType.TOPIC, args.topic)
+        config_futures = admin.describe_configs([config_resource])
+
+        topic_config = {}
+        for resource, future in config_futures.items():
+            try:
+                config = future.result()
+                for key, value in config.items():
+                    topic_config[key] = {
+                        "value": value.value,
+                        "source": str(value.source),
+                        "is_default": value.is_default,
+                    }
+            except Exception:
+                pass
+
+        # Get offsets
+        consumer = get_consumer()
+        partition_offsets = []
+        try:
+            for partition in partitions:
+                tp = TopicPartition(args.topic, partition["id"])
+                low, high = consumer.get_watermark_offsets(tp, timeout=5)
+                partition_offsets.append(
+                    {
+                        "partition": partition["id"],
+                        "low_offset": low,
+                        "high_offset": high,
+                        "message_count": high - low,
+                    }
+                )
+            consumer.close()
+        except Exception:
+            try:
+                consumer.close()
+            except Exception:
+                pass
+
+        total_messages = sum(p.get("message_count", 0) for p in partition_offsets)
+        under_replicated = [p for p in partitions if not p["in_sync"]]
+
+        print(
+            format_output(
+                {
+                    "name": args.topic,
+                    "partition_count": len(partitions),
+                    "replication_factor": (
+                        len(partitions[0]["replicas"]) if partitions else 0
+                    ),
+                    "total_messages": total_messages,
+                    "under_replicated_partitions": len(under_replicated),
+                    "partitions": partitions,
+                    "partition_offsets": partition_offsets,
+                    "config": topic_config,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e), "topic": args.topic}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/streaming-kafka/scripts/get_broker_info.py
+++ b/sre-agent/.claude/skills/streaming-kafka/scripts/get_broker_info.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Get Kafka broker information."""
+
+import sys
+
+from kafka_client import format_output, get_admin_client
+
+
+def main():
+    try:
+        admin = get_admin_client()
+        metadata = admin.list_topics(timeout=10)
+
+        brokers = []
+        for broker_id, broker in metadata.brokers.items():
+            brokers.append(
+                {
+                    "id": broker_id,
+                    "host": broker.host,
+                    "port": broker.port,
+                }
+            )
+
+        brokers.sort(key=lambda b: b["id"])
+
+        print(
+            format_output(
+                {
+                    "cluster_id": metadata.cluster_id,
+                    "controller_id": metadata.controller_id,
+                    "broker_count": len(brokers),
+                    "brokers": brokers,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/streaming-kafka/scripts/get_consumer_lag.py
+++ b/sre-agent/.claude/skills/streaming-kafka/scripts/get_consumer_lag.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Get consumer lag for a Kafka consumer group."""
+
+import argparse
+import sys
+
+from kafka_client import format_output, get_admin_client, get_consumer
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Kafka consumer lag")
+    parser.add_argument("--group", required=True, help="Consumer group ID")
+    parser.add_argument("--topic", help="Optional topic filter")
+    args = parser.parse_args()
+
+    try:
+        from confluent_kafka import TopicPartition
+
+        admin = get_admin_client()
+
+        # Get committed offsets
+        list_offsets_futures = admin.list_consumer_group_offsets([args.group])
+
+        committed_offsets = {}
+        for gid, future in list_offsets_futures.items():
+            try:
+                result = future.result()
+                for tp in result.topic_partitions:
+                    if args.topic and tp.topic != args.topic:
+                        continue
+                    committed_offsets[(tp.topic, tp.partition)] = tp.offset
+            except Exception:
+                pass
+
+        if not committed_offsets:
+            print(
+                format_output(
+                    {
+                        "group_id": args.group,
+                        "message": "No committed offsets found",
+                        "partitions": [],
+                    }
+                )
+            )
+            return
+
+        # Get high watermarks
+        consumer = get_consumer(f"{args.group}-lag-check")
+
+        partitions = []
+        total_lag = 0
+        topics_set = set()
+
+        try:
+            for (topic_name, partition), committed in committed_offsets.items():
+                tp = TopicPartition(topic_name, partition)
+                low, high = consumer.get_watermark_offsets(tp, timeout=5)
+
+                lag = max(0, high - committed if committed >= 0 else high - low)
+
+                partitions.append(
+                    {
+                        "topic": topic_name,
+                        "partition": partition,
+                        "committed_offset": committed,
+                        "high_watermark": high,
+                        "low_watermark": low,
+                        "lag": lag,
+                    }
+                )
+
+                total_lag += lag
+                topics_set.add(topic_name)
+
+            consumer.close()
+        except Exception:
+            try:
+                consumer.close()
+            except Exception:
+                pass
+
+        partitions.sort(key=lambda p: p["lag"], reverse=True)
+
+        if total_lag == 0:
+            health = "healthy"
+        elif total_lag < 1000:
+            health = "minor_lag"
+        elif total_lag < 100000:
+            health = "lagging"
+        else:
+            health = "severely_lagging"
+
+        print(
+            format_output(
+                {
+                    "group_id": args.group,
+                    "topic_filter": args.topic,
+                    "topics_subscribed": list(topics_set),
+                    "partition_count": len(partitions),
+                    "total_lag": total_lag,
+                    "health": health,
+                    "partitions": partitions,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e), "group": args.group}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/streaming-kafka/scripts/kafka_client.py
+++ b/sre-agent/.claude/skills/streaming-kafka/scripts/kafka_client.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Shared Kafka client with credential support.
+
+Credentials are injected transparently by the proxy layer.
+"""
+
+import json
+import os
+
+
+def get_config() -> dict[str, str | None]:
+    """Get Kafka configuration from environment."""
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+        "bootstrap_servers": os.getenv("KAFKA_BOOTSTRAP_SERVERS", ""),
+        "security_protocol": os.getenv("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT"),
+        "sasl_mechanism": os.getenv("KAFKA_SASL_MECHANISM"),
+        "sasl_username": os.getenv("KAFKA_SASL_USERNAME"),
+        "sasl_password": os.getenv("KAFKA_SASL_PASSWORD"),
+        "ssl_cafile": os.getenv("KAFKA_SSL_CAFILE"),
+    }
+
+
+def get_bootstrap_servers() -> str:
+    """Get Kafka bootstrap servers."""
+    servers = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "")
+    if not servers:
+        raise RuntimeError("KAFKA_BOOTSTRAP_SERVERS must be set")
+    return servers
+
+
+def _build_base_config() -> dict:
+    """Build base Kafka client configuration."""
+    config = get_config()
+    base = {
+        "bootstrap.servers": config["bootstrap_servers"],
+        "security.protocol": config.get("security_protocol") or "PLAINTEXT",
+    }
+
+    security_protocol = base["security.protocol"]
+
+    if security_protocol in ("SASL_SSL", "SASL_PLAINTEXT"):
+        base["sasl.mechanism"] = config.get("sasl_mechanism") or "PLAIN"
+        if config.get("sasl_username"):
+            base["sasl.username"] = config["sasl_username"]
+        if config.get("sasl_password"):
+            base["sasl.password"] = config["sasl_password"]
+
+    if security_protocol in ("SSL", "SASL_SSL"):
+        if config.get("ssl_cafile"):
+            base["ssl.ca.location"] = config["ssl_cafile"]
+
+    return base
+
+
+def get_admin_client():
+    """Get Kafka AdminClient."""
+    from confluent_kafka.admin import AdminClient
+
+    return AdminClient(_build_base_config())
+
+
+def get_consumer(group_id: str = "opensre-admin"):
+    """Get Kafka Consumer for offset queries."""
+    from confluent_kafka import Consumer
+
+    cfg = _build_base_config()
+    cfg["group.id"] = group_id
+    cfg["auto.offset.reset"] = "earliest"
+    cfg["enable.auto.commit"] = False
+    return Consumer(cfg)
+
+
+def format_output(data: dict) -> str:
+    """Format output as JSON string."""
+    return json.dumps(data, indent=2, default=str)

--- a/sre-agent/.claude/skills/streaming-kafka/scripts/list_consumer_groups.py
+++ b/sre-agent/.claude/skills/streaming-kafka/scripts/list_consumer_groups.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""List Kafka consumer groups."""
+
+import sys
+
+from kafka_client import format_output, get_admin_client
+
+
+def main():
+    try:
+        admin = get_admin_client()
+
+        groups_future = admin.list_consumer_groups()
+        groups_result = groups_future.result()
+
+        groups = []
+        for group in groups_result.valid:
+            groups.append(
+                {
+                    "group_id": group.group_id,
+                    "is_simple": group.is_simple_consumer_group,
+                    "state": str(group.state) if hasattr(group, "state") else None,
+                }
+            )
+
+        groups.sort(key=lambda g: g["group_id"])
+
+        print(
+            format_output(
+                {
+                    "group_count": len(groups),
+                    "groups": groups,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/streaming-kafka/scripts/list_topics.py
+++ b/sre-agent/.claude/skills/streaming-kafka/scripts/list_topics.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""List Kafka topics."""
+
+import argparse
+import sys
+
+from kafka_client import format_output, get_admin_client
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List Kafka topics")
+    parser.add_argument(
+        "--include-internal", action="store_true", help="Include internal topics (__*)"
+    )
+    args = parser.parse_args()
+
+    try:
+        admin = get_admin_client()
+        metadata = admin.list_topics(timeout=10)
+
+        topics = []
+        for topic_name, topic_metadata in metadata.topics.items():
+            if not args.include_internal and topic_name.startswith("__"):
+                continue
+
+            partitions = []
+            for partition_id, partition_metadata in topic_metadata.partitions.items():
+                partitions.append(
+                    {
+                        "id": partition_id,
+                        "leader": partition_metadata.leader,
+                        "replicas": list(partition_metadata.replicas),
+                        "isrs": list(partition_metadata.isrs),
+                    }
+                )
+
+            topics.append(
+                {
+                    "name": topic_name,
+                    "partition_count": len(topic_metadata.partitions),
+                    "partitions": partitions,
+                }
+            )
+
+        topics.sort(key=lambda t: t["name"])
+
+        print(
+            format_output(
+                {
+                    "cluster_id": metadata.cluster_id,
+                    "broker_count": len(metadata.brokers),
+                    "topic_count": len(topics),
+                    "topics": topics,
+                }
+            )
+        )
+
+    except Exception as e:
+        print(format_output({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/test_backends_direct.py
+++ b/sre-agent/.claude/skills/test_backends_direct.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""
+Direct backend testing - bypasses credential proxy for validation.
+Tests that each backend API is accessible and returns valid data.
+"""
+
+import json
+import ssl
+import urllib.error
+import urllib.request
+from base64 import b64encode
+from datetime import datetime, timedelta, timezone
+
+
+def test_result(name: str, success: bool, message: str, data: any = None):
+    status = "✅ PASS" if success else "❌ FAIL"
+    print(f"\n{status} {name}")
+    print(f"   {message}")
+    if data and not success:
+        print(f"   Response: {str(data)[:200]}")
+
+
+# =============================================================================
+# ELASTICSEARCH
+# =============================================================================
+def test_elasticsearch():
+    print("\n" + "=" * 60)
+    print("ELASTICSEARCH")
+    print("=" * 60)
+
+    url = "https://a6f123d4974844f938d66fd05676392b-1823852830.us-west-2.elb.amazonaws.com:9200"
+    user = "elastic"
+    password = "REDACTED"  # Rotated - use env var or secrets manager
+
+    auth = b64encode(f"{user}:{password}".encode()).decode()
+    headers = {"Authorization": f"Basic {auth}", "Content-Type": "application/json"}
+
+    # Skip SSL verification for self-signed certs
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+    # Test 1: Cluster health
+    try:
+        req = urllib.request.Request(f"{url}/_cluster/health", headers=headers)
+        with urllib.request.urlopen(req, context=ctx, timeout=10) as resp:
+            data = json.loads(resp.read())
+            test_result(
+                "Cluster Health",
+                True,
+                f"Status: {data.get('status')}, Nodes: {data.get('number_of_nodes')}",
+            )
+    except Exception as e:
+        test_result("Cluster Health", False, str(e))
+
+    # Test 2: List indices
+    try:
+        req = urllib.request.Request(f"{url}/_cat/indices?format=json", headers=headers)
+        with urllib.request.urlopen(req, context=ctx, timeout=10) as resp:
+            data = json.loads(resp.read())
+            test_result("List Indices", True, f"Found {len(data)} indices")
+            for idx in data[:5]:
+                print(f"      - {idx.get('index')}: {idx.get('docs.count')} docs")
+    except Exception as e:
+        test_result("List Indices", False, str(e))
+
+    # Test 3: Search logs
+    try:
+        search_body = json.dumps({"query": {"match_all": {}}, "size": 5}).encode()
+        req = urllib.request.Request(
+            f"{url}/logs-*/_search", data=search_body, headers=headers, method="POST"
+        )
+        with urllib.request.urlopen(req, context=ctx, timeout=10) as resp:
+            data = json.loads(resp.read())
+            hits = data.get("hits", {}).get("total", {})
+            count = hits.get("value", 0) if isinstance(hits, dict) else hits
+            test_result("Search Logs", True, f"Total docs: {count}")
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            test_result("Search Logs", True, "No logs-* index (expected if no data)")
+        else:
+            test_result(
+                "Search Logs", False, f"HTTP {e.code}: {e.read().decode()[:100]}"
+            )
+    except Exception as e:
+        test_result("Search Logs", False, str(e))
+
+
+# =============================================================================
+# GRAFANA
+# =============================================================================
+def test_grafana():
+    print("\n" + "=" * 60)
+    print("GRAFANA")
+    print("=" * 60)
+
+    url = (
+        "http://abffcf5b990ec4bd685aef627eb2daf1-1789943242.us-west-2.elb.amazonaws.com"
+    )
+    user = "admin"
+    password = "REDACTED"  # Rotated - use env var or secrets manager
+
+    auth = b64encode(f"{user}:{password}".encode()).decode()
+    headers = {"Authorization": f"Basic {auth}", "Content-Type": "application/json"}
+
+    # Test 1: Health check
+    try:
+        req = urllib.request.Request(f"{url}/api/health", headers=headers)
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            test_result("Health Check", True, f"Version: {data.get('version')}")
+    except Exception as e:
+        test_result("Health Check", False, str(e))
+
+    # Test 2: List datasources
+    try:
+        req = urllib.request.Request(f"{url}/api/datasources", headers=headers)
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            test_result("List Datasources", True, f"Found {len(data)} datasources")
+            for ds in data[:5]:
+                print(f"      - {ds.get('name')} ({ds.get('type')})")
+    except Exception as e:
+        test_result("List Datasources", False, str(e))
+
+    # Test 3: List dashboards
+    try:
+        req = urllib.request.Request(f"{url}/api/search?type=dash-db", headers=headers)
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            test_result("List Dashboards", True, f"Found {len(data)} dashboards")
+            for dash in data[:5]:
+                print(f"      - {dash.get('title')}")
+    except Exception as e:
+        test_result("List Dashboards", False, str(e))
+
+
+# =============================================================================
+# CORALOGIX
+# =============================================================================
+def test_coralogix():
+    print("\n" + "=" * 60)
+    print("CORALOGIX")
+    print("=" * 60)
+
+    api_key = "REDACTED"  # Rotated - use env var or secrets manager
+    api_url = "https://ng-api-http.cx498.coralogix.com"
+
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+    # Test 1: Query logs
+    try:
+        query_body = json.dumps({"query": "source logs | limit 5"}).encode()
+        req = urllib.request.Request(
+            f"{api_url}/api/v1/dataprime/query",
+            data=query_body,
+            headers=headers,
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+            if "queryId" in data:
+                test_result(
+                    "Query Logs",
+                    True,
+                    f"Query ID: {data['queryId'].get('queryId', 'N/A')[:20]}...",
+                )
+            else:
+                test_result("Query Logs", True, f"Response: {str(data)[:100]}")
+    except Exception as e:
+        test_result("Query Logs", False, str(e))
+
+    # Test 2: Check services (aggregation)
+    try:
+        query_body = json.dumps(
+            {
+                "query": "source logs | groupby $l.subsystemname aggregate count() as cnt | limit 10"
+            }
+        ).encode()
+        req = urllib.request.Request(
+            f"{api_url}/api/v1/dataprime/query",
+            data=query_body,
+            headers=headers,
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+            test_result("List Services", True, "Aggregation query accepted")
+    except Exception as e:
+        test_result("List Services", False, str(e))
+
+
+# =============================================================================
+# DATADOG
+# =============================================================================
+def test_datadog():
+    print("\n" + "=" * 60)
+    print("DATADOG")
+    print("=" * 60)
+
+    api_key = "REDACTED"  # Rotated - use env var or secrets manager
+    app_key = "REDACTED"  # Rotated - use env var or secrets manager
+    site = "us5.datadoghq.com"
+
+    headers = {
+        "DD-API-KEY": api_key,
+        "DD-APPLICATION-KEY": app_key,
+        "Content-Type": "application/json",
+    }
+
+    # Test 1: Validate keys
+    try:
+        req = urllib.request.Request(
+            f"https://api.{site}/api/v1/validate", headers=headers
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            test_result(
+                "Validate API Keys",
+                data.get("valid", False),
+                f"Valid: {data.get('valid')}",
+            )
+    except Exception as e:
+        test_result("Validate API Keys", False, str(e))
+
+    # Test 2: List monitors
+    try:
+        req = urllib.request.Request(
+            f"https://api.{site}/api/v1/monitor", headers=headers
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            count = len(data) if isinstance(data, list) else 0
+            test_result("List Monitors", True, f"Found {count} monitors")
+    except Exception as e:
+        test_result("List Monitors", False, str(e))
+
+    # Test 3: Query logs (last 15 min)
+    try:
+        now = datetime.now(timezone.utc)
+        start = now - timedelta(minutes=15)
+        query_body = json.dumps(
+            {
+                "filter": {
+                    "query": "*",
+                    "from": start.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "to": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                "page": {"limit": 5},
+            }
+        ).encode()
+        req = urllib.request.Request(
+            f"https://api.{site}/api/v2/logs/events/search",
+            data=query_body,
+            headers=headers,
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+            logs = data.get("data", [])
+            test_result("Query Logs", True, f"Found {len(logs)} logs in last 15min")
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()[:200]
+        test_result("Query Logs", False, f"HTTP {e.code}: {body}")
+    except Exception as e:
+        test_result("Query Logs", False, str(e))
+
+
+# =============================================================================
+# JAEGER (skipped - ingress routing issue)
+# =============================================================================
+def test_jaeger():
+    print("\n" + "=" * 60)
+    print("JAEGER")
+    print("=" * 60)
+
+    url = "http://k8s-oteldemo-jaegerpu-ddab1a4609-a8c87825ebcf8ab1.elb.us-west-2.amazonaws.com"
+
+    # Try multiple API paths
+    paths = ["/api/services", "/jaeger/api/services", "/query/api/services"]
+
+    for path in paths:
+        try:
+            req = urllib.request.Request(f"{url}{path}")
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                content_type = resp.headers.get("Content-Type", "")
+                if "json" in content_type:
+                    data = json.loads(resp.read())
+                    test_result(
+                        f"API {path}", True, f"Found services: {data.get('data', [])}"
+                    )
+                    return
+                else:
+                    # HTML response = wrong path
+                    continue
+        except Exception:
+            continue
+
+    test_result(
+        "Jaeger API", False, "All API paths return HTML (ingress routing issue)"
+    )
+    print(
+        "   ⚠️  Jaeger needs ingress configuration to expose /api/* separately from UI"
+    )
+
+
+# =============================================================================
+# MAIN
+# =============================================================================
+if __name__ == "__main__":
+    print("=" * 60)
+    print("SRE Agent - Direct Backend Validation")
+    print("=" * 60)
+
+    test_elasticsearch()
+    test_grafana()
+    test_coralogix()
+    test_datadog()
+    test_jaeger()
+
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print("""
+✅ Elasticsearch - Working (has logs-test index)
+✅ Grafana - Working (v12.2.0)
+✅ Coralogix - Working (DataPrime API responding)
+✅ Datadog - Working (API keys valid)
+⚠️  Jaeger - Needs ingress fix (API returns UI HTML)
+❌ Prometheus - DNS not resolving (endpoint may be down)
+""")

--- a/sre-agent/.claude/skills/test_skills.py
+++ b/sre-agent/.claude/skills/test_skills.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""
+Test harness for SRE Agent observability skills.
+
+Tests each skill's scripts against real backends to validate:
+1. Scripts execute without errors
+2. API connectivity works
+3. Response structure is valid
+
+Usage:
+    # Set credentials as environment variables, then run:
+    python test_skills.py
+
+    # Or test specific skill:
+    python test_skills.py --skill jaeger
+
+Required environment variables per skill:
+    ClickUp:       CLICKUP_API_TOKEN
+    Coralogix:     CORALOGIX_DOMAIN, CORALOGIX_API_KEY
+    Datadog:       DATADOG_SITE, DATADOG_API_KEY, DATADOG_APP_KEY
+    Elasticsearch: ELASTICSEARCH_URL (optional: ES_USER, ES_PASSWORD)
+    Honeycomb:     HONEYCOMB_API_KEY
+    Jaeger:        JAEGER_URL
+    Prometheus:    PROMETHEUS_URL
+    Grafana:       GRAFANA_URL, GRAFANA_API_KEY
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class TestResult:
+    skill: str
+    script: str
+    passed: bool
+    output: str
+    error: str = ""
+
+
+SKILLS_DIR = Path(__file__).parent
+
+
+def run_script(
+    skill_dir: str, script: str, args: list[str] = None, env_override: dict = None
+) -> TestResult:
+    """Run a skill script and capture output."""
+    script_path = SKILLS_DIR / skill_dir / "scripts" / script
+
+    if not script_path.exists():
+        return TestResult(
+            skill=skill_dir,
+            script=script,
+            passed=False,
+            output="",
+            error=f"Script not found: {script_path}",
+        )
+
+    cmd = [sys.executable, str(script_path)]
+    if args:
+        cmd.extend(args)
+
+    env = os.environ.copy()
+    if env_override:
+        env.update(env_override)
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+            cwd=str(SKILLS_DIR / skill_dir / "scripts"),
+        )
+
+        if result.returncode != 0:
+            return TestResult(
+                skill=skill_dir,
+                script=script,
+                passed=False,
+                output=result.stdout,
+                error=result.stderr or f"Exit code: {result.returncode}",
+            )
+
+        return TestResult(
+            skill=skill_dir, script=script, passed=True, output=result.stdout
+        )
+    except subprocess.TimeoutExpired:
+        return TestResult(
+            skill=skill_dir,
+            script=script,
+            passed=False,
+            output="",
+            error="Timeout after 30 seconds",
+        )
+    except Exception as e:
+        return TestResult(
+            skill=skill_dir, script=script, passed=False, output="", error=str(e)
+        )
+
+
+def validate_json_output(result: TestResult) -> TestResult:
+    """Validate that output is valid JSON."""
+    if not result.passed:
+        return result
+
+    try:
+        data = json.loads(result.output)
+        # Check for common error patterns in response
+        if isinstance(data, dict):
+            if data.get("error") or data.get("errors"):
+                result.passed = False
+                result.error = (
+                    f"API error in response: {data.get('error') or data.get('errors')}"
+                )
+        return result
+    except json.JSONDecodeError:
+        # Not JSON output - that's OK for non-json mode
+        return result
+
+
+def check_env_vars(required: list[str]) -> tuple[bool, list[str]]:
+    """Check if required environment variables are set."""
+    missing = [var for var in required if not os.environ.get(var)]
+    return len(missing) == 0, missing
+
+
+# =============================================================================
+# Skill Test Definitions
+# =============================================================================
+
+
+def test_coralogix() -> list[TestResult]:
+    """Test Coralogix skill."""
+    results = []
+
+    ok, missing = check_env_vars(["CORALOGIX_DOMAIN", "CORALOGIX_API_KEY"])
+    if not ok:
+        return [
+            TestResult(
+                skill="observability-coralogix",
+                script="(env check)",
+                passed=False,
+                output="",
+                error=f"Missing env vars: {', '.join(missing)}",
+            )
+        ]
+
+    # Test list_services.py
+    result = run_script("observability-coralogix", "list_services.py", ["--json"])
+    result = validate_json_output(result)
+    results.append(result)
+
+    # Test get_statistics.py
+    result = run_script(
+        "observability-coralogix", "get_statistics.py", ["--time-range", "30", "--json"]
+    )
+    result = validate_json_output(result)
+    results.append(result)
+
+    return results
+
+
+def test_datadog() -> list[TestResult]:
+    """Test Datadog skill."""
+    results = []
+
+    ok, missing = check_env_vars(["DATADOG_SITE", "DATADOG_API_KEY", "DATADOG_APP_KEY"])
+    if not ok:
+        return [
+            TestResult(
+                skill="observability-datadog",
+                script="(env check)",
+                passed=False,
+                output="",
+                error=f"Missing env vars: {', '.join(missing)}",
+            )
+        ]
+
+    # Test get_statistics.py
+    result = run_script(
+        "observability-datadog", "get_statistics.py", ["--time-range", "30", "--json"]
+    )
+    result = validate_json_output(result)
+    results.append(result)
+
+    return results
+
+
+def test_elasticsearch() -> list[TestResult]:
+    """Test Elasticsearch skill."""
+    results = []
+
+    ok, missing = check_env_vars(["ELASTICSEARCH_URL"])
+    if not ok:
+        return [
+            TestResult(
+                skill="observability-elasticsearch",
+                script="(env check)",
+                passed=False,
+                output="",
+                error=f"Missing env vars: {', '.join(missing)}",
+            )
+        ]
+
+    # Test get_statistics.py
+    result = run_script(
+        "observability-elasticsearch",
+        "get_statistics.py",
+        ["--time-range", "30", "--json"],
+    )
+    result = validate_json_output(result)
+    results.append(result)
+
+    return results
+
+
+def test_jaeger() -> list[TestResult]:
+    """Test Jaeger skill."""
+    results = []
+
+    ok, missing = check_env_vars(["JAEGER_URL"])
+    if not ok:
+        return [
+            TestResult(
+                skill="observability-jaeger",
+                script="(env check)",
+                passed=False,
+                output="",
+                error=f"Missing env vars: {', '.join(missing)}",
+            )
+        ]
+
+    # Test list_services.py
+    result = run_script("observability-jaeger", "list_services.py", ["--json"])
+    result = validate_json_output(result)
+    results.append(result)
+
+    # Test list_operations.py (if we have services)
+    if result.passed and result.output:
+        try:
+            data = json.loads(result.output)
+            services = data.get("services", [])
+            if services:
+                result2 = run_script(
+                    "observability-jaeger",
+                    "list_operations.py",
+                    [services[0], "--json"],
+                )
+                result2 = validate_json_output(result2)
+                results.append(result2)
+        except Exception:
+            pass
+
+    return results
+
+
+def test_prometheus() -> list[TestResult]:
+    """Test Prometheus skill (via metrics-analysis)."""
+    results = []
+
+    ok, missing = check_env_vars(["PROMETHEUS_URL"])
+    if not ok:
+        return [
+            TestResult(
+                skill="metrics-analysis",
+                script="(env check)",
+                passed=False,
+                output="",
+                error=f"Missing env vars: {', '.join(missing)}",
+            )
+        ]
+
+    # Test query_prometheus.py with a simple query
+    result = run_script("metrics-analysis", "query_prometheus.py", ["up", "--json"])
+    result = validate_json_output(result)
+    results.append(result)
+
+    return results
+
+
+def test_grafana() -> list[TestResult]:
+    """Test Grafana skill (via metrics-analysis)."""
+    results = []
+
+    ok, missing = check_env_vars(["GRAFANA_URL", "GRAFANA_API_KEY"])
+    if not ok:
+        return [
+            TestResult(
+                skill="metrics-analysis",
+                script="(env check)",
+                passed=False,
+                output="",
+                error=f"Missing env vars: {', '.join(missing)}",
+            )
+        ]
+
+    # Test list_dashboards.py
+    result = run_script("metrics-analysis", "list_dashboards.py", ["--json"])
+    result = validate_json_output(result)
+    results.append(result)
+
+    return results
+
+
+def test_honeycomb() -> list[TestResult]:
+    """Test Honeycomb skill."""
+    results = []
+
+    ok, missing = check_env_vars(["HONEYCOMB_API_KEY"])
+    if not ok:
+        return [
+            TestResult(
+                skill="observability-honeycomb",
+                script="(env check)",
+                passed=False,
+                output="",
+                error=f"Missing env vars: {', '.join(missing)}",
+            )
+        ]
+
+    # Test list_datasets.py
+    result = run_script("observability-honeycomb", "list_datasets.py", ["--json"])
+    result = validate_json_output(result)
+    results.append(result)
+
+    # If we have datasets, test get_statistics on the first one
+    if result.passed and result.output:
+        try:
+            data = json.loads(result.output)
+            if data and len(data) > 0:
+                dataset_slug = data[0].get("slug")
+                if dataset_slug:
+                    result2 = run_script(
+                        "observability-honeycomb",
+                        "get_statistics.py",
+                        [dataset_slug, "--time-range", "3600", "--json"],
+                    )
+                    result2 = validate_json_output(result2)
+                    results.append(result2)
+
+                    # Test run_query.py
+                    result3 = run_script(
+                        "observability-honeycomb",
+                        "run_query.py",
+                        [dataset_slug, "--calc", "COUNT", "--json"],
+                    )
+                    result3 = validate_json_output(result3)
+                    results.append(result3)
+        except json.JSONDecodeError:
+            pass
+
+    return results
+
+
+def test_clickup() -> list[TestResult]:
+    """Test ClickUp skill."""
+    results = []
+
+    ok, missing = check_env_vars(["CLICKUP_API_TOKEN"])
+    if not ok:
+        return [
+            TestResult(
+                skill="project-clickup",
+                script="(env check)",
+                passed=False,
+                output="",
+                error=f"Missing env vars: {', '.join(missing)}",
+            )
+        ]
+
+    # Test list_spaces.py
+    result = run_script("project-clickup", "list_spaces.py", ["--json"])
+    result = validate_json_output(result)
+    results.append(result)
+
+    # Test search_tasks.py (basic search)
+    result2 = run_script(
+        "project-clickup", "search_tasks.py", ["--limit", "5", "--json"]
+    )
+    result2 = validate_json_output(result2)
+    results.append(result2)
+
+    return results
+
+
+# =============================================================================
+# Main Test Runner
+# =============================================================================
+
+SKILL_TESTS = {
+    "coralogix": test_coralogix,
+    "datadog": test_datadog,
+    "elasticsearch": test_elasticsearch,
+    "honeycomb": test_honeycomb,
+    "jaeger": test_jaeger,
+    "prometheus": test_prometheus,
+    "grafana": test_grafana,
+    "clickup": test_clickup,
+}
+
+
+def print_result(result: TestResult):
+    """Print a single test result."""
+    status = "✅ PASS" if result.passed else "❌ FAIL"
+    print(f"  {status} {result.script}")
+    if not result.passed and result.error:
+        # Indent error message
+        for line in result.error.strip().split("\n")[:5]:  # Limit to 5 lines
+            print(f"         {line}")
+    elif result.passed and result.output:
+        # Show truncated output for passed tests
+        lines = result.output.strip().split("\n")
+        if len(lines) > 3:
+            print(f"         Output: {lines[0][:60]}... ({len(lines)} lines)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Test SRE Agent skills")
+    parser.add_argument(
+        "--skill",
+        "-s",
+        choices=list(SKILL_TESTS.keys()),
+        help="Test specific skill only",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Show full output for passed tests"
+    )
+    args = parser.parse_args()
+
+    print("=" * 60)
+    print("SRE Agent Skills Test Harness")
+    print("=" * 60)
+    print()
+
+    skills_to_test = [args.skill] if args.skill else list(SKILL_TESTS.keys())
+
+    all_results = []
+
+    for skill_name in skills_to_test:
+        print(f"Testing: {skill_name}")
+        print("-" * 40)
+
+        test_func = SKILL_TESTS[skill_name]
+        results = test_func()
+        all_results.extend(results)
+
+        for result in results:
+            print_result(result)
+
+        print()
+
+    # Summary
+    print("=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+
+    passed = sum(1 for r in all_results if r.passed)
+    failed = sum(1 for r in all_results if not r.passed)
+
+    print(f"Total:  {len(all_results)} tests")
+    print(f"Passed: {passed}")
+    print(f"Failed: {failed}")
+    print()
+
+    if failed > 0:
+        print("Failed tests:")
+        for r in all_results:
+            if not r.passed:
+                print(f"  - {r.skill}/{r.script}: {r.error[:50]}")
+        sys.exit(1)
+    else:
+        print("All tests passed! ✅")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/vcs-gitlab/SKILL.md
+++ b/sre-agent/.claude/skills/vcs-gitlab/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: vcs-gitlab
+description: GitLab project management, CI/CD pipelines, merge requests, and code review. Use when investigating GitLab projects, pipeline failures, merge requests, commits, or issues.
+allowed-tools: Bash(python *)
+---
+
+# GitLab Integration
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `GITLAB_TOKEN` in environment variables - it won't be visible to you. Just run the scripts directly; authentication is handled transparently.
+
+Configuration environment variables you CAN check (non-secret):
+- `GITLAB_URL` - GitLab instance URL (default: `https://gitlab.com`)
+
+---
+
+## Available Scripts
+
+All scripts are in `.claude/skills/vcs-gitlab/scripts/`
+
+### PROJECT SCRIPTS
+
+#### list_projects.py
+```bash
+python .claude/skills/vcs-gitlab/scripts/list_projects.py [--search "query"] [--visibility private]
+```
+
+#### get_project.py
+```bash
+python .claude/skills/vcs-gitlab/scripts/get_project.py --project "group/project"
+```
+
+### CI/CD PIPELINE SCRIPTS
+
+#### get_pipelines.py
+```bash
+python .claude/skills/vcs-gitlab/scripts/get_pipelines.py --project "group/project" [--status failed] [--ref main]
+```
+
+#### get_pipeline_jobs.py
+```bash
+python .claude/skills/vcs-gitlab/scripts/get_pipeline_jobs.py --project "group/project" --pipeline-id 12345
+```
+
+### MERGE REQUEST SCRIPTS
+
+#### list_merge_requests.py
+```bash
+python .claude/skills/vcs-gitlab/scripts/list_merge_requests.py --project "group/project" [--state opened]
+```
+
+#### get_mr.py
+```bash
+python .claude/skills/vcs-gitlab/scripts/get_mr.py --project "group/project" --mr-iid 42
+```
+
+#### get_mr_changes.py
+```bash
+python .claude/skills/vcs-gitlab/scripts/get_mr_changes.py --project "group/project" --mr-iid 42
+```
+
+### COMMIT SCRIPTS
+
+#### list_commits.py
+```bash
+python .claude/skills/vcs-gitlab/scripts/list_commits.py --project "group/project" [--ref main] [--since "2026-01-01T00:00:00Z"]
+```
+
+#### get_commit.py
+```bash
+python .claude/skills/vcs-gitlab/scripts/get_commit.py --project "group/project" --sha abc1234
+```
+
+### BRANCH/ISSUE SCRIPTS
+
+#### list_branches.py
+```bash
+python .claude/skills/vcs-gitlab/scripts/list_branches.py --project "group/project" [--search "feature"]
+```
+
+#### list_issues.py
+```bash
+python .claude/skills/vcs-gitlab/scripts/list_issues.py --project "group/project" [--state opened] [--labels "bug,critical"]
+```
+
+#### create_issue.py
+```bash
+python .claude/skills/vcs-gitlab/scripts/create_issue.py --project "group/project" --title "Title" [--description "Details"]
+```
+
+---
+
+## Investigation Workflows
+
+### Pipeline Failure Investigation
+```
+1. get_pipelines.py --project X --status failed
+2. get_pipeline_jobs.py --project X --pipeline-id <id>
+3. get_commit.py --project X --sha <sha>
+4. get_mr.py --project X --mr-iid <iid>
+```
+
+### Deployment Correlation
+```
+1. list_commits.py --project X --ref main --since "2026-01-15T00:00:00Z"
+2. list_merge_requests.py --project X --state merged
+3. get_mr_changes.py --project X --mr-iid <iid>
+```

--- a/sre-agent/.claude/skills/vcs-gitlab/scripts/create_issue.py
+++ b/sre-agent/.claude/skills/vcs-gitlab/scripts/create_issue.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Create a new issue in a GitLab project.
+
+Usage:
+    python create_issue.py --project "group/project" --title "Title" [--description "Details"]
+"""
+
+import argparse
+import json
+import sys
+
+from gitlab_client import encode_project, gitlab_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create GitLab issue")
+    parser.add_argument("--project", required=True, help="Project ID or path")
+    parser.add_argument("--title", required=True, help="Issue title")
+    parser.add_argument(
+        "--description", default="", help="Issue description (markdown)"
+    )
+    parser.add_argument("--labels", default="", help="Comma-separated labels")
+    parser.add_argument("--assignee-ids", default="", help="Comma-separated user IDs")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        issue_data = {"title": args.title}
+        if args.description:
+            issue_data["description"] = args.description
+        if args.labels:
+            issue_data["labels"] = args.labels
+        if args.assignee_ids:
+            issue_data["assignee_ids"] = [
+                int(x.strip()) for x in args.assignee_ids.split(",")
+            ]
+
+        issue = gitlab_request(
+            "POST",
+            f"projects/{encode_project(args.project)}/issues",
+            json_body=issue_data,
+        )
+        result = {
+            "ok": True,
+            "iid": issue["iid"],
+            "title": issue["title"],
+            "web_url": issue["web_url"],
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Created: #{result['iid']} - {result['title']}")
+            print(f"URL: {result['web_url']}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/vcs-gitlab/scripts/get_commit.py
+++ b/sre-agent/.claude/skills/vcs-gitlab/scripts/get_commit.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Get details of a specific GitLab commit.
+
+Usage:
+    python get_commit.py --project "group/project" --sha abc1234
+"""
+
+import argparse
+import json
+import sys
+
+from gitlab_client import encode_project, gitlab_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get commit details")
+    parser.add_argument("--project", required=True, help="Project ID or path")
+    parser.add_argument("--sha", required=True, help="Commit SHA")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        proj = encode_project(args.project)
+        commit = gitlab_request("GET", f"projects/{proj}/repository/commits/{args.sha}")
+        diff = gitlab_request(
+            "GET",
+            f"projects/{proj}/repository/commits/{args.sha}/diff",
+            params={"per_page": 100},
+        )
+
+        files = [
+            {
+                "old_path": d.get("old_path"),
+                "new_path": d.get("new_path"),
+                "new_file": d.get("new_file"),
+                "deleted_file": d.get("deleted_file"),
+                "diff": d.get("diff", "")[:1000],
+            }
+            for d in (diff or [])[:100]
+        ]
+
+        result = {
+            "ok": True,
+            "id": commit["id"],
+            "short_id": commit["short_id"],
+            "title": commit["title"],
+            "message": commit.get("message"),
+            "author_name": commit["author_name"],
+            "author_email": commit.get("author_email"),
+            "created_at": commit["created_at"],
+            "web_url": commit.get("web_url"),
+            "parent_ids": commit.get("parent_ids", []),
+            "stats": commit.get("stats", {}),
+            "files_changed": files,
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Commit: {result['short_id']} - {result['title']}")
+            print(f"Author: {result['author_name']} | {result['created_at']}")
+            stats = result.get("stats", {})
+            if stats:
+                print(
+                    f"Changes: +{stats.get('additions', 0)} -{stats.get('deletions', 0)}"
+                )
+            if files:
+                print(f"\nFiles ({len(files)}):")
+                for f in files:
+                    print(f"  {f.get('new_path', f.get('old_path', '?'))}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/vcs-gitlab/scripts/get_mr.py
+++ b/sre-agent/.claude/skills/vcs-gitlab/scripts/get_mr.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Get details of a specific merge request.
+
+Usage:
+    python get_mr.py --project "group/project" --mr-iid 42
+"""
+
+import argparse
+import json
+import sys
+
+from gitlab_client import encode_project, gitlab_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get merge request details")
+    parser.add_argument("--project", required=True, help="Project ID or path")
+    parser.add_argument("--mr-iid", required=True, type=int, help="MR IID")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        mr = gitlab_request(
+            "GET",
+            f"projects/{encode_project(args.project)}/merge_requests/{args.mr_iid}",
+        )
+
+        result = {
+            "ok": True,
+            "iid": mr["iid"],
+            "title": mr["title"],
+            "description": mr.get("description"),
+            "state": mr["state"],
+            "source_branch": mr["source_branch"],
+            "target_branch": mr["target_branch"],
+            "author": mr.get("author", {}).get("name") if mr.get("author") else None,
+            "assignees": [a.get("name") for a in mr.get("assignees", [])],
+            "reviewers": [r.get("name") for r in mr.get("reviewers", [])],
+            "labels": mr.get("labels", []),
+            "web_url": mr["web_url"],
+            "merged_at": mr.get("merged_at"),
+            "merge_status": mr.get("merge_status"),
+            "has_conflicts": mr.get("has_conflicts"),
+            "changes_count": mr.get("changes_count"),
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"MR !{result['iid']}: {result['title']}")
+            print(
+                f"State: {result['state']} | {result['source_branch']} -> {result['target_branch']}"
+            )
+            print(f"Author: {result.get('author', '?')}")
+            print(f"URL: {result['web_url']}")
+            if result.get("description"):
+                print(f"\n{result['description'][:500]}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/vcs-gitlab/scripts/get_mr_changes.py
+++ b/sre-agent/.claude/skills/vcs-gitlab/scripts/get_mr_changes.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Get file changes (diff) for a merge request.
+
+Usage:
+    python get_mr_changes.py --project "group/project" --mr-iid 42
+"""
+
+import argparse
+import json
+import sys
+
+from gitlab_client import encode_project, gitlab_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get MR file changes")
+    parser.add_argument("--project", required=True, help="Project ID or path")
+    parser.add_argument("--mr-iid", required=True, type=int, help="MR IID")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        data = gitlab_request(
+            "GET",
+            f"projects/{encode_project(args.project)}/merge_requests/{args.mr_iid}/changes",
+        )
+
+        changes = [
+            {
+                "old_path": c.get("old_path"),
+                "new_path": c.get("new_path"),
+                "new_file": c.get("new_file"),
+                "deleted_file": c.get("deleted_file"),
+                "renamed_file": c.get("renamed_file"),
+                "diff": c.get("diff", "")[:2000],
+            }
+            for c in data.get("changes", [])
+        ]
+        result = {
+            "ok": True,
+            "mr_iid": args.mr_iid,
+            "changes": changes,
+            "count": len(changes),
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"MR !{args.mr_iid} Changes ({len(changes)} files)")
+            for c in changes:
+                action = (
+                    "ADD"
+                    if c.get("new_file")
+                    else (
+                        "DEL"
+                        if c.get("deleted_file")
+                        else "REN" if c.get("renamed_file") else "MOD"
+                    )
+                )
+                print(f"  [{action}] {c.get('new_path', c.get('old_path', '?'))}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/vcs-gitlab/scripts/get_pipeline_jobs.py
+++ b/sre-agent/.claude/skills/vcs-gitlab/scripts/get_pipeline_jobs.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Get jobs for a specific GitLab pipeline.
+
+Usage:
+    python get_pipeline_jobs.py --project "group/project" --pipeline-id 12345
+"""
+
+import argparse
+import json
+import sys
+
+from gitlab_client import encode_project, gitlab_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get pipeline jobs")
+    parser.add_argument("--project", required=True, help="Project ID or path")
+    parser.add_argument("--pipeline-id", required=True, type=int, help="Pipeline ID")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        proj = encode_project(args.project)
+        data = gitlab_request(
+            "GET",
+            f"projects/{proj}/pipelines/{args.pipeline_id}/jobs",
+            params={"per_page": 100},
+        )
+
+        jobs = [
+            {
+                "id": j["id"],
+                "name": j["name"],
+                "stage": j["stage"],
+                "status": j["status"],
+                "web_url": j["web_url"],
+                "duration": j.get("duration"),
+                "failure_reason": j.get("failure_reason"),
+            }
+            for j in data
+        ]
+        result = {
+            "ok": True,
+            "pipeline_id": args.pipeline_id,
+            "jobs": jobs,
+            "count": len(jobs),
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Pipeline #{args.pipeline_id} Jobs ({len(jobs)})")
+            for job in jobs:
+                duration = f"{job['duration']:.0f}s" if job.get("duration") else "?"
+                print(
+                    f"  [{job['status'].upper():8s}] {job['stage']:15s} -> {job['name']} ({duration})"
+                )
+                if job.get("failure_reason"):
+                    print(f"    Failure: {job['failure_reason']}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/vcs-gitlab/scripts/get_pipelines.py
+++ b/sre-agent/.claude/skills/vcs-gitlab/scripts/get_pipelines.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""List CI/CD pipelines for a GitLab project.
+
+Usage:
+    python get_pipelines.py --project "group/project" [--status failed]
+"""
+
+import argparse
+import json
+import sys
+
+from gitlab_client import encode_project, gitlab_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List GitLab pipelines")
+    parser.add_argument("--project", required=True, help="Project ID or path")
+    parser.add_argument(
+        "--status",
+        default="",
+        help="Filter: running, pending, success, failed, canceled, skipped",
+    )
+    parser.add_argument("--ref", default="", help="Filter by branch/tag")
+    parser.add_argument("--max-results", type=int, default=20, help="Max results")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        params = {"per_page": args.max_results}
+        if args.status:
+            params["status"] = args.status
+        if args.ref:
+            params["ref"] = args.ref
+
+        data = gitlab_request(
+            "GET", f"projects/{encode_project(args.project)}/pipelines", params=params
+        )
+        pipelines = [
+            {
+                "id": p["id"],
+                "status": p["status"],
+                "ref": p["ref"],
+                "sha": p["sha"],
+                "web_url": p["web_url"],
+                "created_at": p.get("created_at"),
+                "source": p.get("source"),
+            }
+            for p in data
+        ]
+        result = {"ok": True, "pipelines": pipelines, "count": len(pipelines)}
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Pipelines ({len(pipelines)} found)")
+            for p in pipelines:
+                print(
+                    f"  [{p['status'].upper():8s}] #{p['id']} | {p['ref']} | {p['sha'][:8]}"
+                )
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/vcs-gitlab/scripts/get_project.py
+++ b/sre-agent/.claude/skills/vcs-gitlab/scripts/get_project.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Get GitLab project details.
+
+Usage:
+    python get_project.py --project "group/project"
+"""
+
+import argparse
+import json
+import sys
+
+from gitlab_client import encode_project, gitlab_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get GitLab project details")
+    parser.add_argument("--project", required=True, help="Project ID or path")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        p = gitlab_request("GET", f"projects/{encode_project(args.project)}")
+        result = {
+            "ok": True,
+            "id": p["id"],
+            "name": p["name"],
+            "path": p["path_with_namespace"],
+            "description": p.get("description"),
+            "web_url": p["web_url"],
+            "default_branch": p.get("default_branch"),
+            "visibility": p.get("visibility"),
+            "created_at": p.get("created_at"),
+            "last_activity_at": p.get("last_activity_at"),
+            "forks_count": p.get("forks_count"),
+            "star_count": p.get("star_count"),
+            "open_issues_count": p.get("open_issues_count"),
+        }
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Project: {result['path']}")
+            print(f"URL: {result['web_url']}")
+            print(
+                f"Branch: {result.get('default_branch', '?')} | Visibility: {result.get('visibility', '?')}"
+            )
+            print(
+                f"Stars: {result.get('star_count', 0)} | Forks: {result.get('forks_count', 0)} | Issues: {result.get('open_issues_count', 0)}"
+            )
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/vcs-gitlab/scripts/gitlab_client.py
+++ b/sre-agent/.claude/skills/vcs-gitlab/scripts/gitlab_client.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Shared GitLab API client with proxy support.
+
+Uses REST API v4 directly via httpx (no python-gitlab dependency).
+Credentials are injected transparently by the proxy layer.
+"""
+
+import os
+import urllib.parse
+from typing import Any
+
+import httpx
+
+
+def get_config() -> dict[str, str | None]:
+    """Get GitLab configuration from environment."""
+    return {
+        "tenant_id": os.getenv("OPENSRE_TENANT_ID", "local"),
+        "team_id": os.getenv("OPENSRE_TEAM_ID", "local"),
+        "gitlab_url": os.getenv("GITLAB_URL", "https://gitlab.com"),
+    }
+
+
+def get_base_url() -> str:
+    """Get GitLab API base URL.
+
+    Supports two modes:
+    1. Proxy mode (production): Uses GITLAB_BASE_URL
+    2. Direct mode (testing): Uses GITLAB_URL + /api/v4
+    """
+    proxy_url = os.getenv("GITLAB_BASE_URL")
+    if proxy_url:
+        return proxy_url.rstrip("/")
+
+    gitlab_url = os.getenv("GITLAB_URL", "https://gitlab.com")
+    return f"{gitlab_url.rstrip('/')}/api/v4"
+
+
+def get_headers() -> dict[str, str]:
+    """Get GitLab API headers."""
+    config = get_config()
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+
+    token = os.getenv("GITLAB_TOKEN")
+    if token:
+        headers["PRIVATE-TOKEN"] = token
+    else:
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            headers["X-Tenant-Id"] = config.get("tenant_id") or "local"
+            headers["X-Team-Id"] = config.get("team_id") or "local"
+
+    return headers
+
+
+def encode_project(project: str) -> str:
+    """URL-encode project path for GitLab API."""
+    if project.isdigit():
+        return project
+    return urllib.parse.quote(project, safe="")
+
+
+def gitlab_request(
+    method: str,
+    path: str,
+    params: dict | None = None,
+    json_body: dict | None = None,
+) -> Any:
+    """Make a request to GitLab REST API v4."""
+    base_url = get_base_url()
+    url = f"{base_url}/{path.lstrip('/')}"
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.request(
+            method, url, headers=get_headers(), params=params, json=json_body
+        )
+        response.raise_for_status()
+        if response.status_code == 204:
+            return None
+        return response.json()

--- a/sre-agent/.claude/skills/vcs-gitlab/scripts/list_branches.py
+++ b/sre-agent/.claude/skills/vcs-gitlab/scripts/list_branches.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""List branches in a GitLab project.
+
+Usage:
+    python list_branches.py --project "group/project" [--search "feature"]
+"""
+
+import argparse
+import json
+import sys
+
+from gitlab_client import encode_project, gitlab_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List GitLab branches")
+    parser.add_argument("--project", required=True, help="Project ID or path")
+    parser.add_argument("--search", default="", help="Filter by name")
+    parser.add_argument("--max-results", type=int, default=30, help="Max results")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        params = {"per_page": args.max_results}
+        if args.search:
+            params["search"] = args.search
+
+        data = gitlab_request(
+            "GET",
+            f"projects/{encode_project(args.project)}/repository/branches",
+            params=params,
+        )
+        branches = [
+            {
+                "name": b["name"],
+                "protected": b.get("protected", False),
+                "default": b.get("default", False),
+                "commit_sha": b.get("commit", {}).get("id"),
+                "commit_message": b.get("commit", {}).get("title"),
+            }
+            for b in data
+        ]
+        result = {"ok": True, "branches": branches, "count": len(branches)}
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Branches ({len(branches)} found)")
+            for b in branches:
+                flags = []
+                if b.get("default"):
+                    flags.append("default")
+                if b.get("protected"):
+                    flags.append("protected")
+                flag_str = f" ({', '.join(flags)})" if flags else ""
+                print(f"  {b['name']}{flag_str}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/vcs-gitlab/scripts/list_commits.py
+++ b/sre-agent/.claude/skills/vcs-gitlab/scripts/list_commits.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""List commits in a GitLab project.
+
+Usage:
+    python list_commits.py --project "group/project" [--ref main]
+"""
+
+import argparse
+import json
+import sys
+
+from gitlab_client import encode_project, gitlab_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List GitLab commits")
+    parser.add_argument("--project", required=True, help="Project ID or path")
+    parser.add_argument("--ref", default="", help="Branch or tag name")
+    parser.add_argument("--path", default="", help="File path filter")
+    parser.add_argument("--since", default="", help="Commits after date (ISO 8601)")
+    parser.add_argument("--until", default="", help="Commits before date (ISO 8601)")
+    parser.add_argument("--max-results", type=int, default=20, help="Max results")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        params = {"per_page": args.max_results}
+        if args.ref:
+            params["ref_name"] = args.ref
+        if args.path:
+            params["path"] = args.path
+        if args.since:
+            params["since"] = args.since
+        if args.until:
+            params["until"] = args.until
+
+        data = gitlab_request(
+            "GET",
+            f"projects/{encode_project(args.project)}/repository/commits",
+            params=params,
+        )
+        commits = [
+            {
+                "id": c["id"],
+                "short_id": c["short_id"],
+                "title": c["title"],
+                "author_name": c["author_name"],
+                "created_at": c["created_at"],
+                "web_url": c.get("web_url"),
+            }
+            for c in data
+        ]
+        result = {"ok": True, "commits": commits, "count": len(commits)}
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Commits ({len(commits)} found)")
+            for c in commits:
+                print(f"  {c['short_id']} {c['title']}")
+                print(f"    Author: {c['author_name']} | {c['created_at']}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/vcs-gitlab/scripts/list_issues.py
+++ b/sre-agent/.claude/skills/vcs-gitlab/scripts/list_issues.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""List issues in a GitLab project.
+
+Usage:
+    python list_issues.py --project "group/project" [--state opened]
+"""
+
+import argparse
+import json
+import sys
+
+from gitlab_client import encode_project, gitlab_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List GitLab issues")
+    parser.add_argument("--project", required=True, help="Project ID or path")
+    parser.add_argument("--state", default="opened", help="State: opened, closed, all")
+    parser.add_argument("--labels", default="", help="Comma-separated labels")
+    parser.add_argument("--max-results", type=int, default=20, help="Max results")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        params = {"state": args.state, "per_page": args.max_results}
+        if args.labels:
+            params["labels"] = args.labels
+
+        data = gitlab_request(
+            "GET", f"projects/{encode_project(args.project)}/issues", params=params
+        )
+        issues = [
+            {
+                "iid": i["iid"],
+                "title": i["title"],
+                "state": i["state"],
+                "author": i.get("author", {}).get("name") if i.get("author") else None,
+                "labels": i.get("labels", []),
+                "web_url": i.get("web_url"),
+            }
+            for i in data
+        ]
+        result = {"ok": True, "issues": issues, "count": len(issues)}
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Issues ({len(issues)} {args.state})")
+            for issue in issues:
+                labels = (
+                    f" [{', '.join(issue.get('labels', []))}]"
+                    if issue.get("labels")
+                    else ""
+                )
+                print(f"  #{issue['iid']} [{issue['state']}] {issue['title']}{labels}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/vcs-gitlab/scripts/list_merge_requests.py
+++ b/sre-agent/.claude/skills/vcs-gitlab/scripts/list_merge_requests.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""List merge requests for a GitLab project.
+
+Usage:
+    python list_merge_requests.py --project "group/project" [--state opened]
+"""
+
+import argparse
+import json
+import sys
+
+from gitlab_client import encode_project, gitlab_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List merge requests")
+    parser.add_argument("--project", required=True, help="Project ID or path")
+    parser.add_argument(
+        "--state", default="opened", help="State: opened, closed, merged, all"
+    )
+    parser.add_argument("--max-results", type=int, default=20, help="Max results")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        params = {"state": args.state, "per_page": args.max_results}
+        data = gitlab_request(
+            "GET",
+            f"projects/{encode_project(args.project)}/merge_requests",
+            params=params,
+        )
+
+        mrs = [
+            {
+                "iid": mr["iid"],
+                "title": mr["title"],
+                "state": mr["state"],
+                "source_branch": mr["source_branch"],
+                "target_branch": mr["target_branch"],
+                "author": (
+                    mr.get("author", {}).get("name") if mr.get("author") else None
+                ),
+                "web_url": mr["web_url"],
+                "merged_at": mr.get("merged_at"),
+                "labels": mr.get("labels", []),
+            }
+            for mr in data
+        ]
+        result = {"ok": True, "merge_requests": mrs, "count": len(mrs)}
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Merge Requests ({len(mrs)} {args.state})")
+            for mr in mrs:
+                print(f"  !{mr['iid']} [{mr['state']}] {mr['title']}")
+                print(f"    {mr['source_branch']} -> {mr['target_branch']}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/vcs-gitlab/scripts/list_projects.py
+++ b/sre-agent/.claude/skills/vcs-gitlab/scripts/list_projects.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""List or search GitLab projects.
+
+Usage:
+    python list_projects.py [--search "query"] [--visibility private]
+"""
+
+import argparse
+import json
+import sys
+
+from gitlab_client import gitlab_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List GitLab projects")
+    parser.add_argument("--search", default="", help="Search query")
+    parser.add_argument(
+        "--visibility", default="", help="Filter: public, internal, private"
+    )
+    parser.add_argument("--max-results", type=int, default=20, help="Max results")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    try:
+        params = {"per_page": args.max_results}
+        if args.search:
+            params["search"] = args.search
+        if args.visibility:
+            params["visibility"] = args.visibility
+
+        data = gitlab_request("GET", "projects", params=params)
+        projects = [
+            {
+                "id": p["id"],
+                "name": p["name"],
+                "path": p["path_with_namespace"],
+                "web_url": p["web_url"],
+                "default_branch": p.get("default_branch"),
+                "visibility": p.get("visibility"),
+            }
+            for p in data
+        ]
+        result = {"ok": True, "projects": projects, "count": len(projects)}
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"GitLab Projects ({len(projects)} found)")
+            for p in projects:
+                print(f"  [{p.get('visibility', '?')}] {p['path']}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/vcs-sourcegraph/SKILL.md
+++ b/sre-agent/.claude/skills/vcs-sourcegraph/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: vcs-sourcegraph
+description: Sourcegraph code search across repositories. Use for searching code patterns, finding implementations, and exploring codebases. Supports repo and file filters.
+allowed-tools: Bash(python *)
+---
+
+# Sourcegraph Code Search
+
+## Authentication
+
+**IMPORTANT**: Credentials are injected automatically by a proxy layer. Just run the scripts directly.
+
+## Available Scripts
+
+All scripts are in `.claude/skills/vcs-sourcegraph/scripts/`
+
+### search.py - Code Search
+```bash
+python .claude/skills/vcs-sourcegraph/scripts/search.py --query "func handleError" [--repo-filter "github.com/org/*"] [--file-filter "*.go"] [--limit 20]
+```
+
+## Search Syntax
+
+| Filter | Example | Description |
+|--------|---------|-------------|
+| `repo:` | `repo:github.com/org/*` | Filter by repository |
+| `file:` | `file:*.py` | Filter by file path |
+| `lang:` | `lang:python` | Filter by language |
+| `type:` | `type:symbol` | Search type (symbol, file, diff, commit) |
+
+Regex patterns are supported in queries.

--- a/sre-agent/.claude/skills/vcs-sourcegraph/scripts/search.py
+++ b/sre-agent/.claude/skills/vcs-sourcegraph/scripts/search.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Search code across repositories in Sourcegraph."""
+
+import argparse
+import json
+import sys
+
+from sourcegraph_client import graphql_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search Sourcegraph")
+    parser.add_argument("--query", required=True)
+    parser.add_argument("--repo-filter", help="Repo filter (e.g. github.com/org/*)")
+    parser.add_argument("--file-filter", help="File filter (e.g. *.py)")
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        search_query = args.query
+        if args.repo_filter:
+            search_query += f" repo:{args.repo_filter}"
+        if args.file_filter:
+            search_query += f" file:{args.file_filter}"
+
+        gql = """query Search($query: String!) { search(query: $query) { results { results { ... on FileMatch { file { path url repository { name } } lineMatches { lineNumber line } } } } } }"""
+        data = graphql_request(gql, {"query": search_query})
+
+        matches = []
+        for result in data.get("search", {}).get("results", {}).get("results", []):
+            if len(matches) >= args.limit:
+                break
+            if "file" not in result:
+                continue
+            matches.append(
+                {
+                    "file_path": result["file"]["path"],
+                    "repository": result["file"]["repository"]["name"],
+                    "url": result["file"]["url"],
+                    "matches": [
+                        {"line": m["lineNumber"], "content": m["line"]}
+                        for m in result.get("lineMatches", [])[:3]
+                    ],
+                }
+            )
+
+        if args.json:
+            print(json.dumps(matches, indent=2))
+        else:
+            print(f"Found: {len(matches)} file matches")
+            current_repo = None
+            for m in matches:
+                if m["repository"] != current_repo:
+                    current_repo = m["repository"]
+                    print(f"\n  {current_repo}/")
+                print(f"    {m['file_path']}")
+                for match in m["matches"]:
+                    print(f"      L{match['line']}: {match['content'][:100]}")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sre-agent/.claude/skills/vcs-sourcegraph/scripts/sourcegraph_client.py
+++ b/sre-agent/.claude/skills/vcs-sourcegraph/scripts/sourcegraph_client.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Shared Sourcegraph GraphQL client with proxy support."""
+
+import os
+
+import httpx
+
+
+def get_graphql_url() -> str:
+    proxy_url = os.getenv("SOURCEGRAPH_BASE_URL")
+    if proxy_url:
+        return proxy_url.rstrip("/")
+    url = os.getenv("SOURCEGRAPH_URL", "https://sourcegraph.com").rstrip("/")
+    return f"{url}/.api/graphql"
+
+
+def get_headers() -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    token = os.getenv("SOURCEGRAPH_TOKEN")
+    if token:
+        headers["Authorization"] = f"token {token}"
+    else:
+        sandbox_jwt = os.getenv("SANDBOX_JWT")
+        if sandbox_jwt:
+            headers["X-Sandbox-JWT"] = sandbox_jwt
+        else:
+            headers["X-Tenant-Id"] = os.getenv("OPENSRE_TENANT_ID", "local")
+            headers["X-Team-Id"] = os.getenv("OPENSRE_TEAM_ID", "local")
+    return headers
+
+
+def graphql_request(query, variables=None):
+    body = {"query": query}
+    if variables:
+        body["variables"] = variables
+    with httpx.Client(timeout=30.0) as client:
+        response = client.post(get_graphql_url(), headers=get_headers(), json=body)
+        response.raise_for_status()
+        data = response.json()
+        if "errors" in data:
+            raise Exception(f"GraphQL errors: {data['errors']}")
+        return data.get("data", {})


### PR DESCRIPTION
## What

Adds the **46 agent skills** under `sre-agent/.claude/skills/` (336 files, ~36k lines) to the public repo. This is a clean regeneration of the sync that replaces the withdrawn #11.

## Why

The skills directory was missing from the published repo (reported in #10 / Discussion #7). Root cause: the repo-sync excluded `.claude` with an **unanchored** rsync pattern, which matched `.claude` at *every* depth and stripped the nested `sre-agent/.claude/skills/`. The exclude is now anchored to `/.claude` (root-only), so the agent skills sync through while a root-level `.claude/` (local IDE config) stays private.

## Scope — verified clean

- **Purely additive:** 0 deletions; every changed file is under `sre-agent/.claude/skills/`.
- **46** `SKILL.md` present.
- **No README regression** — the `## Star History` section is intact (the previous attempt in #11 had dropped it; fixed at the source).
- **No `.superpowers/`** — those scratch artifacts were removed in #12 and are gitignored at the source, so this sync doesn't reintroduce them.
- Secret scan (gitleaks) on the synced output: **no leaks found**.

Resolves #10.

---
*Regenerated via the `sync-to-public.yml` workflow after fixing the exclude anchoring, the gitleaks self-scan, and the dry-run guard.*

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>