### PR TITLE
Scope unified-audit to the caller org

### DIFF
--- a/config_service/src/api/routes/audit.py
+++ b/config_service/src/api/routes/audit.py
@@ -17,6 +17,8 @@ from src.api.auth import AdminPrincipal, authenticate_admin_request
 from src.db import repository
 from src.db.session import db_session
 
+from .admin import check_org_access
+
 router = APIRouter(prefix="/unified-audit", tags=["Unified Audit"])
 
 
@@ -129,6 +131,7 @@ def list_unified_audit(
     - config: Configuration changes
     - agent: Agent run records
     """
+    check_org_access(admin, org_id)
     source_list = sources.split(",") if sources else None
     event_type_list = event_types.split(",") if event_types else None
 
@@ -193,6 +196,7 @@ def export_audit_csv(
     admin: AdminPrincipal = Depends(require_admin),
 ):
     """Export audit log as CSV for compliance reporting."""
+    check_org_access(admin, org_id)
     source_list = sources.split(",") if sources else None
     event_type_list = event_types.split(",") if event_types else None
 
@@ -261,6 +265,7 @@ def create_agent_run(
     admin: AdminPrincipal = Depends(require_admin),
 ):
     """Create a new agent run record (called by orchestrator at run start)."""
+    check_org_access(admin, request.org_id)
     run = repository.create_agent_run(
         session,
         run_id=request.run_id,
@@ -357,6 +362,7 @@ def list_agent_runs(
     admin: AdminPrincipal = Depends(require_admin),
 ):
     """List agent runs with filtering."""
+    check_org_access(admin, org_id)
     runs = repository.list_agent_runs(
         session,
         org_id=org_id,

--- a/config_service/src/api/routes/audit.py
+++ b/config_service/src/api/routes/audit.py
@@ -9,7 +9,7 @@ import io
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -303,12 +303,22 @@ def create_agent_run(
 
 @router.patch("/agent-runs/{run_id}", response_model=AgentRunResponse)
 def complete_agent_run(
+    org_id: str,
     run_id: str,
     request: AgentRunCompleteRequest,
     session: Session = Depends(get_db),
     admin: AdminPrincipal = Depends(require_admin),
 ):
     """Mark an agent run as complete (called by orchestrator when run finishes)."""
+    existing = repository.get_agent_run(session, run_id=run_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Agent run not found")
+
+    check_org_access(admin, existing.org_id)
+
+    if org_id != existing.org_id:
+        raise HTTPException(status_code=404, detail="Agent run not found")
+
     run = repository.complete_agent_run(
         session,
         run_id=run_id,
@@ -321,8 +331,6 @@ def complete_agent_run(
     )
 
     if run is None:
-        from fastapi import HTTPException
-
         raise HTTPException(status_code=404, detail="Agent run not found")
 
     session.commit()

--- a/config_service/src/core/admin_rbac.py
+++ b/config_service/src/core/admin_rbac.py
@@ -48,6 +48,9 @@ def resolve_admin_permissions(
     Defaults:
     - ADMIN_PERMISSIONS_DEFAULT: "admin:*" (preserves current behavior)
     - ADMIN_GROUP_PERMISSIONS_JSON: optional fine-grained mapping.
+
+    Note: permission strings are informational for /auth/me unless a route
+    enforces them explicitly. Org boundaries are enforced via check_org_access.
     """
     # Break-glass tokens keep full access by default.
     if auth_kind == "admin_token":

--- a/config_service/tests/test_unified_audit_rbac.py
+++ b/config_service/tests/test_unified_audit_rbac.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 fastapi = pytest.importorskip("fastapi")
@@ -143,3 +145,44 @@ def test_org_admin_denied_foreign_agent_run_create():
         },
     )
     assert r.status_code == 403
+
+
+def test_org_admin_denied_foreign_agent_run_complete(monkeypatch):
+    admin = AdminPrincipal(
+        auth_kind="org_admin_token",
+        subject="org_admin:org1",
+        email=None,
+        claims={},
+        org_id="org1",
+    )
+    client = TestClient(_audit_app(admin))
+
+    foreign_run = SimpleNamespace(org_id="org2")
+    monkeypatch.setattr(
+        audit_routes.repository,
+        "get_agent_run",
+        lambda *a, **k: foreign_run,
+    )
+
+    complete_called = []
+
+    def _fail_if_complete(*args, **kwargs):
+        complete_called.append(True)
+        return None
+
+    monkeypatch.setattr(
+        audit_routes.repository,
+        "complete_agent_run",
+        _fail_if_complete,
+    )
+
+    r = client.patch(
+        "/api/v1/admin/orgs/org1/unified-audit/agent-runs/run-foreign",
+        json={
+            "run_id": "run-foreign",
+            "status": "completed",
+        },
+    )
+    assert r.status_code == 403
+    assert "org1" in r.json()["detail"]
+    assert complete_called == []

--- a/config_service/tests/test_unified_audit_rbac.py
+++ b/config_service/tests/test_unified_audit_rbac.py
@@ -1,0 +1,145 @@
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from src.api.auth import AdminPrincipal
+from src.api.routes import audit as audit_routes
+
+
+def _audit_app(admin: AdminPrincipal) -> FastAPI:
+    app = FastAPI()
+    app.include_router(audit_routes.router, prefix="/api/v1/admin/orgs/{org_id}")
+
+    def override_admin() -> AdminPrincipal:
+        return admin
+
+    def override_db():
+        yield None
+
+    app.dependency_overrides[audit_routes.require_admin] = override_admin
+    app.dependency_overrides[audit_routes.get_db] = override_db
+    return app
+
+
+def test_org_admin_denied_foreign_unified_audit_list():
+    admin = AdminPrincipal(
+        auth_kind="org_admin_token",
+        subject="org_admin:org1",
+        email=None,
+        claims={},
+        org_id="org1",
+    )
+    client = TestClient(_audit_app(admin))
+
+    r = client.get("/api/v1/admin/orgs/org2/unified-audit")
+    assert r.status_code == 403
+    assert "org1" in r.json()["detail"]
+
+
+def test_org_admin_denied_foreign_unified_audit_export():
+    admin = AdminPrincipal(
+        auth_kind="org_admin_token",
+        subject="org_admin:org1",
+        email=None,
+        claims={},
+        org_id="org1",
+    )
+    client = TestClient(_audit_app(admin))
+
+    r = client.get("/api/v1/admin/orgs/org2/unified-audit/export")
+    assert r.status_code == 403
+    assert "org1" in r.json()["detail"]
+
+
+def test_org_admin_denied_foreign_agent_runs_list():
+    admin = AdminPrincipal(
+        auth_kind="org_admin_token",
+        subject="org_admin:org1",
+        email=None,
+        claims={},
+        org_id="org1",
+    )
+    client = TestClient(_audit_app(admin))
+
+    r = client.get("/api/v1/admin/orgs/org2/unified-audit/agent-runs")
+    assert r.status_code == 403
+
+
+def test_org_admin_can_list_own_unified_audit(monkeypatch):
+    admin = AdminPrincipal(
+        auth_kind="org_admin_token",
+        subject="org_admin:org1",
+        email=None,
+        claims={},
+        org_id="org1",
+    )
+    client = TestClient(_audit_app(admin))
+
+    monkeypatch.setattr(audit_routes.repository, "list_unified_audit", lambda *a, **k: ([], 0))
+    monkeypatch.setattr(audit_routes.repository, "list_org_nodes", lambda *a, **k: [])
+
+    r = client.get("/api/v1/admin/orgs/org1/unified-audit")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["events"] == []
+    assert body["total"] == 0
+
+
+def test_super_admin_can_access_any_org_unified_audit(monkeypatch):
+    admin = AdminPrincipal(
+        auth_kind="admin_token",
+        subject="super_admin",
+        email=None,
+        claims={},
+        org_id=None,
+    )
+    client = TestClient(_audit_app(admin))
+
+    monkeypatch.setattr(audit_routes.repository, "list_unified_audit", lambda *a, **k: ([], 0))
+    monkeypatch.setattr(audit_routes.repository, "list_org_nodes", lambda *a, **k: [])
+
+    for org_id in ("org1", "org2"):
+        r = client.get(f"/api/v1/admin/orgs/{org_id}/unified-audit")
+        assert r.status_code == 200
+        assert r.json()["total"] == 0
+
+
+def test_super_admin_can_export_any_org_unified_audit(monkeypatch):
+    admin = AdminPrincipal(
+        auth_kind="admin_token",
+        subject="super_admin",
+        email=None,
+        claims={},
+        org_id=None,
+    )
+    client = TestClient(_audit_app(admin))
+
+    monkeypatch.setattr(audit_routes.repository, "list_unified_audit", lambda *a, **k: ([], 0))
+
+    for org_id in ("org1", "org2"):
+        exp = client.get(f"/api/v1/admin/orgs/{org_id}/unified-audit/export")
+        assert exp.status_code == 200
+        assert "text/csv" in (exp.headers.get("content-type") or "")
+
+
+def test_org_admin_denied_foreign_agent_run_create():
+    admin = AdminPrincipal(
+        auth_kind="org_admin_token",
+        subject="org_admin:org1",
+        email=None,
+        claims={},
+        org_id="org1",
+    )
+    client = TestClient(_audit_app(admin))
+
+    r = client.post(
+        "/api/v1/admin/orgs/org1/unified-audit/agent-runs",
+        json={
+            "run_id": "run-1",
+            "org_id": "org2",
+            "trigger_source": "web",
+            "agent_name": "investigator",
+        },
+    )
+    assert r.status_code == 403


### PR DESCRIPTION
## Summary
- Require org-boundary checks on unified-audit list/export and related agent-run routes
- Completing a run is gated on the run's org, not a client-supplied org id

Closes #32

## Test plan
- [ ] `pytest config_service/tests/test_unified_audit_rbac.py`
- [ ] Org-scoped admin cannot list or export another org's unified audit
- [ ] Super-admin still can