### PR TITLE
Redact tool output in SSE and persisted runs

### DIFF
--- a/sre-agent/events.py
+++ b/sre-agent/events.py
@@ -11,6 +11,8 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from typing import Optional
 
+from tool_output_sanitize import sanitize_tool_input
+
 
 @dataclass
 class StreamEvent:
@@ -92,6 +94,7 @@ def tool_start_event(
     data["parent_agent_type"] = parent_agent_type
     data["depth"] = depth
     if tool_input:
+        tool_input = sanitize_tool_input(name, tool_input)
         # Extract relevant info based on tool type
         if name == "Bash" and "command" in tool_input:
             data["command"] = tool_input["command"]

--- a/sre-agent/server_simple.py
+++ b/sre-agent/server_simple.py
@@ -35,7 +35,7 @@ from memory.retrieval import EpisodeRetriever
 from memory.store import EpisodeStore
 from pydantic import BaseModel
 from report import extract_structured_report
-from tool_output_sanitize import sanitize_tool_end_payload
+from tool_output_sanitize import sanitize_tool_end_payload, sanitize_tool_input
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -296,6 +296,8 @@ def _tool_call_record(
     ).isoformat()
     tool_name = data.get("name") or started.get("name") or "unknown"
     tool_input = data.get("input") or started.get("input")
+    if tool_input is not None:
+        tool_input = sanitize_tool_input(tool_name, tool_input)
     tool_output = data.get("output") or data.get("summary")
     error_message = data.get("error")
     tool_output, error_message = sanitize_tool_end_payload(

--- a/sre-agent/tests/test_tool_output_sanitize.py
+++ b/sre-agent/tests/test_tool_output_sanitize.py
@@ -1,11 +1,14 @@
-"""Unit tests for env/printenv Bash output sanitization."""
+"""Unit tests for tool output/input sanitization and secret redaction."""
 
 import json
 
+from events import tool_start_event
 from tool_output_sanitize import (
     is_env_dump_command,
     sanitize_bash_output,
+    sanitize_command,
     sanitize_tool_end_payload,
+    sanitize_tool_input,
 )
 
 
@@ -41,9 +44,12 @@ def test_printenv_single_var_redacted():
     assert sanitized == "BKT_HOST=<redacted>"
 
 
-def test_kubectl_output_unchanged():
-    output = "NAME    READY   STATUS\npod-1   1/1     Running"
-    assert sanitize_bash_output("kubectl get pods", output) == output
+def test_kubectl_output_redacts_embedded_secrets():
+    secret = "ghp_abcdefghijklmnopqrstuvwxyz1234567890"
+    output = f"NAME    READY   STATUS\npod-1   1/1     Running token={secret}"
+    sanitized = sanitize_bash_output("kubectl get pods", output)
+    assert secret not in sanitized
+    assert "<redacted>" in sanitized
 
 
 def test_json_stdout_wrapper_sanitized():
@@ -58,6 +64,30 @@ def test_json_stdout_wrapper_sanitized():
     parsed = json.loads(sanitized)
     assert secret not in parsed["stdout"]
     assert "BKT_TOKEN=<redacted>" in parsed["stdout"]
+
+
+def test_authorization_header_redacted_in_output():
+    output = "HTTP/1.1 200 OK\nAuthorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig"
+    sanitized, _ = sanitize_tool_end_payload("Read", None, output, None)
+    assert "eyJhbGciOiJIUzI1NiJ9" not in sanitized
+    assert "Authorization: Bearer <redacted>" in sanitized
+
+
+def test_aws_access_key_redacted():
+    key = "AKIAIOSFODNN7EXAMPLE"
+    output = f"Using credentials {key} for request"
+    sanitized, _ = sanitize_tool_end_payload(
+        "Bash", {"command": "aws sts get-caller-identity"}, output, None
+    )
+    assert key not in sanitized
+    assert "<redacted>" in sanitized
+
+
+def test_generic_api_key_assignment_redacted():
+    output = "config: api_key=supersecretvalue12345"
+    sanitized, _ = sanitize_tool_end_payload("Read", None, output, None)
+    assert "supersecretvalue12345" not in sanitized
+    assert "api_key=<redacted>" in sanitized
 
 
 def test_sanitize_tool_end_payload_early_return_for_non_bash():
@@ -80,3 +110,46 @@ def test_sanitize_tool_end_payload_redacts_bash_env():
     )
     assert output == "BKT_TOKEN=<redacted>"
     assert error is None
+
+
+def test_sanitize_tool_end_payload_redacts_error_message():
+    secret = "ghp_abcdefghijklmnopqrstuvwxyz1234567890"
+    _, error = sanitize_tool_end_payload(
+        "Bash",
+        {"command": "curl https://api.github.com"},
+        None,
+        f"401 Unauthorized token={secret}",
+    )
+    assert secret not in error
+    assert "<redacted>" in error
+
+
+def test_sanitize_command_redacts_embedded_bearer_token():
+    secret = "sk-abcdefghijklmnopqrstuvwxyz123456"
+    command = f"curl -H 'Authorization: Bearer {secret}' https://api.example.com"
+    sanitized = sanitize_command(command)
+    assert secret not in sanitized
+    assert "Bearer <redacted>" in sanitized
+
+
+def test_sanitize_tool_input_redacts_bash_command():
+    secret = "ghp_abcdefghijklmnopqrstuvwxyz1234567890"
+    sanitized = sanitize_tool_input(
+        "Bash",
+        {"command": f"curl -H Authorization: Bearer {secret}"},
+    )
+    assert secret not in sanitized["command"]
+    assert "<redacted>" in sanitized["command"]
+
+
+def test_tool_start_event_redacts_command_in_sse_payload():
+    secret = "ghp_abcdefghijklmnopqrstuvwxyz1234567890"
+    evt = tool_start_event(
+        "thread-1",
+        "Bash",
+        {"command": f"curl -H Authorization: Bearer {secret}"},
+        tool_use_id="t1",
+    )
+    assert secret not in evt.data["command"]
+    assert "<redacted>" in evt.data["command"]
+    assert secret not in json.dumps(evt.data["input"])

--- a/sre-agent/tests/test_tool_output_sanitize.py
+++ b/sre-agent/tests/test_tool_output_sanitize.py
@@ -269,3 +269,37 @@ def test_json_value_with_escaped_quote_fully_redacted():
     sanitized, _ = sanitize_tool_end_payload("Read", None, body, None)
     assert secret not in sanitized
     assert '"token": "<redacted>"' in sanitized
+
+
+def test_prefixed_json_and_yaml_token_password_keys_redacted():
+    cases = [
+        ('{"refresh_token": "opaquererefreshtoken99"}', "opaquererefreshtoken99"),
+        ('{"id_token": "opaqueidtokenvalue99999"}', "opaqueidtokenvalue99999"),
+        ('{"POSTGRES_PASSWORD": "superdbpassfromjson"}', "superdbpassfromjson"),
+        ("refresh_token: yamlsecrettokenvalue99", "yamlsecrettokenvalue99"),
+        ("POSTGRES_PASSWORD: yamlsecretpassword99", "yamlsecretpassword99"),
+    ]
+    for output, secret in cases:
+        sanitized, _ = sanitize_tool_end_payload("Read", None, output, None)
+        assert secret not in sanitized, output
+        assert "<redacted>" in sanitized
+
+
+def test_prefixed_env_key_preserves_leading_delimiter():
+    secret = "atlassianapitoken123"
+    output = f"hello JIRA_API_TOKEN={secret}"
+    sanitized, _ = sanitize_tool_end_payload("Read", None, output, None)
+    assert secret not in sanitized
+    assert "hello JIRA_API_TOKEN=<redacted>" in sanitized
+
+
+def test_curl_user_equals_and_glued_u_redacted():
+    secret = "curlsecretpass456"
+    cases = [
+        f"curl --user=deploy:{secret} https://api.example.com",
+        f"curl -udeploy:{secret} https://api.example.com",
+    ]
+    for command in cases:
+        sanitized = sanitize_command(command)
+        assert secret not in sanitized, command
+        assert "deploy:<redacted>" in sanitized

--- a/sre-agent/tests/test_tool_output_sanitize.py
+++ b/sre-agent/tests/test_tool_output_sanitize.py
@@ -153,3 +153,63 @@ def test_tool_start_event_redacts_command_in_sse_payload():
     assert secret not in evt.data["command"]
     assert "<redacted>" in evt.data["command"]
     assert secret not in json.dumps(evt.data["input"])
+
+
+def test_json_quoted_token_key_redacted():
+    secret = "supersecretvalue12345"
+    body = json.dumps({"token": secret, "status": "ok"})
+    sanitized, _ = sanitize_tool_end_payload("Read", None, body, None)
+    assert secret not in sanitized
+    assert '"token": "<redacted>"' in sanitized
+    assert '"status": "ok"' in sanitized
+
+
+def test_json_quoted_keys_with_whitespace_redacted():
+    secret = "my-api-key-value12345"
+    body = '{"api_key" : "' + secret + '", "password": "hunter2pass"}'
+    sanitized, _ = sanitize_tool_end_payload("Read", None, body, None)
+    assert secret not in sanitized
+    assert "hunter2pass" not in sanitized
+    assert '"api_key": "<redacted>"' in sanitized
+    assert '"password": "<redacted>"' in sanitized
+
+
+def test_json_quoted_secrets_inside_sdk_bash_wrapper():
+    secret = "sk-ant-api03-abcdefghijklmnopqrstuvwxyz"
+    inner = json.dumps({"token": secret, "api-key": "anothersecret123"})
+    wrapper = {"stdout": inner, "stderr": "", "returncode": 0}
+    raw = json.dumps(wrapper)
+    sanitized = sanitize_bash_output("curl https://api.example.com", raw)
+    parsed = json.loads(sanitized)
+    assert secret not in parsed["stdout"]
+    assert "anothersecret123" not in parsed["stdout"]
+    assert '"token": "<redacted>"' in parsed["stdout"]
+    assert '"api-key": "<redacted>"' in parsed["stdout"]
+
+
+def test_sk_hyphenated_vendor_keys_redacted():
+    anthropic = "sk-ant-api03-abcdefghijklmnopqrstuvwxyz123456"
+    openai = "sk-proj-abcdefghijklmnopqrstuvwxyz123456"
+    for key in (anthropic, openai):
+        sanitized, _ = sanitize_tool_end_payload("Read", None, f"key={key}", None)
+        assert key not in sanitized
+        assert "<redacted>" in sanitized
+
+
+def test_oauth_label_not_over_redacted():
+    output = "oauth: github-enterprise"
+    sanitized, _ = sanitize_tool_end_payload("Read", None, output, None)
+    assert sanitized == output
+
+
+def test_current_pwd_label_not_over_redacted():
+    output = "current pwd: /Users/foo/project"
+    sanitized, _ = sanitize_tool_end_payload("Read", None, output, None)
+    assert sanitized == output
+
+
+def test_invalid_token_message_redacted():
+    output = "invalid token: expected-claim-missing"
+    sanitized, _ = sanitize_tool_end_payload("Read", None, output, None)
+    assert "expected-claim-missing" not in sanitized
+    assert "token=<redacted>" in sanitized

--- a/sre-agent/tests/test_tool_output_sanitize.py
+++ b/sre-agent/tests/test_tool_output_sanitize.py
@@ -213,3 +213,59 @@ def test_invalid_token_message_redacted():
     sanitized, _ = sanitize_tool_end_payload("Read", None, output, None)
     assert "expected-claim-missing" not in sanitized
     assert "token=<redacted>" in sanitized
+
+
+def test_json_access_token_and_client_secret_redacted():
+    access = "supersecretaccesstoken123"
+    client = "supersecretclientsecret123"
+    body = json.dumps({"access_token": access, "client_secret": client})
+    sanitized, _ = sanitize_tool_end_payload("Read", None, body, None)
+    assert access not in sanitized
+    assert client not in sanitized
+    assert '"access_token": "<redacted>"' in sanitized
+    assert '"client_secret": "<redacted>"' in sanitized
+
+
+def test_url_userinfo_password_redacted():
+    cases = [
+        ("https://admin:sekretpass@db.example.com:5432/app", "sekretpass"),
+        ("postgres://appuser:dbpass12345@localhost:5432/mydb", "dbpass12345"),
+    ]
+    for url, secret in cases:
+        sanitized, _ = sanitize_tool_end_payload("Read", None, url, None)
+        assert secret not in sanitized
+        assert ":<redacted>@" in sanitized
+
+
+def test_plain_url_without_userinfo_unchanged():
+    url = "https://api.example.com/v1/users?page=1"
+    sanitized, _ = sanitize_tool_end_payload("Read", None, url, None)
+    assert sanitized == url
+
+
+def test_curl_u_user_password_redacted():
+    secret = "curlsecretpass123"
+    command = f"curl -u deploy:{secret} https://api.example.com"
+    sanitized = sanitize_command(command)
+    assert secret not in sanitized
+    assert "deploy:<redacted>" in sanitized
+
+
+def test_prefixed_env_style_password_and_token_redacted():
+    cases = [
+        ("POSTGRES_PASSWORD=superdbpass123", "superdbpass123"),
+        ("JIRA_API_TOKEN=atlassianapitoken123", "atlassianapitoken123"),
+        ('export POSTGRES_PASSWORD="longpassvalue123"', "longpassvalue123"),
+    ]
+    for output, secret in cases:
+        sanitized, _ = sanitize_tool_end_payload("Read", None, output, None)
+        assert secret not in sanitized
+        assert "<redacted>" in sanitized
+
+
+def test_json_value_with_escaped_quote_fully_redacted():
+    secret = "value-with-embedded-quote"
+    body = r'{"token": "prefix \"' + secret + r'\" suffix"}'
+    sanitized, _ = sanitize_tool_end_payload("Read", None, body, None)
+    assert secret not in sanitized
+    assert '"token": "<redacted>"' in sanitized

--- a/sre-agent/tool_output_sanitize.py
+++ b/sre-agent/tool_output_sanitize.py
@@ -60,11 +60,22 @@ _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"\bgho_[A-Za-z0-9]{20,}\b"), _REDACTED),
     (re.compile(r"\bxox[baprs]-[0-9a-zA-Z\-]{10,}\b"), _REDACTED),
     (re.compile(r"\bATATT[A-Za-z0-9_\-]{20,}\b"), _REDACTED),
-    (re.compile(r"\bsk-[A-Za-z0-9]{20,}\b"), _REDACTED),
-    # Generic api_key / secret / token / password assignments.
+    # sk-* vendor keys (Anthropic sk-ant-api03-…, OpenAI sk-proj-…, etc.).
+    (re.compile(r"\bsk-[A-Za-z0-9\-]{20,}\b"), _REDACTED),
+    # JSON object keys: "token": "…", "api_key" : "…" (whitespace around ':').
     (
         re.compile(
-            r"(?i)(api[_-]?key|apikey|secret|token|password|passwd|pwd|auth)\s*[:=]\s*['\"]?[^\s'\"]{8,}['\"]?",
+            r'(?i)("(?:token|api[_-]?key|api-key|password|secret|access[_-]?key|authorization)")\s*:\s*"[^"]*"',
+        ),
+        r'\1: "' + _REDACTED + '"',
+    ),
+    # Generic key=value / key: value assignments (word-boundary keys only).
+    (
+        re.compile(
+            r"(?i)\b("
+            r"api[_-]?key|apikey|access[_-]?key|access[_-]?token|"
+            r"client[_-]?secret|secret|token|password|passwd"
+            r")\b\s*[:=]\s*['\"]?[^\s'\"]{8,}['\"]?",
         ),
         r"\1=" + _REDACTED,
     ),

--- a/sre-agent/tool_output_sanitize.py
+++ b/sre-agent/tool_output_sanitize.py
@@ -28,6 +28,16 @@ _SUMMARY_THRESHOLD = 15
 
 _REDACTED = "<redacted>"
 
+# Shared secret key names for JSON object keys and generic key=value assignments.
+# Both matchers derive from this list so they cannot drift.
+_SECRET_KEY_ALT = (
+    r"token|api[_-]?key|apikey|access[_-]?key|access[_-]?token|"
+    r"client[_-]?secret|secret|password|passwd|authorization"
+)
+
+# JSON string values may contain escaped quotes; match until an unescaped closing quote.
+_JSON_STRING_VALUE = r'"(?:[^"\\]|\\.)*"'
+
 # Secret-shaped substrings in arbitrary tool output, commands, and errors.
 _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     # Authorization / auth headers (curl -H, HTTP responses, etc.)
@@ -65,19 +75,38 @@ _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     # JSON object keys: "token": "…", "api_key" : "…" (whitespace around ':').
     (
         re.compile(
-            r'(?i)("(?:token|api[_-]?key|api-key|password|secret|access[_-]?key|authorization)")\s*:\s*"[^"]*"',
+            rf'(?i)("(?:{_SECRET_KEY_ALT})")\s*:\s*{_JSON_STRING_VALUE}',
         ),
         r'\1: "' + _REDACTED + '"',
     ),
     # Generic key=value / key: value assignments (word-boundary keys only).
     (
         re.compile(
-            r"(?i)\b("
-            r"api[_-]?key|apikey|access[_-]?key|access[_-]?token|"
-            r"client[_-]?secret|secret|token|password|passwd"
-            r")\b\s*[:=]\s*['\"]?[^\s'\"]{8,}['\"]?",
+            rf"(?i)\b({_SECRET_KEY_ALT})\b\s*[:=]\s*['\"]?[^\s'\"]" + r"{8,}['\"]?",
         ),
         r"\1=" + _REDACTED,
+    ),
+    # Prefixed env-style keys: POSTGRES_PASSWORD=…, JIRA_API_TOKEN=… (\b misses after '_').
+    (
+        re.compile(
+            r"(?i)(?:^|[\s\"'\\{,])"
+            r"([A-Za-z0-9_]*_(?:PASSWORD|TOKEN|SECRET|API_KEY|ACCESS_KEY))"
+            r"\s*=\s*\S+",
+        ),
+        r"\1=" + _REDACTED,
+    ),
+    # URL userinfo: scheme://user:password@host (common DB/HTTP schemes only).
+    (
+        re.compile(
+            r"(?i)((?:https?|postgres(?:ql)?|mysql|redis|mongodb(?:\+srv)?|amqp)://)"
+            r"([^:@/\s]+):([^@\s/]+)@",
+        ),
+        rf"\1\2:{_REDACTED}@",
+    ),
+    # curl -u / --user user:password
+    (
+        re.compile(r"(?i)((?:^|[\s|;&])(?:-u|--user)\s+)([^:\s]+):([^\s'\"]+)"),
+        rf"\1\2:{_REDACTED}",
     ),
     # PEM private keys.
     (

--- a/sre-agent/tool_output_sanitize.py
+++ b/sre-agent/tool_output_sanitize.py
@@ -79,6 +79,14 @@ _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         ),
         r'\1: "' + _REDACTED + '"',
     ),
+    # Prefixed JSON keys: "refresh_token": "…", "POSTGRES_PASSWORD": "…"
+    (
+        re.compile(
+            r'(?i)("([A-Za-z0-9_]*_(?:PASSWORD|TOKEN|SECRET|API_KEY|ACCESS_KEY))")'
+            rf"\s*:\s*{_JSON_STRING_VALUE}",
+        ),
+        r'\1: "' + _REDACTED + '"',
+    ),
     # Generic key=value / key: value assignments (word-boundary keys only).
     (
         re.compile(
@@ -86,14 +94,15 @@ _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         ),
         r"\1=" + _REDACTED,
     ),
-    # Prefixed env-style keys: POSTGRES_PASSWORD=…, JIRA_API_TOKEN=… (\b misses after '_').
+    # Prefixed env / YAML keys: POSTGRES_PASSWORD=…, refresh_token: … (\b misses after '_').
+    # Keep the delimiter character before the key so surrounding text is not glued.
     (
         re.compile(
-            r"(?i)(?:^|[\s\"'\\{,])"
+            r"(?i)(^|[\s\"'\\{,])"
             r"([A-Za-z0-9_]*_(?:PASSWORD|TOKEN|SECRET|API_KEY|ACCESS_KEY))"
-            r"\s*=\s*\S+",
+            r"\s*[:=]\s*\S+",
         ),
-        r"\1=" + _REDACTED,
+        rf"\1\2={_REDACTED}",
     ),
     # URL userinfo: scheme://user:password@host (common DB/HTTP schemes only).
     (
@@ -103,9 +112,17 @@ _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         ),
         rf"\1\2:{_REDACTED}@",
     ),
-    # curl -u / --user user:password
+    # curl -u / --user user:password (spaced, glued, or --user= / -u= forms)
     (
-        re.compile(r"(?i)((?:^|[\s|;&])(?:-u|--user)\s+)([^:\s]+):([^\s'\"]+)"),
+        re.compile(
+            r"(?i)((?:^|[\s|;&])(?:--user=|-u=|--user\s+|-u\s+))"
+            r"([^:\s]+):([^\s'\"]+)"
+        ),
+        rf"\1\2:{_REDACTED}",
+    ),
+    # Glued short form: curl -udeploy:pass (no space after -u)
+    (
+        re.compile(r"(?i)((?:^|[\s|;&])-u)([^:\s=/-][^:\s]*):([^\s'\"]+)"),
         rf"\1\2:{_REDACTED}",
     ),
     # PEM private keys.

--- a/sre-agent/tool_output_sanitize.py
+++ b/sre-agent/tool_output_sanitize.py
@@ -1,11 +1,13 @@
-"""Sanitize env/printenv Bash tool output before SSE stream and DB persistence.
+"""Sanitize tool inputs and outputs before SSE stream and DB persistence.
 
-Keeps variable names visible for debugging; strips all values so secrets never
-land in traces or the web UI.
+Redacts environment dumps, Authorization headers, bearer tokens, common API key
+patterns, AWS keys, and other credential shapes so secrets never land in traces
+or the web UI.
 """
 
 from __future__ import annotations
 
+import copy
 import json
 import re
 from typing import Any
@@ -25,6 +27,63 @@ _DECLARE_X_LINE = re.compile(r"^declare\s+-x\s+([A-Za-z_][A-Za-z0-9_]*)(?:=(.*))
 _SUMMARY_THRESHOLD = 15
 
 _REDACTED = "<redacted>"
+
+# Secret-shaped substrings in arbitrary tool output, commands, and errors.
+_SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # Authorization / auth headers (curl -H, HTTP responses, etc.)
+    (
+        re.compile(
+            r"(?i)(Authorization\s*:\s*)(Bearer|Basic|Token)\s+[^\s'\"]+",
+            re.MULTILINE,
+        ),
+        r"\1\2 " + _REDACTED,
+    ),
+    (
+        re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._\-+/=]{8,}"),
+        "Bearer " + _REDACTED,
+    ),
+    (
+        re.compile(r"(?i)\bBasic\s+[A-Za-z0-9+/=]{8,}"),
+        "Basic " + _REDACTED,
+    ),
+    # AWS access key IDs and common secret-key assignments.
+    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), _REDACTED),
+    (
+        re.compile(
+            r"(?i)(aws[_\s-]?secret[_\s-]?access[_\s-]?key|secret_access_key)\s*[:=]\s*['\"]?[A-Za-z0-9/+=]{40}['\"]?",
+        ),
+        r"\1=" + _REDACTED,
+    ),
+    # Well-known token prefixes.
+    (re.compile(r"\bghp_[A-Za-z0-9]{20,}\b"), _REDACTED),
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"), _REDACTED),
+    (re.compile(r"\bgho_[A-Za-z0-9]{20,}\b"), _REDACTED),
+    (re.compile(r"\bxox[baprs]-[0-9a-zA-Z\-]{10,}\b"), _REDACTED),
+    (re.compile(r"\bATATT[A-Za-z0-9_\-]{20,}\b"), _REDACTED),
+    (re.compile(r"\bsk-[A-Za-z0-9]{20,}\b"), _REDACTED),
+    # Generic api_key / secret / token / password assignments.
+    (
+        re.compile(
+            r"(?i)(api[_-]?key|apikey|secret|token|password|passwd|pwd|auth)\s*[:=]\s*['\"]?[^\s'\"]{8,}['\"]?",
+        ),
+        r"\1=" + _REDACTED,
+    ),
+    # PEM private keys.
+    (
+        re.compile(
+            r"-----BEGIN[A-Z ]*PRIVATE KEY-----[\s\S]*?-----END[A-Z ]*PRIVATE KEY-----",
+            re.MULTILINE,
+        ),
+        _REDACTED,
+    ),
+    # JWT-shaped tokens (three base64url segments).
+    (
+        re.compile(
+            r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"
+        ),
+        _REDACTED,
+    ),
+]
 
 
 def is_env_dump_command(command: str) -> bool:
@@ -83,28 +142,61 @@ def _redact_env_text(text: str) -> str:
     return "\n".join(redacted_lines)
 
 
-def sanitize_bash_output(command: str, output: str | None) -> str | None:
-    """Redact values from env/printenv/set output; pass everything else through."""
-    if output is None or not is_env_dump_command(command):
-        return output
+def _redact_secrets_in_text(text: str) -> str:
+    """Apply regex-based secret redaction to arbitrary text."""
+    redacted = text
+    for pattern, replacement in _SECRET_PATTERNS:
+        redacted = pattern.sub(replacement, redacted)
+    return redacted
 
-    # SDK Bash responses are sometimes JSON-wrapped with stdout/stderr fields.
-    wrapper = _try_parse_json_output(output)
+
+def _sanitize_plain_or_json_text(text: str) -> str:
+    """Redact secrets in plain text or SDK JSON stdout/stderr wrappers."""
+    wrapper = _try_parse_json_output(text)
     if wrapper is not None:
         changed = False
         for field in ("stdout", "stderr"):
             if field in wrapper and wrapper[field] is not None:
                 inner = wrapper[field]
                 if isinstance(inner, str):
-                    sanitized = _redact_env_text(inner)
+                    sanitized = _redact_secrets_in_text(inner)
                     if sanitized != inner:
                         wrapper[field] = sanitized
                         changed = True
         if changed:
             return json.dumps(wrapper)
-        return output
+        return text
 
-    return _redact_env_text(output)
+    return _redact_secrets_in_text(text)
+
+
+def sanitize_bash_output(command: str, output: str | None) -> str | None:
+    """Redact env dumps and secret-shaped values from Bash tool output."""
+    if output is None:
+        return None
+
+    if is_env_dump_command(command):
+        wrapper = _try_parse_json_output(output)
+        if wrapper is not None:
+            changed = False
+            for field in ("stdout", "stderr"):
+                if field in wrapper and wrapper[field] is not None:
+                    inner = wrapper[field]
+                    if isinstance(inner, str):
+                        sanitized = _redact_env_text(inner)
+                        sanitized = _redact_secrets_in_text(sanitized)
+                        if sanitized != inner:
+                            wrapper[field] = sanitized
+                            changed = True
+            if changed:
+                output = json.dumps(wrapper)
+        else:
+            output = _redact_env_text(output)
+            output = _redact_secrets_in_text(output)
+    else:
+        output = _sanitize_plain_or_json_text(output)
+
+    return output
 
 
 def _try_parse_json_output(output: str) -> dict | None:
@@ -125,6 +217,27 @@ def _extract_command(tool_input: Any) -> str | None:
     return None
 
 
+def sanitize_command(command: str) -> str:
+    """Redact secret-shaped substrings embedded in a Bash command string."""
+    return _redact_secrets_in_text(command)
+
+
+def sanitize_tool_input(tool_name: str, tool_input: Any) -> Any:
+    """Redact secrets in tool_start payloads (commands, args, etc.)."""
+    if not isinstance(tool_input, dict):
+        return tool_input
+
+    sanitized = copy.deepcopy(tool_input)
+    if tool_name == "Bash" and isinstance(sanitized.get("command"), str):
+        sanitized["command"] = sanitize_command(sanitized["command"])
+
+    for key, value in sanitized.items():
+        if isinstance(value, str) and key != "command":
+            sanitized[key] = _redact_secrets_in_text(value)
+
+    return sanitized
+
+
 def sanitize_tool_end_payload(
     tool_name: str,
     tool_input: Any,
@@ -132,14 +245,14 @@ def sanitize_tool_end_payload(
     error: str | None,
 ) -> tuple[str | None, str | None]:
     """Entry point for hooks and persistence. Returns (output, error)."""
-    if tool_name != "Bash":
-        return output, error
+    if tool_name == "Bash":
+        command = _extract_command(tool_input)
+        if command:
+            return (
+                sanitize_bash_output(command, output),
+                sanitize_bash_output(command, error) if error else error,
+            )
 
-    command = _extract_command(tool_input)
-    if not command or not is_env_dump_command(command):
-        return output, error
-
-    return (
-        sanitize_bash_output(command, output),
-        sanitize_bash_output(command, error) if error else error,
-    )
+    sanitized_output = _sanitize_plain_or_json_text(output) if output else output
+    sanitized_error = _sanitize_plain_or_json_text(error) if error else error
+    return sanitized_output, sanitized_error


### PR DESCRIPTION
## Summary
- Broaden tool-output redaction on the live stream and persisted traces
- Target known credential shapes so ordinary diagnostic text is not mangled

Closes #34

## Test plan
- [ ] `pytest sre-agent/tests/test_tool_output_sanitize.py`
- [ ] Secret-bearing tool output is redacted; env-dump cases still redacted