### PR TITLE
Add Docker Hub multi-arch publish CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,43 @@
+# GitHub Actions (public OpenSRE)
+
+## Publish Docker images (`docker-publish.yml`)
+
+Builds and pushes multi-arch (`linux/amd64`, `linux/arm64`) images to Docker Hub when a `v*` tag is pushed, or via manual `workflow_dispatch` with a tag input.
+
+### Images
+
+| Context | Docker Hub |
+|---------|------------|
+| `config_service/` | `swapnildahiphale/opensre-config-service` |
+| `sre-agent/` | `swapnildahiphale/opensre-sre-agent` |
+| `web_ui/` | `swapnildahiphale/opensre-web-ui` |
+| `teams-bot/` | `swapnildahiphale/opensre-teams-bot` |
+
+Each publish tags both the version (e.g. `v1.1.0`) and `latest`.
+
+### Required secrets
+
+Set on this repository (Settings → Secrets and variables → Actions):
+
+| Secret | Purpose |
+|--------|---------|
+| `DOCKERHUB_USERNAME` | Docker Hub username (`swapnildahiphale`) |
+| `DOCKERHUB_TOKEN` | Docker Hub access token with push permission |
+
+```bash
+gh secret set DOCKERHUB_USERNAME --repo swapnildahiphale/OpenSRE
+gh secret set DOCKERHUB_TOKEN --repo swapnildahiphale/OpenSRE
+```
+
+### How to publish
+
+1. Ensure Docker Hub repositories exist (or allow auto-create on first push).
+2. Secrets above are set.
+3. Push a version tag from `main` (or create a GitHub Release with tag `vX.Y.Z`):
+
+```bash
+git tag v1.1.0
+git push origin v1.1.0
+```
+
+4. Or re-run: Actions → **Publish Docker images** → Run workflow → enter tag (e.g. `v1.1.0`).

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,94 @@
+# Build and push multi-arch images to Docker Hub on version tags.
+# Public repo only (swapnildahiphale/OpenSRE). Secrets stay on this repo.
+#
+# Required secrets:
+#   DOCKERHUB_USERNAME — Docker Hub username (swapnildahiphale)
+#   DOCKERHUB_TOKEN    — Docker Hub access token with push scope
+
+name: Publish Docker images
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to build and publish (e.g. v1.1.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  DOCKERHUB_NAMESPACE: swapnildahiphale
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - context: config_service
+            image: opensre-config-service
+          - context: sre-agent
+            image: opensre-sre-agent
+          - context: web_ui
+            image: opensre-web-ui
+          - context: teams-bot
+            image: opensre-teams-bot
+
+    steps:
+      - name: Resolve tag
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          case "$TAG" in
+            v*) ;;
+            *)
+              echo "::error::Tag must start with v (got: $TAG)"
+              exit 1
+              ;;
+          esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.meta.outputs.tag }}
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./${{ matrix.context }}
+          file: ./${{ matrix.context }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.DOCKERHUB_NAMESPACE }}/${{ matrix.image }}:${{ steps.meta.outputs.tag }}
+            ${{ env.DOCKERHUB_NAMESPACE }}/${{ matrix.image }}:latest
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 env:
   DOCKERHUB_NAMESPACE: swapnildahiphale


### PR DESCRIPTION
## Summary
- Add `.github/workflows/docker-publish.yml` to build/push four multi-arch images to Docker Hub on `v*` tags (and manual dispatch)
- Document secrets and image names in `.github/workflows/README.md`

## Test plan
- [ ] Set `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` on this public repo
- [ ] Create/confirm Docker Hub repos for `opensre-config-service`, `opensre-sre-agent`, `opensre-web-ui`, `opensre-teams-bot`
- [ ] Push a test tag (e.g. `v0.0.0-dockerhub-test`) or run workflow_dispatch
- [ ] Confirm four images appear with the tag and `latest`
- [ ] Confirm private repo was not changed for this feature