### PR TITLE
Validate GitHub App install callback state

### DIFF
--- a/config_service/src/api/routes/github.py
+++ b/config_service/src/api/routes/github.py
@@ -16,6 +16,11 @@ from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from src.api.auth import AdminPrincipal, require_admin
+from src.core.github_install_state import (
+    mint_install_state,
+    validate_and_consume_install_state,
+)
 from src.db.models import GitHubInstallation
 from src.db.session import get_db
 
@@ -41,6 +46,13 @@ def _get_github_app_config() -> dict:
     }
 
 
+class GitHubInstallStartResponse(BaseModel):
+    """Response for starting a GitHub App installation flow."""
+
+    state: str
+    install_url: str
+
+
 class GitHubInstallationInfo(BaseModel):
     """Information about a GitHub App installation."""
 
@@ -53,6 +65,34 @@ class GitHubInstallationInfo(BaseModel):
     linked: bool = False
     org_id: Optional[str] = None
     team_node_id: Optional[str] = None
+
+
+@router.get("/install/start", response_model=GitHubInstallStartResponse)
+async def github_install_start(
+    admin: AdminPrincipal = Depends(require_admin),
+):
+    """
+    Mint CSRF state and return the GitHub App installation URL.
+
+    Call this before redirecting the user to GitHub. The returned state must be
+    echoed back on GET /github/callback.
+    """
+    config = _get_github_app_config()
+    app_name = config.get("app_name") or "opensre"
+    state = mint_install_state(created_by=admin.auth_kind)
+
+    install_url = (
+        f"https://github.com/apps/{app_name}/installations/new"
+        f"?{urlencode({'state': state})}"
+    )
+
+    logger.info(
+        "github_install_start",
+        auth_kind=admin.auth_kind,
+        app_name=app_name,
+    )
+
+    return GitHubInstallStartResponse(state=state, install_url=install_url)
 
 
 @router.get("/callback")
@@ -89,6 +129,26 @@ async def github_callback(
         raise HTTPException(
             status_code=400,
             detail="Missing installation_id. This endpoint should be called by GitHub.",
+        )
+
+    if not state:
+        logger.warning(
+            "github_callback_missing_state",
+            installation_id=installation_id,
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="Missing state parameter. Start install via GET /github/install/start.",
+        )
+
+    if not validate_and_consume_install_state(state):
+        logger.warning(
+            "github_callback_invalid_state",
+            installation_id=installation_id,
+        )
+        raise HTTPException(
+            status_code=403,
+            detail="Invalid or expired state parameter.",
         )
 
     # Fetch installation details from GitHub API
@@ -209,6 +269,7 @@ async def github_callback(
 async def get_installation_info(
     installation_id: int,
     session: Session = Depends(get_db),
+    admin: AdminPrincipal = Depends(require_admin),
 ):
     """
     Get information about a GitHub installation.

--- a/config_service/src/core/github_install_state.py
+++ b/config_service/src/core/github_install_state.py
@@ -1,0 +1,43 @@
+"""Server-side CSRF state for GitHub App installation callback."""
+
+import os
+import secrets
+from typing import Any, Dict, Optional
+
+from src.core.cache import TTLCache
+
+_DEFAULT_TTL_SECONDS = int(os.getenv("GITHUB_INSTALL_STATE_TTL_SECONDS", "600"))
+
+# In-memory one-time state store (sufficient for simple/local single-process mode).
+_state_store = TTLCache(ttl_seconds=_DEFAULT_TTL_SECONDS, max_items=500)
+
+
+def mint_install_state(created_by: str = "") -> str:
+    """Mint opaque state and store it until callback validation consumes it."""
+    state = secrets.token_urlsafe(32)
+    _state_store.set(
+        state,
+        {"created_by": created_by},
+        ttl_seconds=_DEFAULT_TTL_SECONDS,
+    )
+    return state
+
+
+def validate_and_consume_install_state(state: Optional[str]) -> bool:
+    """
+    Validate callback state and consume it (one-time use).
+
+    Returns True when state was present, unexpired, and successfully consumed.
+    """
+    if not state:
+        return False
+    entry: Optional[Dict[str, Any]] = _state_store.get(state)
+    if entry is None:
+        return False
+    _state_store.invalidate(state)
+    return True
+
+
+def clear_install_state_store() -> None:
+    """Clear all pending install states (used in tests)."""
+    _state_store.clear()

--- a/config_service/tests/test_github_callback.py
+++ b/config_service/tests/test_github_callback.py
@@ -1,0 +1,253 @@
+"""Tests for GitHub App install callback state validation."""
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.types import JSON
+
+from src.api.main import create_app
+from src.core.github_install_state import clear_install_state_store, mint_install_state
+from src.db.models import GitHubInstallation, NodeType, OrgNode
+from src.db.session import get_db
+
+
+def _create_sqlite_tables(engine, models):
+    """Create only the tables needed for GitHub route tests on SQLite."""
+    if engine.dialect.name == "sqlite":
+        for model in models:
+            for column in model.__table__.columns:
+                if isinstance(column.type, JSONB):
+                    column.type = JSON()
+    for model in models:
+        model.__table__.create(bind=engine)
+
+
+def _sample_installation_payload(installation_id: int = 12345) -> dict:
+    return {
+        "id": installation_id,
+        "app_id": 999,
+        "account": {
+            "id": 42,
+            "login": "example-org",
+            "type": "Organization",
+            "avatar_url": "https://example.com/avatar.png",
+        },
+        "permissions": {"contents": "read"},
+        "repository_selection": "all",
+    }
+
+
+@pytest.fixture()
+def app_github(monkeypatch):
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    _create_sqlite_tables(engine, (OrgNode, GitHubInstallation))
+    SessionLocal = sessionmaker(bind=engine)
+
+    monkeypatch.setenv("TOKEN_PEPPER", "test-pepper")
+    monkeypatch.setenv("ADMIN_TOKEN", "admin-secret")
+    monkeypatch.setenv("GITHUB_APP_ID", "999")
+    monkeypatch.setenv("GITHUB_APP_NAME", "opensre-test")
+
+    with SessionLocal() as s:
+        s.add(
+            OrgNode(
+                org_id="org1",
+                node_id="root",
+                parent_id=None,
+                node_type=NodeType.org,
+                name="Root",
+            )
+        )
+        s.commit()
+
+    def override_get_db():
+        with SessionLocal() as s:
+            try:
+                yield s
+                s.commit()
+            except Exception:
+                s.rollback()
+                raise
+
+    app = create_app()
+    app.dependency_overrides[get_db] = override_get_db
+    clear_install_state_store()
+    app.state.test_session_local = SessionLocal
+    yield app
+    clear_install_state_store()
+
+
+@pytest.fixture()
+def client(app_github):
+    return TestClient(app_github)
+
+
+@pytest.fixture()
+def admin_headers():
+    return {"Authorization": "Bearer admin-secret"}
+
+
+def test_install_start_requires_admin(client):
+    r = client.get("/github/install/start")
+    assert r.status_code in (401, 503)
+
+
+def test_install_start_mints_state(client, admin_headers):
+    r = client.get("/github/install/start", headers=admin_headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["state"]
+    assert "state=" in body["install_url"]
+    assert "opensre-test" in body["install_url"]
+
+
+def test_callback_missing_state_fails(client, monkeypatch):
+    async def fake_fetch(installation_id, config):
+        return _sample_installation_payload(installation_id)
+
+    monkeypatch.setattr(
+        "src.api.routes.github._fetch_installation_details",
+        fake_fetch,
+    )
+
+    r = client.get("/github/callback", params={"installation_id": 12345})
+    assert r.status_code == 400
+    assert "state" in r.json()["detail"].lower()
+
+
+def test_callback_invalid_state_fails(client, monkeypatch):
+    async def fake_fetch(installation_id, config):
+        return _sample_installation_payload(installation_id)
+
+    monkeypatch.setattr(
+        "src.api.routes.github._fetch_installation_details",
+        fake_fetch,
+    )
+
+    r = client.get(
+        "/github/callback",
+        params={"installation_id": 12345, "state": "not-a-real-state"},
+    )
+    assert r.status_code == 403
+    assert "invalid" in r.json()["detail"].lower()
+
+
+def test_callback_valid_state_succeeds(client, monkeypatch, admin_headers):
+    install = client.get("/github/install/start", headers=admin_headers)
+    state = install.json()["state"]
+
+    async def fake_fetch(installation_id, config):
+        return _sample_installation_payload(installation_id)
+
+    monkeypatch.setattr(
+        "src.api.routes.github._fetch_installation_details",
+        fake_fetch,
+    )
+
+    r = client.get(
+        "/github/callback",
+        params={
+            "installation_id": 12345,
+            "setup_action": "install",
+            "state": state,
+        },
+        follow_redirects=False,
+    )
+    assert r.status_code == 302
+    assert "installation_id=12345" in r.headers["location"]
+    assert "example-org" in r.headers["location"]
+
+    SessionLocal = client.app.state.test_session_local
+    with SessionLocal() as session:
+        row = (
+            session.query(GitHubInstallation)
+            .filter(GitHubInstallation.installation_id == 12345)
+            .first()
+        )
+        assert row is not None
+        assert row.account_login == "example-org"
+
+
+def test_callback_state_is_one_time_use(client, monkeypatch, admin_headers):
+    install = client.get("/github/install/start", headers=admin_headers)
+    state = install.json()["state"]
+
+    async def fake_fetch(installation_id, config):
+        return _sample_installation_payload(installation_id)
+
+    monkeypatch.setattr(
+        "src.api.routes.github._fetch_installation_details",
+        fake_fetch,
+    )
+
+    first = client.get(
+        "/github/callback",
+        params={"installation_id": 12345, "state": state},
+        follow_redirects=False,
+    )
+    assert first.status_code == 302
+
+    second = client.get(
+        "/github/callback",
+        params={"installation_id": 12345, "state": state},
+    )
+    assert second.status_code == 403
+
+
+def test_get_installation_requires_admin(client, app_github):
+    SessionLocal = app_github.state.test_session_local
+    with SessionLocal() as session:
+        session.add(
+            GitHubInstallation(
+                id="inst-1",
+                installation_id=777,
+                app_id=999,
+                account_id=42,
+                account_login="example-org",
+                account_type="Organization",
+                status="active",
+            )
+        )
+        session.commit()
+
+    r = client.get("/github/installations/777")
+    assert r.status_code in (401, 503)
+
+
+def test_get_installation_with_admin(client, app_github, admin_headers):
+    SessionLocal = app_github.state.test_session_local
+    with SessionLocal() as session:
+        session.add(
+            GitHubInstallation(
+                id="inst-1",
+                installation_id=777,
+                app_id=999,
+                account_id=42,
+                account_login="example-org",
+                account_type="Organization",
+                status="active",
+            )
+        )
+        session.commit()
+
+    r = client.get("/github/installations/777", headers=admin_headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["installation_id"] == 777
+    assert body["account_login"] == "example-org"
+
+
+def test_mint_install_state_helper():
+    clear_install_state_store()
+    state = mint_install_state(created_by="test")
+    assert state
+    clear_install_state_store()

--- a/web_ui/next.config.ts
+++ b/web_ui/next.config.ts
@@ -31,6 +31,7 @@ const nextConfig: NextConfig = {
       // Proxy GitHub App OAuth callback to config service
       // GitHub redirects here after app installation
       { source: "/github/callback", destination: `${base}/github/callback` },
+      { source: "/github/install/start", destination: `${base}/github/install/start` },
       { source: "/github/installations/:path*", destination: `${base}/github/installations/:path*` },
     ];
   },


### PR DESCRIPTION
## Summary
- Mint one-time server-side state before GitHub App install and reject callbacks that omit or reuse it
- Require admin on install-start and installation info routes

Closes #31

## Test plan
- [ ] `pytest config_service/tests/test_github_callback.py`
- [ ] Callback without state → 400; bogus or expired state → 403
- [ ] Install start and installation info require admin