### PR TITLE
chore(env): add Cloud Agent dev environment (Docker Compose stack)

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,13 @@
+{
+  "name": "OpenSRE",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "ports": [
+    { "name": "web-ui", "port": 3002 },
+    { "name": "config-service", "port": 8081 },
+    { "name": "sre-agent", "port": 8001 },
+    { "name": "neo4j-browser", "port": 7475 },
+    { "name": "neo4j-bolt", "port": 7688 }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OpenSRE — Cloud Agent install script
+# ============================================================================
+# This runs ONCE after the repository is checked out (and, with environment
+# builds, it is what creates the baseline snapshot). Everything here must be
+# idempotent: it can run again on a partially-prepared machine without breaking.
+#
+# OpenSRE's whole dev stack runs through Docker Compose (`make dev`), so the
+# main job of this script is to make Docker usable inside the Cloud Agent VM
+# (a nested-container environment) and to pre-build the compose images so the
+# first boot is fast. Per-boot work (starting the Docker daemon and the stack)
+# lives in start.sh instead.
+# ============================================================================
+
+set -euo pipefail
+
+# Resolve the repository root from this script's location so the script works
+# no matter what directory it is invoked from.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+echo "[install] OpenSRE Cloud Agent setup starting in $REPO_ROOT"
+
+# ----------------------------------------------------------------------------
+# 1. Install Docker Engine + Compose plugin (only if it is not already present).
+# ----------------------------------------------------------------------------
+# The default Cloud Agent image ships Node, pnpm, Python, make, git and curl,
+# but not Docker. We add Docker Engine via Docker's official convenience script.
+# `command -v docker` keeps this step idempotent across re-runs / snapshots.
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[install] Docker not found — installing Docker Engine..."
+  curl -fsSL https://get.docker.com -o /tmp/get-docker.sh
+  sudo sh /tmp/get-docker.sh
+  rm -f /tmp/get-docker.sh
+else
+  echo "[install] Docker already installed: $(docker --version)"
+fi
+
+# ----------------------------------------------------------------------------
+# 2. Install fuse-overlayfs (required storage driver for nested Docker).
+# ----------------------------------------------------------------------------
+# The Cloud Agent root filesystem is itself an overlay mount, so Docker's normal
+# overlay2 driver cannot stack on top of it. fuse-overlayfs works in userspace
+# and is the reliable choice here. uidmap is handy for rootless tooling too.
+# DEBIAN_FRONTEND + --force-confold keep apt fully non-interactive (some base
+# images have a modified /etc/fuse.conf that would otherwise prompt).
+if ! command -v fuse-overlayfs >/dev/null 2>&1; then
+  echo "[install] Installing fuse-overlayfs + uidmap..."
+  sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    -o Dpkg::Options::="--force-confold" \
+    fuse-overlayfs uidmap
+else
+  echo "[install] fuse-overlayfs already installed."
+fi
+
+# ----------------------------------------------------------------------------
+# 3. Tell the Docker daemon to use the fuse-overlayfs storage driver.
+# ----------------------------------------------------------------------------
+# Writing daemon.json here (durable state captured in the snapshot) means the
+# daemon started in start.sh picks up the right driver automatically.
+echo "[install] Writing /etc/docker/daemon.json (storage-driver: fuse-overlayfs)"
+sudo mkdir -p /etc/docker
+echo '{
+  "storage-driver": "fuse-overlayfs"
+}' | sudo tee /etc/docker/daemon.json >/dev/null
+
+# Allow the current (non-root) user to talk to the Docker socket without sudo.
+# Group membership only applies to new logins, so start.sh also relaxes the
+# socket permissions each boot; adding the group here is a durable convenience.
+sudo groupadd -f docker
+sudo usermod -aG docker "$(id -un)" || true
+
+# ----------------------------------------------------------------------------
+# 4. Create the local .env file the compose stack reads.
+# ----------------------------------------------------------------------------
+# `make dev` (and docker-compose) require a .env file. We seed it from the
+# committed example if the developer has not provided one. The example uses a
+# placeholder ANTHROPIC_API_KEY, which is enough to boot every service; a real
+# key is only needed to run live LLM investigations. If ANTHROPIC_API_KEY is
+# present in the environment (e.g. injected as a Cloud Agent secret), we splice
+# it into .env so investigations work out of the box.
+if [ ! -f "$REPO_ROOT/.env" ]; then
+  echo "[install] Creating .env from .env.example"
+  cp "$REPO_ROOT/.env.example" "$REPO_ROOT/.env"
+fi
+if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "[install] Injecting ANTHROPIC_API_KEY from the environment into .env"
+  # Replace the placeholder line with the real key (portable sed in-place).
+  sed -i "s|^ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}|" "$REPO_ROOT/.env"
+fi
+
+# ----------------------------------------------------------------------------
+# 5. Bring Docker up briefly to create volumes and pre-build the images.
+# ----------------------------------------------------------------------------
+# Building the images now means they land in /var/lib/docker, which the build
+# snapshot captures — so the first real boot does not pay the (heavy) build
+# cost again. This needs a running daemon, so we start one temporarily.
+"$SCRIPT_DIR/start-dockerd.sh"
+
+# The named volumes in docker-compose.yml are declared `external: true` so that
+# a stray `docker compose down -v` cannot wipe investigation/memory data. That
+# means we must create them explicitly before the stack can start.
+echo "[install] Creating external Docker volumes (idempotent)"
+for vol in opensre-postgres-data opensre-neo4j-data opensre-agent-sessions; do
+  docker volume create "$vol" >/dev/null
+done
+
+# Pre-build the three application images (config-service, sre-agent, web-ui).
+# Postgres/Neo4j are pulled on first `up`. `make dev` also runs a helper that
+# generates the (optional) LiteLLM config; setup-llm is a no-op for the default
+# direct-Anthropic setup. We build here rather than run so install terminates.
+echo "[install] Pre-building compose images (this is the slow, one-time step)"
+export COMPOSE_PROJECT_NAME=opensre
+docker compose -f docker-compose.yml build
+
+echo "[install] Install complete. Services are started per-boot by start.sh."

--- a/.cursor/seed-neo4j.sh
+++ b/.cursor/seed-neo4j.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OpenSRE — one-time Neo4j knowledge-graph seed
+# ============================================================================
+# Loads the otel-demo service topology (scripts/populate_neo4j.cypher) into Neo4j
+# so topology-aware investigations and blast-radius queries work out of the box.
+#
+# IMPORTANT: this only seeds when the graph is EMPTY. The seed cypher begins with
+# `MATCH (n) DETACH DELETE n`, so running it against a populated graph would wipe
+# real data. Guarding on emptiness makes this safe to call on every boot — a
+# fresh environment gets seeded once, and later restarts leave existing data
+# (topology edits, memory episodes) untouched.
+#
+# We load the cypher inside the neo4j container via cypher-shell because in the
+# dev compose file the neo4j service sits on an internal-only network, so its
+# bolt port is not published to the host.
+# ============================================================================
+
+set -euo pipefail
+
+CONTAINER="opensre-neo4j"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+CYPHER_FILE="$REPO_ROOT/scripts/populate_neo4j.cypher"
+ENV_FILE="$REPO_ROOT/.env"
+
+# Read Neo4j credentials from the environment, falling back to the repo .env
+# (the compose source of truth). We deliberately do not hardcode a default
+# password here so no secret value lives in the committed script.
+read_env() { grep -E "^$1=" "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2-; }
+NEO4J_USER="${NEO4J_USERNAME:-$(read_env NEO4J_USERNAME)}"
+NEO4J_PASS="${NEO4J_PASSWORD:-$(read_env NEO4J_PASSWORD)}"
+NEO4J_USER="${NEO4J_USER:-neo4j}"
+
+if [ ! -f "$CYPHER_FILE" ]; then
+  echo "[seed-neo4j] $CYPHER_FILE not found — skipping."
+  exit 0
+fi
+
+# Helper: run a cypher query and return the raw plain output.
+run_cypher() {
+  docker exec -i "$CONTAINER" cypher-shell -u "$NEO4J_USER" -p "$NEO4J_PASS" \
+    --format plain "$1" 2>/dev/null
+}
+
+# Wait until Neo4j accepts bolt queries (up to ~60s). Fresh boots need this
+# because make dev returns before Neo4j has finished starting.
+echo "[seed-neo4j] Waiting for Neo4j to accept queries..."
+for i in $(seq 1 60); do
+  if run_cypher "RETURN 1;" >/dev/null 2>&1; then
+    break
+  fi
+  if [ "$i" -eq 60 ]; then
+    echo "[seed-neo4j] Neo4j not ready after 60s — skipping seed (non-fatal)."
+    exit 0
+  fi
+  sleep 1
+done
+
+# Only seed when the graph is empty, so we never clobber existing data.
+NODE_COUNT="$(run_cypher "MATCH (n) RETURN count(n) AS c;" | sed -n '2p' | tr -d '[:space:]')"
+NODE_COUNT="${NODE_COUNT:-0}"
+
+if [ "$NODE_COUNT" != "0" ]; then
+  echo "[seed-neo4j] Graph already has $NODE_COUNT nodes — leaving it untouched."
+  exit 0
+fi
+
+echo "[seed-neo4j] Empty graph — loading otel-demo topology from populate_neo4j.cypher"
+docker exec -i "$CONTAINER" cypher-shell -u "$NEO4J_USER" -p "$NEO4J_PASS" \
+  --format plain < "$CYPHER_FILE" >/dev/null 2>&1 || true
+
+SEEDED="$(run_cypher "MATCH (n) RETURN count(n) AS c;" | sed -n '2p' | tr -d '[:space:]')"
+echo "[seed-neo4j] Done. Graph now has ${SEEDED:-?} nodes."

--- a/.cursor/start-dockerd.sh
+++ b/.cursor/start-dockerd.sh
@@ -25,6 +25,18 @@ sudo modprobe br_netfilter 2>/dev/null || true
 sudo sysctl -w net.bridge.bridge-nf-call-iptables=0 >/dev/null 2>&1 || true
 sudo sysctl -w net.bridge.bridge-nf-call-ip6tables=0 >/dev/null 2>&1 || true
 
+# Second nested-container fix: legacy iptables blocks container egress.
+# This VM has BOTH netfilter backends active — nftables (Docker 29's default,
+# where it writes its bridge/NAT rules) and iptables-legacy. The legacy FORWARD
+# chain ships with a default DROP policy that only whitelists docker0, so packets
+# from Docker's custom compose bridges (br-*) pass the nft rules but get dropped
+# by legacy → containers on compose networks have no outbound internet (LLM calls
+# hang, image pulls fail). Relaxing the legacy FORWARD policy to ACCEPT lets that
+# traffic through; the nftables backend still enforces Docker's real isolation.
+if command -v iptables-legacy >/dev/null 2>&1; then
+  sudo iptables-legacy -P FORWARD ACCEPT 2>/dev/null || true
+fi
+
 # ----------------------------------------------------------------------------
 # Start dockerd only if it is not already answering.
 # ----------------------------------------------------------------------------

--- a/.cursor/start-dockerd.sh
+++ b/.cursor/start-dockerd.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OpenSRE — Docker daemon bootstrap (shared by install.sh and start.sh)
+# ============================================================================
+# Starts the Docker daemon inside the Cloud Agent VM if it is not already
+# running, applies the networking fix required for nested containers, and waits
+# until the daemon is ready. Safe to call repeatedly (idempotent).
+#
+# Why a script instead of `service docker start`? The Cloud Agent VM does not
+# run systemd (PID 1 is not init), so we launch `dockerd` directly.
+# ============================================================================
+
+set -euo pipefail
+
+# ----------------------------------------------------------------------------
+# Nested-container networking fix (MUST run before containers talk to each other)
+# ----------------------------------------------------------------------------
+# Inside this VM the container bridge sits on top of another bridge, and the
+# kernel's bridge-netfilter passes intra-bridge traffic through iptables. In
+# this nested setup that silently drops container-to-container packets, so
+# services like config-service cannot reach Postgres. Turning bridge-netfilter
+# off lets same-bridge traffic flow directly while outbound NAT still works.
+# `|| true` keeps this non-fatal if the knob is unavailable.
+sudo modprobe br_netfilter 2>/dev/null || true
+sudo sysctl -w net.bridge.bridge-nf-call-iptables=0 >/dev/null 2>&1 || true
+sudo sysctl -w net.bridge.bridge-nf-call-ip6tables=0 >/dev/null 2>&1 || true
+
+# ----------------------------------------------------------------------------
+# Start dockerd only if it is not already answering.
+# ----------------------------------------------------------------------------
+if sudo docker info >/dev/null 2>&1; then
+  echo "[dockerd] Already running."
+else
+  echo "[dockerd] Starting Docker daemon in the background..."
+  # nohup + background so the daemon outlives this script; logs go to a file
+  # the agent can inspect. setsid detaches it from our process group.
+  sudo bash -c 'nohup dockerd >/var/log/dockerd.log 2>&1 &'
+
+  # Wait (up to ~60s) for the daemon socket to come up.
+  echo "[dockerd] Waiting for the daemon to become ready..."
+  for i in $(seq 1 60); do
+    if sudo docker info >/dev/null 2>&1; then
+      echo "[dockerd] Ready after ${i}s."
+      break
+    fi
+    if [ "$i" -eq 60 ]; then
+      echo "[dockerd] ERROR: daemon did not become ready in 60s. Recent log:"
+      sudo tail -n 40 /var/log/dockerd.log || true
+      exit 1
+    fi
+    sleep 1
+  done
+fi
+
+# ----------------------------------------------------------------------------
+# Let the non-root agent user use `docker` without sudo.
+# ----------------------------------------------------------------------------
+# The Makefile / docker-compose call `docker` directly (no sudo). The daemon
+# socket is root-owned, so we relax its permissions each boot. Group membership
+# added in install.sh only takes effect on a fresh login, so this is the
+# reliable per-boot mechanism.
+if [ -S /var/run/docker.sock ]; then
+  sudo chmod 666 /var/run/docker.sock || true
+fi

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OpenSRE — Cloud Agent start script (runs on every boot)
+# ============================================================================
+# Per-boot responsibilities only:
+#   1. Make sure the Docker daemon is running (with the nested-networking fix).
+#   2. Bring the whole OpenSRE stack up via `make dev` (docker compose up -d).
+#
+# Heavy, one-time work (installing Docker, building images, creating volumes)
+# lives in install.sh so it is captured in the environment snapshot and NOT
+# repeated here. This script must tolerate restarts and reach a clear success.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+echo "[start] Booting OpenSRE dev stack from $REPO_ROOT"
+
+# 1. Ensure the Docker daemon is up and the networking fix is applied.
+"$SCRIPT_DIR/start-dockerd.sh"
+
+# 2. Safety net: if a previous boot / another checkout left the .env missing
+#    (it is git-ignored), recreate it so `make dev` can read it.
+if [ ! -f "$REPO_ROOT/.env" ]; then
+  echo "[start] .env missing — recreating from .env.example"
+  cp "$REPO_ROOT/.env.example" "$REPO_ROOT/.env"
+  if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    sed -i "s|^ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}|" "$REPO_ROOT/.env"
+  fi
+fi
+
+# 3. The compose volumes are external, so make sure they exist (idempotent).
+for vol in opensre-postgres-data opensre-neo4j-data opensre-agent-sessions; do
+  docker volume create "$vol" >/dev/null
+done
+
+# 4. Bring the stack up. COMPOSE_PROJECT_NAME=opensre matches the fixed
+#    container names in docker-compose.yml. `make dev` runs the LLM-config
+#    helper, reconciles stale containers, then `docker compose up -d --build`.
+#    It is idempotent: already-running services are left in place.
+export COMPOSE_PROJECT_NAME=opensre
+echo "[start] Starting services (postgres, config-service, neo4j, sre-agent, web-ui)..."
+make dev
+
+echo "[start] OpenSRE is up. Web console: http://localhost:3002 (admin token: local-admin-token)"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -66,4 +66,9 @@ export COMPOSE_PROJECT_NAME=opensre
 echo "[start] Starting services (postgres, config-service, neo4j, sre-agent, web-ui)..."
 make dev
 
+# 5. Seed the Neo4j knowledge graph with the otel-demo topology, but only when
+#    it is empty (safe to run every boot; never wipes existing data). This gives
+#    fresh environments topology-aware investigation data out of the box.
+bash "$SCRIPT_DIR/seed-neo4j.sh" || echo "[start] KG seed skipped (non-fatal)."
+
 echo "[start] OpenSRE is up. Web console: http://localhost:3002 (admin token: local-admin-token)"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -27,9 +27,30 @@ echo "[start] Booting OpenSRE dev stack from $REPO_ROOT"
 if [ ! -f "$REPO_ROOT/.env" ]; then
   echo "[start] .env missing — recreating from .env.example"
   cp "$REPO_ROOT/.env.example" "$REPO_ROOT/.env"
-  if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
-    sed -i "s|^ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}|" "$REPO_ROOT/.env"
-  fi
+fi
+
+# Always sync the ANTHROPIC_API_KEY from the environment (Cloud Agent secret)
+# into .env on every boot. This runs even when .env already exists, so applying
+# the secret and restarting is enough to pick it up — no manual edit needed.
+if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "[start] Syncing ANTHROPIC_API_KEY from the environment into .env"
+  sed -i "s|^ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}|" "$REPO_ROOT/.env"
+fi
+
+# Point the sre-agent at a reachable Anthropic IP.
+# docker-compose.yml pins api.anthropic.com to a Cloudflare edge IP as an India
+# TLS workaround, but that edge is unreachable from Cloud Agent VMs, which makes
+# every LLM call hang. We resolve Anthropic's real IPv4 on the host (no /etc/hosts
+# pin here) and pass it to compose via ANTHROPIC_HOST_IP so the container uses a
+# route that actually works. Falls back to Anthropic's canonical IP if resolution
+# fails. This does not change the committed default for other networks.
+ANTHROPIC_HOST_IP="$(python3 -c "import socket; print(sorted({a[4][0] for a in socket.getaddrinfo('api.anthropic.com',443,socket.AF_INET)})[0])" 2>/dev/null || true)"
+ANTHROPIC_HOST_IP="${ANTHROPIC_HOST_IP:-160.79.104.10}"
+echo "[start] Using ANTHROPIC_HOST_IP=${ANTHROPIC_HOST_IP} for the sre-agent"
+if grep -q '^ANTHROPIC_HOST_IP=' "$REPO_ROOT/.env"; then
+  sed -i "s|^ANTHROPIC_HOST_IP=.*|ANTHROPIC_HOST_IP=${ANTHROPIC_HOST_IP}|" "$REPO_ROOT/.env"
+else
+  echo "ANTHROPIC_HOST_IP=${ANTHROPIC_HOST_IP}" >> "$REPO_ROOT/.env"
 fi
 
 # 3. The compose volumes are external, so make sure they exist (idempotent).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,8 +147,11 @@ services:
     restart: unless-stopped
     # Anthropic DNS now points at 160.79.104.10, which fails TLS from some
     # networks (e.g. India). Cloudflare edge still works — temporary workaround.
+    # The pinned IP is env-overridable so environments where the Cloudflare edge
+    # is unreachable (e.g. Cloud Agent VMs) can point at a reachable Anthropic IP
+    # via ANTHROPIC_HOST_IP in .env. Default preserves the original workaround.
     extra_hosts:
-      - "api.anthropic.com:104.18.19.125"
+      - "api.anthropic.com:${ANTHROPIC_HOST_IP:-104.18.19.125}"
     env_file:
       - .env
     environment:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a Cursor Cloud Agent development environment so future agents can run the full OpenSRE stack out of the box. OpenSRE's dev experience is entirely Docker Compose based (`make dev`), so the environment makes Docker usable inside the Cloud Agent VM (a nested-container host) and brings the stack up automatically. This is a **repository-managed** environment (config lives in `.cursor/environment.json`), so it is versioned with the code and follows branches/PRs.

New files under `.cursor/` (force-added because `/.cursor/` is normally git-ignored):

- `environment.json` — default base image + `install`/`start` hooks + forwarded ports.
- `install.sh` — one-time setup: installs Docker Engine + `fuse-overlayfs`, writes `/etc/docker/daemon.json`, seeds `.env`, creates the external Docker volumes, pre-builds the compose images.
- `start-dockerd.sh` — idempotent Docker daemon bootstrap with the nested-container networking fixes.
- `start.sh` — per-boot startup: ensures the daemon is up, syncs secrets into `.env`, runs `make dev`, and seeds the knowledge graph.
- `seed-neo4j.sh` — one-time (empty-graph-only) Neo4j knowledge-graph seed.

Also makes one small, backward-compatible change to `docker-compose.yml` (see below).

## Type of Change

- [x] 🔧 Refactoring / code cleanup (tooling / environment)

## Changes Made

- `.cursor/environment.json` (`user: ubuntu`, install/start hooks, forwarded ports: web-ui 3002, config-service 8081, sre-agent 8001, neo4j 7475/7688).
- Idempotent install/start scripts that stand up Docker + the compose stack in the nested VM. Nested-container fixes: `fuse-overlayfs` storage driver, `bridge-nf-call-iptables=0` (container-to-container), and `iptables-legacy -P FORWARD ACCEPT` (custom-bridge egress — the legacy DROP policy was silently blocking outbound traffic from compose networks).
- `start.sh` syncs `ANTHROPIC_API_KEY` from the Cloud Agent secret into `.env` on every boot, and sets `ANTHROPIC_HOST_IP` to a reachable Anthropic IP.
- `docker-compose.yml`: the pinned `api.anthropic.com` IP (an India TLS workaround) is now env-overridable via `ANTHROPIC_HOST_IP` — **default unchanged**. The hardcoded Cloudflare edge IP was unreachable from the Cloud Agent VM and made every LLM call hang.
- `seed-neo4j.sh` loads the otel-demo topology into Neo4j, but only when the graph is empty (safe on every boot).

## Testing

### Local end-to-end validation (in the Cloud Agent VM)

1. `install.sh` → installs Docker + fuse-overlayfs, builds images; re-ran to confirm idempotence (~5s cached).
2. `start.sh` from a stopped stack → all 5 services healthy in ~17s.
3. Health: config-service `{"status":"ok"}`, sre-agent `{"status":"healthy","mode":"simple"}`, web-ui HTTP 200.
4. Migrations run automatically; config-service seeds `local.yaml`.
5. Real API flow: issued a team token (config-service admin API → Postgres) and fetched the merged effective config through the web-ui proxy (web-ui → config-service → Postgres, HTTP 200).
6. Neo4j read/write; sre-agent `/memory/*` returns live stats (agent → Neo4j).
7. **KG seed**: `seed-neo4j.sh` loads 52 nodes / 125 relationships of otel-demo topology; blast-radius sample works (`cartservice → valkey`); re-running with a populated graph correctly leaves it untouched.
8. **Agent LLM ping (with `ANTHROPIC_API_KEY` secret applied)**: `POST /investigate` returns the exact requested reply (`pong - OpenSRE agent online`) in ~5s, and a second ping confirms it runs as Claude Sonnet 4.6. This required the connectivity fixes above (before them, LLM calls hung indefinitely).
9. Lint/tests: `ruff check .` passes; web UI `vitest` 101/101 pass; config-service pytest 72 pass (remaining failures pre-existing, need `ENCRYPTION_KEY`/Postgres test DB).

### Prebuilt-environment build validation

- Snapshotted the working VM and triggered a draft environment build off this branch: build **SUCCEEDED** (fresh checkout, `install.sh` reused Docker + cached images, exit 0).
- Booted a fresh Cloud Agent from the build and verified end to end: tooling present, all 5 services healthy, health checks pass, token creation + config-merge proxy + Neo4j memory all work.

## Additional Context

- Nested VM can't use Docker's `overlay2` (root FS already an overlay) → `fuse-overlayfs`.
- `ANTHROPIC_API_KEY` is only needed for live LLM investigations; every service boots without it. Applied as a Cloud Agent secret, `start.sh` splices it into `.env` on boot.
- For fast boots, enable **Environment Builds** on this environment after merge.

## Deployment Notes

- [x] Requires new secrets/credentials (optional: `ANTHROPIC_API_KEY` for live investigations)
- [x] Backward compatible

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d909ce4c-2692-4b6e-9708-890956db36a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d909ce4c-2692-4b6e-9708-890956db36a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

