### PR TITLE
Fix fresh local Docker Compose setup (volumes, org alignment, token list)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,8 @@ cp .env.example .env
 
 ```bash
 make dev
-# Starts Postgres, config-service, Neo4j, sre-agent, web-ui
+# Ensures external Docker volumes exist, then starts
+# Postgres, config-service, Neo4j, sre-agent, web-ui
 # Migrations run automatically
 # Web console: http://localhost:3002
 ```

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # Run 'make help' to see all available targets.
 
-.PHONY: help setup-llm compose-reconcile dev dev-slack dev-teams stop logs logs-agent logs-config logs-web status clean db-shell \
+.PHONY: help setup-llm ensure-volumes compose-reconcile dev dev-slack dev-teams stop logs logs-agent logs-config logs-web status clean db-shell \
         kind-create kind-delete otel-install otel-images otel-wait e2e-verify \
         e2e-setup e2e-teardown e2e-agent e2e-status e2e-token \
         e2e-setup-eks e2e-teardown-eks eks-port-forward eks-port-forward-stop \
@@ -142,18 +142,22 @@ help:
 setup-llm:
 	@bash scripts/generate-litellm-config.sh
 
+# External volumes (postgres/neo4j/agent-sessions) must exist before compose up.
+ensure-volumes:
+	@bash scripts/ensure-volumes.sh
+
 compose-reconcile:
 	@bash scripts/compose-reconcile.sh
 
-dev: setup-llm compose-reconcile
+dev: setup-llm ensure-volumes compose-reconcile
 	$(COMPOSE_DEV) up -d --build
 	@bash scripts/post-startup-banner.sh
 
-dev-slack: setup-llm compose-reconcile
+dev-slack: setup-llm ensure-volumes compose-reconcile
 	$(COMPOSE_DEV) --profile slack up -d --build
 	@bash scripts/post-startup-banner.sh
 
-dev-teams: setup-llm compose-reconcile
+dev-teams: setup-llm ensure-volumes compose-reconcile
 	$(COMPOSE_DEV) --profile teams up -d --build
 	@bash scripts/post-startup-banner.sh
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cp .env.example .env
 make dev
 ```
 
-This starts Postgres, config-service, Neo4j, sre-agent, and the web console. Migrations run automatically. Open **http://localhost:3002** and paste the admin token shown in the terminal to sign in. (LiteLLM is an optional `--profile litellm` add-on.)
+Requires **Docker Desktop** (or equivalent) running. `make dev` creates the external data volumes if they are missing, then starts Postgres, config-service, Neo4j, sre-agent, and the web console. Migrations run automatically. Open **http://localhost:3002** and paste the admin token shown in the terminal to sign in. (LiteLLM is an optional `--profile litellm` add-on.)
 
 > **[Full setup guide](https://www.opensre.in/docs/quick-start)** · **[Entra SSO](https://www.opensre.in/docs/sso)** · **[Slack integration](https://www.opensre.in/docs/integrations)** · **[Configuration](https://www.opensre.in/docs/configuration)**
 

--- a/config_service/scripts/seed_demo_data.py
+++ b/config_service/scripts/seed_demo_data.py
@@ -20,7 +20,7 @@ from src.db.session import db_session
 def main() -> None:
     load_dotenv()
     # Minimal seed data so /me/effective has something to return.
-    org_id = os.getenv("SEED_ORG_ID", "org1")
+    org_id = os.getenv("SEED_ORG_ID", "local")
     root_id = os.getenv("SEED_ROOT_NODE_ID", "root")
     team_id = os.getenv("SEED_TEAM_NODE_ID", "teamA")
     team_name = os.getenv("SEED_TEAM_NAME", "Team A")

--- a/config_service/src/api/routes/admin.py
+++ b/config_service/src/api/routes/admin.py
@@ -1031,12 +1031,10 @@ def admin_list_org_tokens(
 ):
     """List all tokens across all teams in the organization."""
     check_org_access(principal, org_id)
-    from src.db.repository import get_org_node, list_org_tokens
+    from src.db.repository import list_org_tokens, org_exists
 
-    # Verify org exists (org root node has node_id == org_id)
-    try:
-        get_org_node(session, org_id=org_id, node_id=org_id)
-    except ValueError:
+    # Org root is typically node_id='root' (seed / ensure_org_root_node), not node_id==org_id.
+    if not org_exists(session, org_id=org_id):
         raise HTTPException(status_code=404, detail="Organization not found")
 
     tokens = list_org_tokens(session, org_id=org_id)

--- a/config_service/src/db/repository.py
+++ b/config_service/src/db/repository.py
@@ -449,6 +449,26 @@ def get_org_node(session: Session, *, org_id: str, node_id: str) -> OrgNode:
     return node
 
 
+def org_exists(session: Session, *, org_id: str) -> bool:
+    """True if the org has any org-type root node.
+
+    Local seed and ensure_org_root_node use node_id='root' (not node_id==org_id).
+    Some deployments also use node_id==org_id. Accept either.
+    """
+    return (
+        session.execute(
+            select(OrgNode.node_id)
+            .where(
+                OrgNode.org_id == org_id,
+                OrgNode.node_type == NodeType.org,
+                OrgNode.parent_id.is_(None),
+            )
+            .limit(1)
+        ).scalar_one_or_none()
+        is not None
+    )
+
+
 def list_node_config_audit(
     session: Session, *, org_id: str, node_id: str, limit: int = 50
 ) -> List["ConfigChangeHistory"]:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,11 @@ services:
       ADMIN_AUTH_MODE: token
       TEAM_AUTH_MODE: token
       SSO_DEFAULT_TEAM_NODE_ID: ${SSO_DEFAULT_TEAM_NODE_ID:-default}
+      # Shared admin token has no org claim; /auth/me uses this so Org Tree
+      # and other admin pages target the seeded tenant (entrypoint seed uses local).
+      DEFAULT_ORG_ID: ${DEFAULT_ORG_ID:-local}
+      SEED_ORG_ID: ${SEED_ORG_ID:-local}
+      SEED_TEAM_NODE_ID: ${SEED_TEAM_NODE_ID:-default}
       IMPERSONATION_JWT_SECRET: local-dev-impersonation-secret-32chars!!
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       LOG_FORMAT: console
@@ -283,6 +288,11 @@ services:
       - WEB_UI_COOKIE_SECURE=0
       - HOSTNAME=0.0.0.0
       - PORT=3000
+      # Fallback when a page needs an org before identity loads; must match
+      # config-service DEFAULT_ORG_ID / seed tenant.
+      - DEFAULT_ORG_ID=${DEFAULT_ORG_ID:-local}
+      - NEXT_PUBLIC_DEFAULT_ORG_ID=${DEFAULT_ORG_ID:-local}
+      - ORG_ID=${ORG_ID:-local}
     ports:
       - "3002:3000"
     depends_on:
@@ -387,10 +397,9 @@ networks:
 
 # Named volumes are shared across worktrees via COMPOSE_PROJECT_NAME=opensre.
 # Mark external so `docker compose down -v` / `make clean` from ANY worktree
-# cannot wipe investigation/memory data. Create once if missing:
-#   docker volume create opensre-postgres-data
-#   docker volume create opensre-neo4j-data
-#   docker volume create opensre-agent-sessions
+# cannot wipe investigation/memory data.
+# `make dev` creates them via scripts/ensure-volumes.sh if missing.
+# Manual (optional): docker volume create opensre-{postgres,neo4j}-data opensre-agent-sessions
 volumes:
   postgres-data:
     name: opensre-postgres-data

--- a/scripts/ensure-volumes.sh
+++ b/scripts/ensure-volumes.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Ensure external Compose volumes exist before `make dev*`.
+#
+# Volumes are marked external:true in docker-compose.yml so
+# `docker compose down -v` / `make clean` cannot wipe investigation data
+# across worktrees. Compose will not create external volumes itself —
+# create them once (idempotent) here.
+
+set -euo pipefail
+
+VOLUMES=(
+  opensre-postgres-data
+  opensre-neo4j-data
+  opensre-agent-sessions
+)
+
+for name in "${VOLUMES[@]}"; do
+  if docker volume inspect "$name" >/dev/null 2>&1; then
+    continue
+  fi
+  echo "ensure-volumes: creating $name"
+  docker volume create "$name" >/dev/null
+done

--- a/web_ui/src/app/admin/audit/page.tsx
+++ b/web_ui/src/app/admin/audit/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useIdentity } from '@/lib/useIdentity';
 import { apiFetch } from '@/lib/apiClient';
+import { defaultOrgId } from '@/lib/defaultOrgId';
 import { 
   Activity, 
   RefreshCcw,
@@ -87,7 +88,7 @@ export default function AuditPage() {
   // Team options
   const [teams, setTeams] = useState<TeamOption[]>([]);
   
-  const orgId = identity?.org_id || 'org1';
+  const orgId = identity?.org_id || defaultOrgId();
   const isAdmin = identity?.role === 'admin';
 
   // Load teams for filter dropdown

--- a/web_ui/src/app/admin/defaults/page.tsx
+++ b/web_ui/src/app/admin/defaults/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { RequireRole } from '@/components/RequireRole';
 import { apiFetch } from '@/lib/apiClient';
+import { defaultOrgId } from '@/lib/defaultOrgId';
 import { useIdentity } from '@/lib/useIdentity';
 import { isPromptSet, agentPromptPatch, buildAgentList } from '@/lib/agentPrompts';
 import {
@@ -62,7 +63,7 @@ export default function OrgDefaultsPage() {
     enabled: true,
   });
 
-  const orgId = identity?.org_id || 'org1';
+  const orgId = identity?.org_id || defaultOrgId();
 
   // Load org-level config
   const loadOrgConfig = useCallback(async () => {

--- a/web_ui/src/app/admin/org-tree/page.tsx
+++ b/web_ui/src/app/admin/org-tree/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { RequireRole } from '@/components/RequireRole';
 import { apiFetch } from '@/lib/apiClient';
+import { defaultOrgId } from '@/lib/defaultOrgId';
 import { useIdentity } from '@/lib/useIdentity';
 import { Network, RefreshCcw, Plus, X, ChevronRight, Settings, Key, Edit2 } from 'lucide-react';
 
@@ -176,7 +177,7 @@ export default function OrgTreePage() {
   const [tokens, setTokens] = useState<{ token_id: string; revoked_at?: string }[]>([]);
 
   // Admin shared token has no org in the token; config-service sets org_id from DEFAULT_ORG_ID.
-  const orgId = identity?.org_id || undefined;
+  const orgId = identity?.org_id || defaultOrgId();
 
   const loadNodes = useCallback(async () => {
     if (!orgId) return; // Wait for identity to load
@@ -208,6 +209,10 @@ export default function OrgTreePage() {
 
   // Create node
   const handleCreateNode = async () => {
+    if (!orgId) {
+      alert('Organization is not loaded yet. Refresh and sign in again (admin token needs DEFAULT_ORG_ID).');
+      return;
+    }
     if (!newNodeId.trim()) {
       alert('Node ID is required');
       return;
@@ -250,7 +255,7 @@ export default function OrgTreePage() {
 
   // Save edit
   const handleSaveEdit = async () => {
-    if (!selectedNode) return;
+    if (!selectedNode || !orgId) return;
     try {
       const res = await apiFetch(`/api/admin/orgs/${orgId}/nodes/${selectedNode.node_id}`, {
         method: 'PATCH',

--- a/web_ui/src/app/admin/pending-changes/page.tsx
+++ b/web_ui/src/app/admin/pending-changes/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useIdentity } from '@/lib/useIdentity';
 import { apiFetch } from '@/lib/apiClient';
+import { defaultOrgId } from '@/lib/defaultOrgId';
 import { 
   Clock, 
   CheckCircle, 
@@ -41,7 +42,7 @@ export default function PendingChangesPage() {
   const [reviewingId, setReviewingId] = useState<string | null>(null);
   const [reviewComment, setReviewComment] = useState('');
 
-  const orgId = identity?.org_id || 'org1';
+  const orgId = identity?.org_id || defaultOrgId();
   const isAdmin = identity?.role === 'admin';
 
   const loadChanges = useCallback(async () => {

--- a/web_ui/src/app/admin/security-policies/page.tsx
+++ b/web_ui/src/app/admin/security-policies/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useIdentity } from '@/lib/useIdentity';
 import { apiFetch } from '@/lib/apiClient';
+import { defaultOrgId } from '@/lib/defaultOrgId';
 import { 
   Shield, 
   Key, 
@@ -18,7 +19,7 @@ export default function SecurityPoliciesPage() {
   const [policiesSaving, setPoliciesSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
 
-  const orgId = identity?.org_id || 'org1';
+  const orgId = identity?.org_id || defaultOrgId();
   const isAdmin = identity?.role === 'admin';
 
   // Load security policies

--- a/web_ui/src/app/admin/sso/page.tsx
+++ b/web_ui/src/app/admin/sso/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useIdentity } from '@/lib/useIdentity';
 import { apiFetch } from '@/lib/apiClient';
+import { defaultOrgId } from '@/lib/defaultOrgId';
 import { 
   Shield, 
   Save, 
@@ -82,7 +83,7 @@ export default function SSOSettingsPage() {
   const [adminGroup, setAdminGroup] = useState('');
   const [allowedDomains, setAllowedDomains] = useState('');
 
-  const orgId = identity?.org_id || 'org1';
+  const orgId = identity?.org_id || defaultOrgId();
   const isAdmin = identity?.role === 'admin';
 
   const loadConfig = useCallback(async () => {

--- a/web_ui/src/app/admin/token-management/page.tsx
+++ b/web_ui/src/app/admin/token-management/page.tsx
@@ -2,6 +2,7 @@
 
 import { RequireRole } from '@/components/RequireRole';
 import { apiFetch } from '@/lib/apiClient';
+import { defaultOrgId } from '@/lib/defaultOrgId';
 import { useIdentity } from '@/lib/useIdentity';
 import { useEffect, useState } from 'react';
 import {
@@ -45,7 +46,7 @@ interface TokenHealth {
 
 export default function TokenManagementPage() {
   const { identity } = useIdentity();
-  const orgId = identity?.org_id;
+  const orgId = identity?.org_id || defaultOrgId();
 
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -104,7 +105,15 @@ export default function TokenManagementPage() {
       const res = await fetch(`/api/admin/orgs/${orgId}/tokens`);
 
       if (!res.ok) {
-        throw new Error(`Failed to load tokens: ${res.statusText}`);
+        let detail = res.statusText || `HTTP ${res.status}`;
+        try {
+          const body = await res.json();
+          if (body?.detail) detail = typeof body.detail === 'string' ? body.detail : JSON.stringify(body.detail);
+          else if (body?.error) detail = body.error;
+        } catch {
+          /* keep statusText */
+        }
+        throw new Error(`Failed to load tokens: ${detail}`);
       }
 
       const data = await res.json();

--- a/web_ui/src/app/api/topology/nodes/route.ts
+++ b/web_ui/src/app/api/topology/nodes/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { defaultOrgId } from "@/lib/defaultOrgId";
 import { getConfigServiceBaseUrl, getUpstreamAuthHeaders } from "../../_utils/upstream";
 
 export const runtime = "nodejs";
@@ -11,7 +12,7 @@ export async function GET(request: NextRequest) {
 
   try {
     const baseUrl = getConfigServiceBaseUrl();
-    const orgId = process.env.ORG_ID || "org1";
+    const orgId = defaultOrgId();
 
     const upstreamUrl = new URL(`/api/v1/admin/orgs/${orgId}/nodes`, baseUrl);
     const res = await fetch(upstreamUrl, {

--- a/web_ui/src/lib/defaultOrgId.ts
+++ b/web_ui/src/lib/defaultOrgId.ts
@@ -1,0 +1,9 @@
+/** Default org for local/self-hosted when identity has no org claim. */
+export function defaultOrgId(): string {
+  return (
+    process.env.NEXT_PUBLIC_DEFAULT_ORG_ID?.trim() ||
+    process.env.DEFAULT_ORG_ID?.trim() ||
+    process.env.ORG_ID?.trim() ||
+    "local"
+  );
+}


### PR DESCRIPTION
## Summary

Fixes multiple fresh-clone local setup failures that make the admin console appear broken after `make dev`. Reproduces and addresses [#49](https://github.com/swapnildahiphale/OpenSRE/issues/49).

Rebased onto latest `main` (includes the new release sync and the upstream SSO schema migration).

---

## Issues reproduced

### 1. `make dev` fails — external Docker volumes missing

**Symptom**
```text
external volume "opensre-neo4j-data" not found
make: *** [dev] Error 1
```
(Same for `opensre-postgres-data`, `opensre-agent-sessions`.)

**Root cause**  
Volumes are marked `external: true` in `docker-compose.yml` so `docker compose down -v` cannot wipe shared data across worktrees. Docker Compose does not auto-create external volumes. README only documented `make dev`.

**Fix**
- Added `scripts/ensure-volumes.sh` (idempotent volume creation)
- Wired `ensure-volumes` into `make dev`, `make dev-slack`, and `make dev-teams`
- Updated README / CONTRIBUTING / compose comments

---

### 2. Org Tree — teams invisible / created under wrong org

**Symptom**
- Create team in Org Tree → not visible in dashboard
- Retry same name → "already exists"
- Logs: `POST /api/v1/admin/orgs/undefined/nodes`
- Token issue dropdown empty (teams not listed for the org the UI queries)

**Root cause**
- Shared admin token has no org claim in the JWT
- `DEFAULT_ORG_ID` was not set in compose → `/auth/me` returned `org_id: null`
- Web UI interpolated `undefined` into API URLs, or hard-coded fallback `org1`
- Local seed tenant is `local` (not `org1`)

**Fix**
- Set `DEFAULT_ORG_ID=local`, `SEED_ORG_ID=local`, `SEED_TEAM_NODE_ID=default` in `docker-compose.yml` (kept alongside upstream `SSO_DEFAULT_TEAM_NODE_ID` / `WEB_UI_SSO_ORG_ID`)
- Added `web_ui/src/lib/defaultOrgId.ts` and replaced `org1` fallbacks across admin pages and topology route
- Org Tree guards before create/edit when org is not loaded
- `seed_demo_data.py` default org → `local`

---

### 3. Token Management — `Failed to load tokens: Not Found`

**Symptom**  
Red error banner on Token Management page (`Failed to load tokens: Not Found`), while Org Tree → team → Tokens modal still showed issued tokens.

**Root cause**  
`GET /orgs/{org_id}/tokens` verified org existence via `get_org_node(org_id, node_id=org_id)`. Local seed creates org root as `node_id=root`, not `node_id=org_id`.

**Fix**
- Added `org_exists()` in `repository.py` (accepts org root with `node_id=root`)
- Updated `admin_list_org_tokens` to use it
- Token Management page uses `defaultOrgId()` and clearer API error messages

---

## Note on SSO schema

The `sso_configs.provider_type` 500 from [#49](https://github.com/swapnildahiphale/OpenSRE/issues/49) is already fixed on `main` by `20260901_sso_configs_oidc_schema.py`, so this PR no longer includes a duplicate migration.

---

## Files changed (17)

| Area | Files |
|------|-------|
| Make / Docker | `Makefile`, `scripts/ensure-volumes.sh`, `docker-compose.yml` |
| Backend | `repository.py`, `admin.py`, `seed_demo_data.py` |
| Web UI | `defaultOrgId.ts`, org-tree, token-management, audit, defaults, SSO, security-policies, pending-changes, topology route |
| Docs | `README.md`, `CONTRIBUTING.md` |

---

## Test plan

- [ ] Fresh clone on macOS: `cp .env.example .env`, set `ANTHROPIC_API_KEY`, start Docker Desktop, `make dev` (no manual `docker volume create`)
- [ ] Open http://localhost:3002, sign in with admin token
- [ ] `/api/v1/auth/me` returns `"org_id":"local"`
- [ ] `/api/v1/admin/orgs/local/sso-config/public` returns 200 (not 500)
- [ ] Org Tree: create a team under org `local` → appears in tree
- [ ] Token Management: loads without Not Found; issue token; team appears in dropdown
- [ ] Org Tree → team → Tokens: list/revoke still works