### PR TITLE
Narrow the console API proxy and remove the hardcoded service identity

### DIFF
--- a/config_service/src/api/auth.py
+++ b/config_service/src/api/auth.py
@@ -146,6 +146,13 @@ class AdminPrincipal:
     org_id: Optional[str] = None  # Set for org-scoped admins
 
 
+def resolve_admin_audit_actor(principal: AdminPrincipal) -> str:
+    """Derive audit actor from authenticated principal (not spoofable headers)."""
+    if principal.email:
+        return principal.email
+    return principal.subject
+
+
 def authenticate_admin_request(
     authorization: str = Header(default=""),
     x_admin_token: str = Header(default="", alias="X-Admin-Token"),
@@ -163,12 +170,10 @@ def authenticate_admin_request(
 
     # 0) Internal service header for agent service
     internal_secret = os.getenv("INTERNAL_SERVICE_SECRET", "")
-    if x_internal_service and (
-        x_internal_service == "agent"
-        or (
-            internal_secret
-            and secrets.compare_digest(x_internal_service, internal_secret)
-        )
+    if (
+        x_internal_service
+        and internal_secret
+        and secrets.compare_digest(x_internal_service, internal_secret)
     ):
         return AdminPrincipal(
             auth_kind="internal_service",

--- a/config_service/src/api/routes/admin.py
+++ b/config_service/src/api/routes/admin.py
@@ -11,7 +11,11 @@ from fastapi.responses import Response
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from src.api.auth import AdminPrincipal, authenticate_admin_request
+from src.api.auth import (
+    AdminPrincipal,
+    authenticate_admin_request,
+    resolve_admin_audit_actor,
+)
 from src.core.audit_log import audit_logger
 from src.core.config_cache import get_config_cache
 from src.core.metrics import ADMIN_ACTIONS_TOTAL
@@ -661,10 +665,10 @@ def admin_patch_node_config(
     body: PatchConfigRequest,
     principal: AdminPrincipal = Depends(require_admin),
     session: Session = Depends(get_db),
-    x_admin_actor: str = Header(default="admin", convert_underscores=False),
     x_bypass_approval: str = Header(default="", convert_underscores=False),
 ):
     check_org_access(principal, org_id)
+    admin_actor = resolve_admin_audit_actor(principal)
     try:
         # Check if this change requires approval
         bypass = x_bypass_approval.lower() == "true"
@@ -710,7 +714,7 @@ def admin_patch_node_config(
                         change_path=f"agents.{agent_id}.prompt.system",
                         proposed_value={"agent": agent_id, "prompt": new_text},
                         previous_value={"agent": agent_id, "prompt": prev_text},
-                        requested_by=x_admin_actor,
+                        requested_by=admin_actor,
                     )
                     pending_ids.append(pending.id)
                 session.commit()
@@ -726,7 +730,7 @@ def admin_patch_node_config(
                         to_emails=[admin_email],
                         change_type="Prompt",
                         team_name=node_id,
-                        requested_by=x_admin_actor,
+                        requested_by=admin_actor,
                         change_summary="Change to "
                         + ", ".join(sorted(prompt_edits.keys()))
                         + " prompt(s)",
@@ -756,7 +760,7 @@ def admin_patch_node_config(
                         change_path="enabled_tools",
                         proposed_value=body.patch.get("enabled_tools"),
                         previous_value=current_config.get("enabled_tools"),
-                        requested_by=x_admin_actor,
+                        requested_by=admin_actor,
                     )
                     session.commit()
 
@@ -771,7 +775,7 @@ def admin_patch_node_config(
                             to_emails=[admin_email],
                             change_type="Tool Enablement",
                             team_name=node_id,
-                            requested_by=x_admin_actor,
+                            requested_by=admin_actor,
                             change_summary="Changes to enabled tools",
                             dashboard_url=dashboard_url,
                         )
@@ -788,7 +792,7 @@ def admin_patch_node_config(
             org_id=org_id,
             node_id=node_id,
             config_patch=body.patch,
-            updated_by=x_admin_actor,
+            updated_by=admin_actor,
             skip_validation=True,  # Admin can bypass validation
         )
         merged = updated_config.config_json
@@ -807,7 +811,7 @@ def admin_patch_node_config(
             audit=True,
             org_id=org_id,
             node_id=node_id,
-            updated_by=x_admin_actor,
+            updated_by=admin_actor,
             auth_kind=principal.auth_kind,
             actor=principal.email or principal.subject,
         )
@@ -824,16 +828,16 @@ def admin_rollback_node_config(
     body: RollbackConfigRequest,
     principal: AdminPrincipal = Depends(require_admin),
     session: Session = Depends(get_db),
-    x_admin_actor: str = Header(default="admin", convert_underscores=False),
 ):
     check_org_access(principal, org_id)
+    admin_actor = resolve_admin_audit_actor(principal)
     try:
         updated_config, diff = rollback_to_version(
             session,
             org_id=org_id,
             node_id=node_id,
             version=body.version,
-            rolled_back_by=x_admin_actor,
+            rolled_back_by=admin_actor,
         )
         cfg = updated_config.config_json
         session.commit()
@@ -852,7 +856,7 @@ def admin_rollback_node_config(
             org_id=org_id,
             node_id=node_id,
             rollback_version=body.version,
-            updated_by=x_admin_actor,
+            updated_by=admin_actor,
             auth_kind=principal.auth_kind,
             actor=principal.email or principal.subject,
         )
@@ -870,15 +874,15 @@ def admin_issue_team_token(
     team_node_id: str,
     principal: AdminPrincipal = Depends(require_admin),
     session: Session = Depends(get_db),
-    x_admin_actor: str = Header(default="admin", convert_underscores=False),
 ):
     check_org_access(principal, org_id)
+    admin_actor = resolve_admin_audit_actor(principal)
     pepper = get_token_pepper()
     token = issue_team_token(
         session,
         org_id=org_id,
         team_node_id=team_node_id,
-        issued_by=x_admin_actor,
+        issued_by=admin_actor,
         pepper=pepper,
     )
     ADMIN_ACTIONS_TOTAL.labels("issue_team_token", "ok").inc()
@@ -887,7 +891,7 @@ def admin_issue_team_token(
         audit=True,
         org_id=org_id,
         team_node_id=team_node_id,
-        issued_by=x_admin_actor,
+        issued_by=admin_actor,
         auth_kind=principal.auth_kind,
         actor=principal.email or principal.subject,
     )
@@ -902,7 +906,6 @@ def admin_issue_team_impersonation_token(
     org_id: str,
     team_node_id: str,
     principal: AdminPrincipal = Depends(require_admin),
-    x_admin_actor: str = Header(default="admin", convert_underscores=False),
     session: Session = Depends(get_db),
 ):
     """
@@ -911,6 +914,7 @@ def admin_issue_team_impersonation_token(
     This avoids long-lived team token sprawl when orchestrator needs to call team-scoped endpoints.
     """
     check_org_access(principal, org_id)
+    admin_actor = resolve_admin_audit_actor(principal)
     from src.core.impersonation import mint_team_impersonation_token
     from src.db.repository import record_impersonation_jti
 
@@ -951,7 +955,7 @@ def admin_issue_team_impersonation_token(
         audit=True,
         org_id=org_id,
         team_node_id=team_node_id,
-        issued_by=x_admin_actor,
+        issued_by=admin_actor,
         auth_kind=principal.auth_kind,
         actor=principal.email or principal.subject,
         jti=jti,
@@ -969,9 +973,9 @@ def admin_revoke_team_token(
     token_id: str,
     principal: AdminPrincipal = Depends(require_admin),
     session: Session = Depends(get_db),
-    x_admin_actor: str = Header(default="admin", convert_underscores=False),
 ):
     check_org_access(principal, org_id)
+    admin_actor = resolve_admin_audit_actor(principal)
     revoke_team_token_scoped(
         session, org_id=org_id, team_node_id=team_node_id, token_id=token_id
     )
@@ -982,7 +986,7 @@ def admin_revoke_team_token(
         org_id=org_id,
         team_node_id=team_node_id,
         token_id=token_id,
-        revoked_by=x_admin_actor,
+        revoked_by=admin_actor,
         auth_kind=principal.auth_kind,
         actor=principal.email or principal.subject,
     )
@@ -1126,10 +1130,10 @@ def admin_extend_token(
     body: dict,
     principal: AdminPrincipal = Depends(require_admin),
     session: Session = Depends(get_db),
-    x_admin_actor: str = Header(default="admin", convert_underscores=False),
 ):
     """Extend token expiration by specified number of days."""
     check_org_access(principal, org_id)
+    admin_actor = resolve_admin_audit_actor(principal)
     from src.db.repository import extend_token_expiration, get_token_by_id
 
     # Verify token belongs to org
@@ -1145,7 +1149,7 @@ def admin_extend_token(
         session,
         token_id=token_id,
         days=days,
-        extended_by=x_admin_actor,
+        extended_by=admin_actor,
     )
 
     if not updated_token:
@@ -1162,7 +1166,7 @@ def admin_extend_token(
         org_id=org_id,
         token_id=token_id,
         days=days,
-        extended_by=x_admin_actor,
+        extended_by=admin_actor,
         auth_kind=principal.auth_kind,
         actor=principal.email or principal.subject,
     )
@@ -1182,10 +1186,10 @@ def admin_bulk_revoke_tokens(
     body: dict,
     principal: AdminPrincipal = Depends(require_admin),
     session: Session = Depends(get_db),
-    x_admin_actor: str = Header(default="admin", convert_underscores=False),
 ):
     """Bulk revoke multiple tokens."""
     check_org_access(principal, org_id)
+    admin_actor = resolve_admin_audit_actor(principal)
     from src.db.repository import bulk_revoke_tokens, get_token_by_id
 
     token_ids = body.get("token_ids", [])
@@ -1206,7 +1210,7 @@ def admin_bulk_revoke_tokens(
     count = bulk_revoke_tokens(
         session,
         token_ids=token_ids,
-        revoked_by=x_admin_actor,
+        revoked_by=admin_actor,
     )
 
     session.commit()
@@ -1217,7 +1221,7 @@ def admin_bulk_revoke_tokens(
         audit=True,
         org_id=org_id,
         token_count=count,
-        revoked_by=x_admin_actor,
+        revoked_by=admin_actor,
         auth_kind=principal.auth_kind,
         actor=principal.email or principal.subject,
     )
@@ -1762,13 +1766,13 @@ def admin_issue_org_admin_token(
     org_id: str,
     principal: AdminPrincipal = Depends(require_admin),
     session: Session = Depends(get_db),
-    x_admin_actor: str = Header(default="admin", convert_underscores=False),
 ):
     """Issue a new org admin token.
 
     Only super-admins (global admin token) can issue org admin tokens.
     Org admins cannot issue new admin tokens for their own org.
     """
+    admin_actor = resolve_admin_audit_actor(principal)
     # Only super-admin can issue org admin tokens
     if principal.org_id is not None:
         raise HTTPException(
@@ -1781,7 +1785,7 @@ def admin_issue_org_admin_token(
     token = issue_org_admin_token(
         session,
         org_id=org_id,
-        issued_by=x_admin_actor,
+        issued_by=admin_actor,
         pepper=pepper,
     )
     ADMIN_ACTIONS_TOTAL.labels("issue_org_admin_token", "ok").inc()
@@ -1789,7 +1793,7 @@ def admin_issue_org_admin_token(
         "admin_issue_org_admin_token",
         audit=True,
         org_id=org_id,
-        issued_by=x_admin_actor,
+        issued_by=admin_actor,
         auth_kind=principal.auth_kind,
         actor=principal.email or principal.subject,
     )
@@ -1802,12 +1806,12 @@ def admin_revoke_org_admin_token(
     token_id: str,
     principal: AdminPrincipal = Depends(require_admin),
     session: Session = Depends(get_db),
-    x_admin_actor: str = Header(default="admin", convert_underscores=False),
 ):
     """Revoke an org admin token.
 
     Can be done by super-admin or by another org admin of the same org.
     """
+    admin_actor = resolve_admin_audit_actor(principal)
     # Super-admin can revoke any, org admin can only revoke their own org's tokens
     if principal.org_id is not None and principal.org_id != org_id:
         raise HTTPException(
@@ -1817,7 +1821,7 @@ def admin_revoke_org_admin_token(
     from src.db.repository import revoke_org_admin_token
 
     revoke_org_admin_token(
-        session, org_id=org_id, token_id=token_id, revoked_by=x_admin_actor
+        session, org_id=org_id, token_id=token_id, revoked_by=admin_actor
     )
     ADMIN_ACTIONS_TOTAL.labels("revoke_org_admin_token", "ok").inc()
     audit_logger().info(
@@ -1825,7 +1829,7 @@ def admin_revoke_org_admin_token(
         audit=True,
         org_id=org_id,
         token_id=token_id,
-        revoked_by=x_admin_actor,
+        revoked_by=admin_actor,
         auth_kind=principal.auth_kind,
         actor=principal.email or principal.subject,
     )

--- a/config_service/src/db/repository.py
+++ b/config_service/src/db/repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import secrets
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
@@ -405,7 +406,7 @@ def authenticate_org_admin_token(
     if row is None:
         raise ValueError("Token not found")
 
-    if row.token_hash != expected_hash:
+    if not secrets.compare_digest(row.token_hash, expected_hash):
         raise ValueError("Invalid token")
 
     if row.revoked_at is not None:
@@ -740,7 +741,9 @@ def authenticate_bearer_token(
         raise ValueError("Invalid token")
     if row.revoked_at is not None:
         raise ValueError("Token revoked")
-    if row.token_hash != hash_token(token_secret, pepper=pepper):
+    if not secrets.compare_digest(
+        row.token_hash, hash_token(token_secret, pepper=pepper)
+    ):
         raise ValueError("Invalid token")
 
     # Check expiration
@@ -792,7 +795,9 @@ def authenticate_bearer_token_extended(
         raise ValueError("Invalid token")
     if row.revoked_at is not None:
         raise ValueError("Token revoked")
-    if row.token_hash != hash_token(token_secret, pepper=pepper):
+    if not secrets.compare_digest(
+        row.token_hash, hash_token(token_secret, pepper=pepper)
+    ):
         raise ValueError("Invalid token")
 
     # Check expiration

--- a/config_service/tests/test_internal_auth_hardening.py
+++ b/config_service/tests/test_internal_auth_hardening.py
@@ -1,0 +1,168 @@
+"""Tests for internal auth hardening (bucket B — scoped changes only)."""
+
+from pathlib import Path
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.api.auth import (
+    AdminPrincipal,
+    authenticate_admin_request,
+    resolve_admin_audit_actor,
+)
+from src.api.main import create_app
+from src.db.config_models import ConfigChangeHistory, NodeConfiguration
+from src.db.models import NodeType, OrgNode
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture()
+def app_db_admin(monkeypatch):
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    for table in (
+        OrgNode.__table__,
+        NodeConfiguration.__table__,
+        ConfigChangeHistory.__table__,
+    ):
+        table.create(engine, checkfirst=True)
+    SessionLocal = sessionmaker(bind=engine)
+
+    monkeypatch.setenv("TOKEN_PEPPER", "test-pepper")
+    monkeypatch.setenv("ADMIN_TOKEN", "admin-secret")
+
+    with SessionLocal() as s:
+        s.add(
+            OrgNode(
+                org_id="org1",
+                node_id="root",
+                parent_id=None,
+                node_type=NodeType.org,
+                name="Root",
+            )
+        )
+        s.commit()
+
+    from src.api.routes import admin as admin_routes
+
+    def override_get_db():
+        with SessionLocal() as s:
+            try:
+                yield s
+                s.commit()
+            except Exception:
+                s.rollback()
+                raise
+
+    app = create_app()
+    app.dependency_overrides[admin_routes.get_db] = override_get_db
+    return app, SessionLocal
+
+
+class TestAdminInternalServiceAuth:
+    def test_agent_literal_does_not_grant_admin(self, monkeypatch):
+        monkeypatch.setenv("INTERNAL_SERVICE_SECRET", "real-secret")
+        monkeypatch.setenv("ADMIN_AUTH_MODE", "token")
+        with pytest.raises(HTTPException) as exc:
+            authenticate_admin_request(
+                authorization="",
+                x_admin_token="",
+                x_internal_service="agent",
+            )
+        assert exc.value.status_code == 401
+
+    def test_valid_internal_secret_grants_admin(self, monkeypatch):
+        monkeypatch.setenv("INTERNAL_SERVICE_SECRET", "real-secret")
+        monkeypatch.setenv("ADMIN_AUTH_MODE", "token")
+        principal = authenticate_admin_request(
+            authorization="",
+            x_admin_token="",
+            x_internal_service="real-secret",
+        )
+        assert principal.auth_kind == "internal_service"
+        assert principal.subject == "service:real-secret"
+
+
+class TestResolveAdminAuditActor:
+    def test_prefers_email_over_subject(self):
+        principal = AdminPrincipal(
+            auth_kind="oidc",
+            subject="user-123",
+            email="admin@example.com",
+            claims={},
+        )
+        assert resolve_admin_audit_actor(principal) == "admin@example.com"
+
+    def test_falls_back_to_subject(self):
+        principal = AdminPrincipal(
+            auth_kind="admin_token",
+            subject="super_admin",
+            email=None,
+            claims={},
+        )
+        assert resolve_admin_audit_actor(principal) == "super_admin"
+
+
+class TestAdminAuditActorFromPrincipal:
+    def test_spoofed_x_admin_actor_header_ignored_on_config_write(
+        self, app_db_admin
+    ):
+        app, SessionLocal = app_db_admin
+        client = TestClient(app)
+        hdr = {
+            "Authorization": "Bearer admin-secret",
+            "X-Admin-Actor": "spoofed-attacker",
+        }
+
+        client.post(
+            "/api/v1/admin/orgs/org1/nodes",
+            headers=hdr,
+            json={"node_id": "teamA", "parent_id": "root", "node_type": "team"},
+        )
+        resp = client.put(
+            "/api/v1/admin/orgs/org1/nodes/teamA/config",
+            headers=hdr,
+            json={"patch": {"knowledge_source": {"google": ["drive:folder/demo"]}}},
+        )
+        assert resp.status_code == 200
+
+        with SessionLocal() as session:
+            row = session.execute(
+                select(NodeConfiguration).where(
+                    NodeConfiguration.org_id == "org1",
+                    NodeConfiguration.node_id == "teamA",
+                )
+            ).scalar_one()
+            assert row.updated_by == "super_admin"
+            assert row.updated_by != "spoofed-attacker"
+
+
+class TestNextConfigProxyNarrowed:
+    def test_no_blanket_api_v1_rewrite(self):
+        text = (REPO_ROOT / "web_ui/next.config.ts").read_text()
+        assert "/api/v1/:path*" not in text
+
+    def test_local_bff_route_handlers_still_exist(self):
+        for rel in (
+            "web_ui/src/app/api/v1/tools/metadata/route.ts",
+            "web_ui/src/app/api/v1/integrations/schemas/route.ts",
+            "web_ui/src/app/api/v1/team/output-config/route.ts",
+        ):
+            assert (REPO_ROOT / rel).is_file(), rel
+
+
+class TestRepositoryTokenHashCompareDigest:
+    def test_token_hash_checks_use_compare_digest(self):
+        text = (REPO_ROOT / "config_service/src/db/repository.py").read_text()
+        assert "secrets.compare_digest" in text
+        assert "token_hash !=" not in text

--- a/web_ui/next.config.ts
+++ b/web_ui/next.config.ts
@@ -21,13 +21,11 @@ const nextConfig: NextConfig = {
     const base = process.env.CONFIG_SERVICE_URL;
     if (!base) return [];
 
-    // Proxy identity endpoints and /api/v1/* directly to the config service.
+    // Proxy identity endpoints to the config service (BFF routes handle /api/v1/*).
     return [
       { source: "/api/auth/me", destination: `${base}/api/auth/me` },
       { source: "/api/whoami", destination: `${base}/api/whoami` },
       { source: "/api/config/identity", destination: `${base}/api/config/identity` },
-      // Proxy all /api/v1/* endpoints to config service
-      { source: "/api/v1/:path*", destination: `${base}/api/v1/:path*` },
       // Proxy GitHub App OAuth callback to config service
       // GitHub redirects here after app installation
       { source: "/github/callback", destination: `${base}/github/callback` },


### PR DESCRIPTION
## Summary
- Narrow the console's `/api/v1/*` proxy to the paths the UI actually calls, instead of forwarding the whole control-plane API
- Remove the hardcoded service identity value that resolved to a cross-org admin principal
- Compare token hashes in constant time
- Derive the audit actor from the authenticated principal rather than a client-supplied header

Closes #26

## Test plan
- [ ] `pytest config_service/tests/test_internal_auth_hardening.py`
- [ ] Console pages that use `/api/v1/*` still load (tool metadata, integration schemas, team output config)
- [ ] Admin and internal routes are no longer reachable through the console origin
- [ ] Audit rows record the authenticated principal