### PR TITLE
fix: forward answers to pending questions

### DIFF
--- a/sre-agent/agent.py
+++ b/sre-agent/agent.py
@@ -1676,12 +1676,11 @@ class InteractiveAgentSession:
 
     async def provide_answer(self, answers: dict) -> None:
         """Provide answer to pending AskUserQuestion."""
-        if (
-            hasattr(self, "_pending_answer_event")
-            and self._pending_answer_event is not None
-        ):
-            self._pending_answer = answers
-            self._pending_answer_event.set()
+        if not hasattr(self, "_pending_answer_event") or self._pending_answer_event is None:
+            raise RuntimeError("No pending question")
+
+        self._pending_answer = answers
+        self._pending_answer_event.set()
 
 
 def create_agent_session(thread_id: str, team_config=None):

--- a/sre-agent/agent.py
+++ b/sre-agent/agent.py
@@ -530,6 +530,10 @@ class TextSegmentBuffer:
         return (fallback or "").strip()
 
 
+class NoPendingQuestionError(RuntimeError):
+    """Raised when an answer arrives without an active user question."""
+
+
 class InteractiveAgentSession:
     """
     Manages a persistent ClaudeSDKClient session that supports interrupts.
@@ -1677,7 +1681,7 @@ class InteractiveAgentSession:
     async def provide_answer(self, answers: dict) -> None:
         """Provide answer to pending AskUserQuestion."""
         if not hasattr(self, "_pending_answer_event") or self._pending_answer_event is None:
-            raise RuntimeError("No pending question")
+            raise NoPendingQuestionError("No pending question")
 
         self._pending_answer = answers
         self._pending_answer_event.set()

--- a/sre-agent/server_simple.py
+++ b/sre-agent/server_simple.py
@@ -1088,11 +1088,11 @@ async def answer(request: AnswerRequest):
     if not session.is_running:
         raise HTTPException(409, "Investigation is not executing")
 
+    from agent import NoPendingQuestionError
+
     try:
         await session.provide_answer(request.answers)
-    except RuntimeError as e:
-        if "No pending question" not in str(e):
-            raise
+    except NoPendingQuestionError as e:
         raise HTTPException(409, str(e)) from e
 
     return {"status": "ok", "thread_id": request.thread_id}

--- a/sre-agent/server_simple.py
+++ b/sre-agent/server_simple.py
@@ -1079,13 +1079,21 @@ async def answer(request: AnswerRequest):
     """
     Send answer to agent's AskUserQuestion.
     """
-    if request.thread_id not in _active_sessions:
+    session = _active_sessions.get(request.thread_id)
+    if session is None:
         raise HTTPException(404, f"No active session for thread {request.thread_id}")
 
     print(f"📬 Forwarding answer to thread {request.thread_id}")
 
-    _active_sessions[request.thread_id]
-    # TODO: Implement answer forwarding when InteractiveAgentSession supports it
+    if not session.is_running:
+        raise HTTPException(409, "Investigation is not executing")
+
+    try:
+        await session.provide_answer(request.answers)
+    except RuntimeError as e:
+        if "No pending question" not in str(e):
+            raise
+        raise HTTPException(409, str(e)) from e
 
     return {"status": "ok", "thread_id": request.thread_id}
 

--- a/sre-agent/tests/test_answer_api.py
+++ b/sre-agent/tests/test_answer_api.py
@@ -1,0 +1,68 @@
+import asyncio
+
+import pytest
+import server_simple
+from agent import InteractiveAgentSession
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    return TestClient(server_simple.app)
+
+
+@pytest.fixture(autouse=True)
+def clear_active_sessions():
+    server_simple._active_sessions.clear()
+    yield
+    server_simple._active_sessions.clear()
+
+
+def _session(thread_id: str, is_running: bool = False) -> InteractiveAgentSession:
+    session = InteractiveAgentSession.__new__(InteractiveAgentSession)
+    session.thread_id = thread_id
+    session.is_running = is_running
+    return session
+
+
+def test_answer_returns_404_for_missing_thread(client):
+    response = client.post(
+        "/answer", json={"thread_id": "missing", "answers": {"q": "a"}}
+    )
+
+    assert response.status_code == 404
+
+
+def test_answer_returns_409_for_idle_session(client):
+    server_simple._active_sessions["idle"] = _session("idle")
+
+    response = client.post(
+        "/answer", json={"thread_id": "idle", "answers": {"q": "a"}}
+    )
+
+    assert response.status_code == 409
+
+
+def test_answer_returns_409_for_running_session_without_pending_question(client):
+    server_simple._active_sessions["running"] = _session("running", is_running=True)
+
+    response = client.post(
+        "/answer", json={"thread_id": "running", "answers": {"q": "a"}}
+    )
+
+    assert response.status_code == 409
+
+
+def test_answer_delivers_to_running_session_with_pending_question(client):
+    session = _session("pending", is_running=True)
+    session._pending_answer_event = asyncio.Event()
+    session._pending_answer = None
+    server_simple._active_sessions["pending"] = session
+    answers = {"question": "answer"}
+
+    response = client.post("/answer", json={"thread_id": "pending", "answers": answers})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "thread_id": "pending"}
+    assert session._pending_answer == answers
+    assert session._pending_answer_event.is_set()

--- a/sre-agent/tests/test_answer_api.py
+++ b/sre-agent/tests/test_answer_api.py
@@ -53,6 +53,21 @@ def test_answer_returns_409_for_running_session_without_pending_question(client)
     assert response.status_code == 409
 
 
+def test_answer_does_not_translate_unrelated_runtime_error(client):
+    class FailingSession:
+        is_running = True
+
+        async def provide_answer(self, answers):
+            raise RuntimeError("storage failure: No pending question index is corrupt")
+
+    server_simple._active_sessions["failing"] = FailingSession()
+
+    with pytest.raises(RuntimeError, match="storage failure"):
+        client.post(
+            "/answer", json={"thread_id": "failing", "answers": {"q": "a"}}
+        )
+
+
 def test_answer_delivers_to_running_session_with_pending_question(client):
     session = _session("pending", is_running=True)
     session._pending_answer_event = asyncio.Event()


### PR DESCRIPTION
## Description

Make the simple-mode `/answer` endpoint report success only after an executing session accepts the payload into a pending `AskUserQuestion`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring / code cleanup
- [x] 🧪 Test improvements
- [ ] 🚀 Performance improvement
- [ ] 🔒 Security fix

## Related Issues

Closes #20

## Changes Made

- reject answers for idle sessions or sessions without a pending question
- await the production session consumer before returning HTTP 200
- use a typed no-pending-question exception so unrelated runtime failures are not translated to HTTP 409
- cover missing, idle, no-pending, unrelated-failure, and successful delivery through the real FastAPI route

## Testing

### Test Plan

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested locally with Docker Compose
- [ ] Tested in Kubernetes environment (if applicable)

### Testing Steps

1. Ran 23 focused answer, interrupt, queue-message, and completion tests; all passed.
2. Exercised the real `/answer` route with a concurrent waiter and verified the exact payload and event signal.
3. Verified an unrelated `RuntimeError` containing the old marker remains a server error instead of being translated to HTTP 409.
4. Ran the broader suite: 218 passed, 19 skipped, and five unrelated environment/baseline failures remained (two end-to-end tests require a local service, two reproduce existing agent-registry failures, and one requires GNU `grep` on PATH).
5. Ran changed-file `ruff check` and `git diff --check`; both passed.
6. Maintainer local validation: clean merge and rebase onto current `main`; `ruff check` on changed files passed; 379 unit tests passed (+5 new), 3 pre-existing Helm template failures unrelated to this PR.

## Screenshots / Videos

Not applicable; this is an API behavior change.

## Checklist

- [x] Code follows the project's style guidelines (`black` and `ruff` for Python; changed-file Ruff lint passes)
- [x] Self-review of code completed
- [x] Comments added for complex logic (not needed beyond the typed exception docstring)
- [x] Documentation updated (not needed; the public API shape is unchanged)
- [x] No new warnings introduced
- [x] Tests added/updated and passing
- [ ] All CI checks passing (no PR CI workflow on this repo)
- [x] Changes comply with [Apache 2.0 license](LICENSE)
- [x] Branch is up to date with `main`

## Additional Context

The no-pending condition now uses a dedicated `NoPendingQuestionError`; unrelated runtime failures propagate normally.

## Deployment Notes

- [ ] Requires database migration
- [ ] Requires configuration changes
- [ ] Requires environment variable updates
- [ ] Requires new secrets/credentials
- [x] Backward compatible
- [x] None of the above