### PR TITLE
Pin publish workflow actions to SHAs and add build provenance

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,9 @@
 # Build and push multi-arch images to Docker Hub on version tags.
 # Public repo only (swapnildahiphale/OpenSRE). Secrets stay on this repo.
 #
+# Action pins use full commit SHAs (supply-chain hardening). Provenance
+# attestation (e.g. build-push-action provenance: true) is a follow-up.
+#
 # Required secrets:
 #   DOCKERHUB_USERNAME — Docker Hub username (swapnildahiphale)
 #   DOCKERHUB_TOKEN    — Docker Hub access token with push scope
@@ -60,7 +63,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ steps.meta.outputs.tag }}
 
@@ -70,19 +73,19 @@ jobs:
           sudo docker image prune --all --force
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./${{ matrix.context }}
           file: ./${{ matrix.context }}/Dockerfile

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,8 @@
 # Build and push multi-arch images to Docker Hub on version tags.
 # Public repo only (swapnildahiphale/OpenSRE). Secrets stay on this repo.
 #
-# Action pins use full commit SHAs (supply-chain hardening). Provenance
-# attestation (e.g. build-push-action provenance: true) is a follow-up.
+# Action pins use full commit SHAs (supply-chain hardening). Provenance is
+# attached on publish via build-push provenance and attest-build-provenance.
 #
 # Required secrets:
 #   DOCKERHUB_USERNAME — Docker Hub username (swapnildahiphale)
@@ -23,7 +23,8 @@ on:
 
 permissions:
   contents: read
-  actions: write
+  id-token: write
+  attestations: write
 
 env:
   DOCKERHUB_NAMESPACE: swapnildahiphale
@@ -85,14 +86,23 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
+        id: push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./${{ matrix.context }}
           file: ./${{ matrix.context }}/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: true
           tags: |
             ${{ env.DOCKERHUB_NAMESPACE }}/${{ matrix.image }}:${{ steps.meta.outputs.tag }}
             ${{ env.DOCKERHUB_NAMESPACE }}/${{ matrix.image }}:latest
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+
+      - name: Attest provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-name: ${{ env.DOCKERHUB_NAMESPACE }}/${{ matrix.image }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/sre-agent/tests/test_docker_publish_workflow.py
+++ b/sre-agent/tests/test_docker_publish_workflow.py
@@ -1,0 +1,83 @@
+"""Static checks for .github/workflows/docker-publish.yml supply-chain hardening."""
+
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOW = REPO / ".github" / "workflows" / "docker-publish.yml"
+
+USES_SHA_RE = re.compile(
+    r"^\s+uses:\s+[\w-]+/[\w-]+@[0-9a-f]{40}(?:\s+#.*)?$"
+)
+PERM_KEY_RE = re.compile(r"^  ([\w-]+):\s+(\w+)\s*$")
+
+
+def _workflow_text() -> str:
+    assert WORKFLOW.is_file(), f"missing workflow: {WORKFLOW}"
+    return WORKFLOW.read_text()
+
+
+def _permissions_block(text: str) -> dict[str, str]:
+    perms: dict[str, str] = {}
+    in_perms = False
+    for line in text.splitlines():
+        if line.strip() == "permissions:":
+            in_perms = True
+            continue
+        if not in_perms:
+            continue
+        match = PERM_KEY_RE.match(line)
+        if match:
+            perms[match.group(1)] = match.group(2)
+            continue
+        if line.strip():
+            break
+    return perms
+
+
+def _build_push_step_block(text: str) -> str:
+    lines = text.splitlines()
+    start = next(
+        i for i, line in enumerate(lines) if line.strip() == "- name: Build and push"
+    )
+    block: list[str] = [lines[start]]
+    for line in lines[start + 1 :]:
+        if line.startswith("      - name:"):
+            break
+        block.append(line)
+    return "\n".join(block)
+
+
+def test_all_uses_pinned_to_full_sha():
+    text = _workflow_text()
+    uses_lines = [
+        (i + 1, line)
+        for i, line in enumerate(text.splitlines())
+        if re.search(r"\buses:", line)
+    ]
+    assert uses_lines, "expected at least one uses: line"
+    for line_no, line in uses_lines:
+        assert USES_SHA_RE.match(line), (
+            f"line {line_no}: unpinned or invalid uses: {line.strip()}"
+        )
+
+
+def test_permissions_limited_for_publish():
+    perms = _permissions_block(_workflow_text())
+    assert perms.get("contents") == "read"
+    assert perms.get("id-token") == "write"
+    assert perms.get("attestations") == "write"
+    assert "actions" not in perms
+
+
+def test_build_push_enables_provenance():
+    block = _build_push_step_block(_workflow_text())
+    assert re.search(r"^\s+id:\s+push\s*$", block, re.MULTILINE)
+    assert re.search(r"^\s+provenance:\s+true\s*$", block, re.MULTILINE)
+
+
+def test_attest_build_provenance_step_exists():
+    text = _workflow_text()
+    assert "actions/attest-build-provenance@" in text
+    assert "subject-digest: ${{ steps.push.outputs.digest }}" in text
+    assert "push-to-registry: true" in text


### PR DESCRIPTION
## Summary
- Pin every `uses:` in the image publish workflow to a full commit SHA (version kept as a trailing comment)
- Reduce workflow `permissions` to `contents: read` plus what attestation requires
- Attach build provenance to published images

Closes #35

## Test plan
- [ ] Workflow parses; action references resolve
- [ ] A tag build publishes multi-arch images as before
- [ ] Provenance attestation is present on the published tag