### PR TITLE
fix: memory extraction guardrails and episode retry

### DIFF
--- a/config_service/src/api/routes/internal.py
+++ b/config_service/src/api/routes/internal.py
@@ -102,6 +102,7 @@ class AgentRunResponse(BaseModel):
     completed_at: Optional[datetime] = None
     duration_seconds: Optional[float] = None
     tool_calls_count: Optional[int] = None
+    trigger_message: Optional[str] = None
     output_summary: Optional[str] = None
     output_json: Optional[dict] = None
     error_message: Optional[str] = None
@@ -140,6 +141,7 @@ def create_agent_run(
         completed_at=run.completed_at,
         duration_seconds=run.duration_seconds,
         tool_calls_count=run.tool_calls_count,
+        trigger_message=run.trigger_message,
         output_summary=run.output_summary,
         output_json=run.output_json,
         error_message=run.error_message,
@@ -183,6 +185,7 @@ def complete_agent_run(
         completed_at=run.completed_at,
         duration_seconds=run.duration_seconds,
         tool_calls_count=run.tool_calls_count,
+        trigger_message=run.trigger_message,
         output_summary=run.output_summary,
         output_json=run.output_json,
         error_message=run.error_message,
@@ -296,6 +299,7 @@ def list_agent_runs_internal(
                 completed_at=run.completed_at,
                 duration_seconds=run.duration_seconds,
                 tool_calls_count=run.tool_calls_count,
+                trigger_message=run.trigger_message,
                 output_summary=run.output_summary,
                 error_message=run.error_message,
             )
@@ -391,6 +395,34 @@ def get_stale_runs_count(
     return StaleRunsCountResponse(
         stale_count=count,
         max_age_seconds=max_age_seconds,
+    )
+
+
+@router.get("/agent-runs/{run_id}", response_model=AgentRunResponse)
+def get_agent_run(
+    run_id: str,
+    session: Session = Depends(get_db),
+    service: str = Depends(require_internal_service),
+):
+    """Get a single agent run by ID (internal service-to-service)."""
+    run = repository.get_agent_run(session, run_id=run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="Agent run not found")
+    return AgentRunResponse(
+        id=run.id,
+        org_id=run.org_id,
+        team_node_id=run.team_node_id,
+        correlation_id=run.correlation_id,
+        agent_name=run.agent_name,
+        status=run.status,
+        started_at=run.started_at,
+        completed_at=run.completed_at,
+        duration_seconds=run.duration_seconds,
+        tool_calls_count=run.tool_calls_count,
+        trigger_message=run.trigger_message,
+        output_summary=run.output_summary,
+        output_json=run.output_json,
+        error_message=run.error_message,
     )
 
 

--- a/sre-agent/investigation_lifecycle.py
+++ b/sre-agent/investigation_lifecycle.py
@@ -133,6 +133,7 @@ def finalize_investigation(
             root_cause=ext.root_cause,
             summary=ext.summary,
             effectiveness_score=compute_effectiveness(ext.resolved, ext.root_cause),
+            extraction_status=ext.status,
             duration_seconds=duration_seconds,
             created_at=(prior.created_at if prior else now),
             updated_at=now,

--- a/sre-agent/memory/extraction.py
+++ b/sre-agent/memory/extraction.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import re
 from dataclasses import dataclass, field
 from typing import List, Optional
 
@@ -12,20 +13,157 @@ logger = logging.getLogger(__name__)
 
 _MODEL = os.getenv("MEMORY_LLM_MODEL", "claude-haiku-4-5-20251001")
 
+EXTRACTION_JSON_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": [
+        "issue_type",
+        "issue_description",
+        "severity",
+        "components",
+        "root_cause",
+        "resolved",
+        "summary",
+    ],
+    "properties": {
+        "issue_type": {"type": "string"},
+        "issue_description": {"type": "string"},
+        "severity": {"type": ["string", "null"]},
+        "components": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["type", "name"],
+                "properties": {
+                    "type": {"type": "string"},
+                    "name": {"type": "string"},
+                },
+            },
+        },
+        "root_cause": {"type": ["string", "null"]},
+        "resolved": {"type": "boolean"},
+        "summary": {"type": "string"},
+    },
+}
 
-def llm_text_completion(prompt: str, max_tokens: int = 300) -> str:
+
+def _initial_structured_cap() -> str:
+    provider = os.getenv("MEMORY_LLM_PROVIDER", "anthropic")
+    if provider == "openai_compat":
+        return "json_object"
+    return "json_schema"
+
+
+_structured_cap = _initial_structured_cap()
+
+
+def _anthropic_client():
+    from anthropic import Anthropic
+
+    return Anthropic()
+
+
+def _format_unsupported(exc: Exception) -> bool:
+    if isinstance(exc, TypeError):
+        return True
+    status = getattr(exc, "status_code", None)
+    if status == 400:
+        return True
+    msg = str(exc).lower()
+    return "output_config" in msg or "response_format" in msg
+
+
+def _extract_message_text(msg) -> str:
+    return "".join(
+        b.text for b in msg.content if getattr(b, "type", "") == "text"
+    ).strip()
+
+
+def _anthropic_messages_create(client, prompt: str, max_tokens: int, json_schema: dict | None):
+    """Create an Anthropic message, optionally with structured output config."""
+    global _structured_cap
+    kwargs = {
+        "model": _MODEL,
+        "max_tokens": max_tokens,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    if json_schema is not None and _structured_cap == "json_schema":
+        output_config = {"format": {"type": "json_schema", "schema": json_schema}}
+        try:
+            return client.messages.create(**kwargs, output_config=output_config)
+        except TypeError as e:
+            if "output_config" not in str(e):
+                raise
+            try:
+                return client.messages.create(
+                    **kwargs, extra_body={"output_config": output_config}
+                )
+            except Exception as e:
+                if not _format_unsupported(e):
+                    raise
+                _structured_cap = "prompt"
+                return client.messages.create(**kwargs)
+        except Exception as e:
+            if not _format_unsupported(e):
+                raise
+            _structured_cap = "prompt"
+            return client.messages.create(**kwargs)
+    return client.messages.create(**kwargs)
+
+
+def _openai_compat_completion(prompt: str, max_tokens: int, json_schema: dict | None) -> str:
+    """OpenAI-compatible chat completions via httpx (no OpenAI SDK)."""
+    global _structured_cap
+    import httpx
+
+    base = (os.getenv("OPENAI_BASE_URL") or os.getenv("ANTHROPIC_BASE_URL") or "").rstrip(
+        "/"
+    )
+    api_key = os.getenv("OPENAI_API_KEY") or os.getenv("ANTHROPIC_API_KEY") or ""
+    payload: dict = {
+        "model": _MODEL,
+        "max_tokens": max_tokens,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    if json_schema is not None and _structured_cap == "json_object":
+        payload["response_format"] = {"type": "json_object"}
     try:
-        from anthropic import Anthropic
-
-        client = Anthropic()
-        msg = client.messages.create(
-            model=_MODEL,
-            max_tokens=max_tokens,
-            messages=[{"role": "user", "content": prompt}],
+        resp = httpx.post(
+            f"{base}/chat/completions",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json=payload,
+            timeout=60.0,
         )
-        return "".join(
-            b.text for b in msg.content if getattr(b, "type", "") == "text"
-        ).strip()
+        if resp.status_code == 400 and json_schema is not None:
+            body = resp.text.lower()
+            if "response_format" in body or "json_schema" in body:
+                _structured_cap = "prompt"
+                payload.pop("response_format", None)
+                resp = httpx.post(
+                    f"{base}/chat/completions",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                    json=payload,
+                    timeout=60.0,
+                )
+        resp.raise_for_status()
+        data = resp.json()
+        return (data.get("choices") or [{}])[0].get("message", {}).get("content", "").strip()
+    except Exception as e:
+        logger.error("[MEMORY] openai_compat completion failed: %s", e)
+        return ""
+
+
+def llm_text_completion(
+    prompt: str, max_tokens: int = 300, json_schema: dict | None = None
+) -> str:
+    provider = os.getenv("MEMORY_LLM_PROVIDER", "anthropic")
+    try:
+        if provider == "openai_compat":
+            return _openai_compat_completion(prompt, max_tokens, json_schema)
+        client = _anthropic_client()
+        msg = _anthropic_messages_create(client, prompt, max_tokens, json_schema)
+        return _extract_message_text(msg)
     except Exception as e:
         logger.error("[MEMORY] LLM completion failed: %s", e)
         return ""
@@ -77,6 +215,7 @@ class Extraction:
     root_cause: Optional[str] = None
     resolved: bool = False
     summary: str = ""
+    status: str = "ok"
 
 
 _EXTRACT_PROMPT = """You are summarizing an SRE investigation into a compact JSON record.
@@ -117,13 +256,34 @@ def extract_investigation(
             f'{{"issue_type": "{prior.issue_type}", "root_cause": {json.dumps(prior.root_cause)}, '
             f'"resolved": {str(prior.resolved).lower()}, "summary": {json.dumps(prior.summary)}}}\n\n'
         )
-    raw = llm_text_completion(
-        _EXTRACT_PROMPT.format(
-            prior_block=prior_block, prompt=prompt[:2000], result=result_text[:4000]
-        ),
-        max_tokens=500,
+    prompt_text = _EXTRACT_PROMPT.format(
+        prior_block=prior_block, prompt=prompt[:2000], result=result_text[:4000]
     )
+    try:
+        raw = llm_text_completion(
+            prompt_text, max_tokens=500, json_schema=EXTRACTION_JSON_SCHEMA
+        )
+    except Exception:
+        raw = ""
+    if not raw:
+        try:
+            raw = llm_text_completion(
+                prompt_text, max_tokens=500, json_schema=EXTRACTION_JSON_SCHEMA
+            )
+        except Exception:
+            raw = ""
     data = _safe_json(raw)
+    if not data and (not raw.strip() or not _raw_looks_like_json_object(raw)):
+        return Extraction(
+            issue_type="unknown",
+            issue_description=prompt[:200],
+            severity=None,
+            components=[],
+            root_cause=None,
+            resolved=False,
+            summary=result_text[:200] if result_text else "",
+            status="failed",
+        )
     comps = [
         Component(type=c.get("type", "unknown"), name=c.get("name", ""))
         for c in data.get("components", [])
@@ -137,7 +297,17 @@ def extract_investigation(
         root_cause=data.get("root_cause"),
         resolved=bool(data.get("resolved", False)),
         summary=data.get("summary") or (result_text[:200] if result_text else ""),
+        status="ok",
     )
+
+
+def _raw_looks_like_json_object(raw: str) -> bool:
+    s = raw.strip()
+    if s.startswith("```"):
+        s = s.split("```")[1] if "```" in s[3:] else s.strip("`")
+        s = s[4:] if s.startswith("json") else s
+    start, end = s.find("{"), s.rfind("}")
+    return start >= 0 and end > start
 
 
 def _safe_json(raw: str) -> dict:
@@ -150,6 +320,7 @@ def _safe_json(raw: str) -> dict:
     start, end = s.find("{"), s.rfind("}")
     if start >= 0 and end > start:
         s = s[start : end + 1]
+    s = re.sub(r",\s*([}\]])", r"\1", s)
     try:
         return json.loads(s)
     except Exception as e:

--- a/sre-agent/memory/models.py
+++ b/sre-agent/memory/models.py
@@ -43,6 +43,7 @@ class Episode(BaseModel):
     root_cause: Optional[str] = None
     summary: str = ""
     effectiveness_score: float = 0.1
+    extraction_status: str = "ok"
 
     duration_seconds: Optional[float] = None
     created_at: str = ""

--- a/sre-agent/memory/retrieval.py
+++ b/sre-agent/memory/retrieval.py
@@ -25,6 +25,7 @@ WHERE e.org_id = $org_id
   AND ($team_node_id IS NULL OR e.team_node_id = $team_node_id)
   AND ($exclude_cid IS NULL OR e.correlation_id <> $exclude_cid)
   AND ($issue_type IS NULL OR e.issue_type = $issue_type)
+  AND (e.extraction_status IS NULL OR e.extraction_status <> 'failed')
 OPTIONAL MATCH (e)-[:AFFECTED]->(s:Service)
 RETURN e.correlation_id AS correlation_id, e.episode_id AS episode_id,
        e.agent_run_id AS agent_run_id, e.org_id AS org_id, e.team_node_id AS team_node_id,

--- a/sre-agent/memory/store.py
+++ b/sre-agent/memory/store.py
@@ -62,6 +62,7 @@ class EpisodeStore:
             "summary": ep.summary,
             "effectiveness_score": ep.effectiveness_score,
             "duration_seconds": ep.duration_seconds,
+            "extraction_status": ep.extraction_status or "ok",
             "created_at": ep.created_at,
             "updated_at": ep.updated_at,
             "embedding": ep.embedding,
@@ -102,6 +103,24 @@ class EpisodeStore:
             return None
         return self._node_to_episode(dict(rec["e"]), correlation_id)
 
+    def get_by_episode_id(
+        self, episode_id: str, org_id: str, team_node_id: str
+    ) -> Optional[Episode]:
+        with self._session() as s:
+            rec = s.run(
+                """
+                MATCH (e:Episode {episode_id: $eid, org_id: $org, team_node_id: $team})
+                RETURN e AS e
+                """,
+                eid=episode_id,
+                org=org_id,
+                team=team_node_id,
+            ).single()
+        if not rec:
+            return None
+        n = dict(rec["e"])
+        return self._node_to_episode(n, n.get("correlation_id", ""))
+
     @staticmethod
     def _node_to_episode(n: dict, correlation_id: str) -> Episode:
         comps = [Component(**c) for c in json.loads(n.get("components_json", "[]"))]
@@ -122,6 +141,7 @@ class EpisodeStore:
             root_cause=n.get("root_cause"),
             summary=n.get("summary", ""),
             effectiveness_score=float(n.get("effectiveness_score", 0.1)),
+            extraction_status=n.get("extraction_status") or "ok",
             duration_seconds=n.get("duration_seconds"),
             created_at=n.get("created_at", ""),
             updated_at=n.get("updated_at", ""),

--- a/sre-agent/server_simple.py
+++ b/sre-agent/server_simple.py
@@ -1146,9 +1146,38 @@ def _episode_row(r: dict) -> dict:
         "summary": e.get("summary"),
         "effectiveness_score": e.get("effectiveness_score"),
         "skills_used": e.get("skills_used", []),
+        "extraction_status": e.get("extraction_status") or "ok",
         "created_at": e.get("created_at"),
         "updated_at": e.get("updated_at"),
     }
+
+
+def _episode_from_model(ep) -> dict:
+    import json as _json
+
+    services = [c.name for c in ep.components if c.type == "service"]
+    return _episode_row(
+        {
+            "e": {
+                "episode_id": ep.episode_id,
+                "correlation_id": ep.correlation_id,
+                "agent_run_id": ep.agent_run_id,
+                "issue_type": ep.issue_type,
+                "issue_description": ep.issue_description,
+                "severity": ep.severity,
+                "components_json": _json.dumps([c.model_dump() for c in ep.components]),
+                "resolved": ep.resolved,
+                "root_cause": ep.root_cause,
+                "summary": ep.summary,
+                "effectiveness_score": ep.effectiveness_score,
+                "skills_used": ep.skills_used,
+                "extraction_status": ep.extraction_status,
+                "created_at": ep.created_at,
+                "updated_at": ep.updated_at,
+            },
+            "services": services,
+        }
+    )
 
 
 @app.get("/memory/episodes")
@@ -1170,6 +1199,7 @@ async def memory_stats(request: Request):
     org_id, team_node_id = _tenancy_from_request(request)
     q = (
         "MATCH (e:Episode {org_id:$org, team_node_id:$team}) "
+        "WHERE (e.extraction_status IS NULL OR e.extraction_status <> 'failed') "
         "RETURN count(e) AS total, "
         "sum(CASE WHEN e.resolved THEN 1 ELSE 0 END) AS resolved, "
         "collect(DISTINCT e.issue_type) AS issue_types"
@@ -1222,6 +1252,7 @@ async def memory_overview(request: Request):
         stats_rec = sess.run(
             """
             MATCH (e:Episode {org_id:$org, team_node_id:$team})
+            WHERE (e.extraction_status IS NULL OR e.extraction_status <> 'failed')
             RETURN count(e) AS total,
                    sum(CASE WHEN e.resolved THEN 1 ELSE 0 END) AS resolved
             """,
@@ -1233,6 +1264,7 @@ async def memory_overview(request: Request):
             """
             MATCH (e:Episode {org_id:$org, team_node_id:$team})
             WHERE e.issue_type IS NOT NULL AND e.issue_type <> ''
+              AND (e.extraction_status IS NULL OR e.extraction_status <> 'failed')
             RETURN e.issue_type AS issue_type, count(*) AS count
             ORDER BY count DESC
             """,
@@ -1243,6 +1275,7 @@ async def memory_overview(request: Request):
         recent_rows = sess.run(
             """
             MATCH (e:Episode {org_id:$org, team_node_id:$team})
+            WHERE (e.extraction_status IS NULL OR e.extraction_status <> 'failed')
             OPTIONAL MATCH (e)-[:AFFECTED]->(s:Service)
             RETURN e AS e, collect(s.name) AS services
             ORDER BY coalesce(e.updated_at, e.created_at) DESC
@@ -1256,6 +1289,7 @@ async def memory_overview(request: Request):
             """
             MATCH (e:Episode {org_id:$org, team_node_id:$team})
             WHERE coalesce(e.updated_at, e.created_at) >= $week_ago
+              AND (e.extraction_status IS NULL OR e.extraction_status <> 'failed')
             RETURN count(e) AS count
             """,
             org=org_id,
@@ -1306,6 +1340,56 @@ async def memory_overview(request: Request):
             "latest_strategies": [_overview_strategy_row(r) for r in latest_strats],
         },
     }
+
+
+@app.post("/memory/episodes/{episode_id}/reextract")
+async def memory_reextract(request: Request, episode_id: str):
+    org_id, team_node_id = _tenancy_from_request(request)
+    store = EpisodeStore()
+    ep = store.get_by_episode_id(episode_id, org_id, team_node_id)
+    if not ep:
+        raise HTTPException(404, "episode not found")
+    if not ep.agent_run_id:
+        raise HTTPException(409, "episode has no agent run")
+    run = httpx.get(
+        f"{_CONFIG_SERVICE_URL}/api/v1/internal/agent-runs/{ep.agent_run_id}",
+        headers=_INTERNAL_HEADERS,
+        timeout=5.0,
+    )
+    if run.status_code == 404:
+        raise HTTPException(409, "agent run not found")
+    run.raise_for_status()
+    body = run.json()
+    prompt = body.get("trigger_message") or ""
+    result_text = body.get("output_summary") or ""
+    if len(result_text.strip()) < 50:
+        raise HTTPException(409, "agent run has no result to summarize")
+    tc_resp = httpx.get(
+        f"{_CONFIG_SERVICE_URL}/api/v1/internal/agent-runs/{ep.agent_run_id}/tool-calls",
+        headers=_INTERNAL_HEADERS,
+        timeout=5.0,
+    )
+    tool_calls = []
+    if tc_resp.is_success:
+        for tc in tc_resp.json().get("tool_calls") or []:
+            tool_calls.append(
+                {
+                    "tool_name": tc.get("tool_name"),
+                    "tool_input": tc.get("tool_input") or {},
+                    "tool_output": tc.get("tool_output"),
+                }
+            )
+    _il.finalize_investigation(
+        correlation_id=ep.correlation_id,
+        agent_run_id=ep.agent_run_id,
+        prompt=prompt,
+        result_text=result_text,
+        tool_calls=tool_calls,
+        org_id=org_id,
+        team_node_id=team_node_id,
+    )
+    updated = store.get_by_episode_id(episode_id, org_id, team_node_id)
+    return {"success": True, "result": _episode_from_model(updated)}
 
 
 @app.post("/memory/search")

--- a/sre-agent/tests/test_investigation_lifecycle.py
+++ b/sre-agent/tests/test_investigation_lifecycle.py
@@ -55,7 +55,11 @@ def test_finalize_consolidates_via_prior(monkeypatch):
         il,
         "extract_investigation",
         lambda *a, **k: Extraction(
-            issue_type="db", root_cause="missing index", resolved=True, summary="fixed"
+            status="ok",
+            issue_type="db",
+            root_cause="missing index",
+            resolved=True,
+            summary="fixed",
         ),
     )
     monkeypatch.setattr(il, "_embed_episode_text", lambda ep: [0.0] * 384)
@@ -75,6 +79,40 @@ def test_finalize_consolidates_via_prior(monkeypatch):
         and ep.resolved is True
     )
     assert ep.effectiveness_score == 0.8 and ep.agent_run_id == "run9"
+    assert captured["ep"].extraction_status == "ok"
+
+
+def test_finalize_persists_failed_status(monkeypatch):
+    import investigation_lifecycle as il
+    from memory.extraction import Extraction
+
+    captured = {}
+
+    class FakeStore:
+        def get_by_correlation(self, cid):
+            return None
+
+        def upsert_episode(self, ep):
+            captured["ep"] = ep
+
+    monkeypatch.setattr(il, "_store", FakeStore())
+    monkeypatch.setattr(
+        il,
+        "extract_investigation",
+        lambda *a, **k: Extraction(status="failed", summary="stub " * 20),
+    )
+    monkeypatch.setattr(il, "_embed_episode_text", lambda ep: [0.0] * 384)
+    il.finalize_investigation(
+        "c-fail",
+        "run1",
+        "prompt",
+        "result text long enough to store " * 5,
+        [{"tool_name": "Skill", "tool_input": {"skill": "memory-search"}, "tool_output": "ok"}],
+        org_id="acme",
+        team_node_id="t1",
+    )
+    assert captured["ep"].extraction_status == "failed"
+    assert captured["ep"].skills_used == ["memory-search"]
 
 
 def test_guidance_requires_memory_before_reporting_back():

--- a/sre-agent/tests/test_memory_extraction.py
+++ b/sre-agent/tests/test_memory_extraction.py
@@ -33,3 +33,165 @@ def test_extract_key_findings_shape():
     ]
     finds = extract_key_findings(calls)
     assert finds and finds[0].skill == "metrics-analysis" and "98%" in finds[0].finding
+
+
+def test_safe_json_strips_fence_and_trailing_comma():
+    from memory.extraction import _safe_json
+
+    raw = '```json\n{"issue_type": "crashloop-backoff", "resolved": false,}\n```'
+    assert _safe_json(raw)["issue_type"] == "crashloop-backoff"
+
+
+def test_safe_json_empty_is_empty_dict():
+    from memory.extraction import _safe_json
+
+    assert _safe_json("") == {}
+    assert _safe_json("not json") == {}
+
+
+def test_extract_investigation_marks_failed_when_llm_returns_garbage(monkeypatch):
+    import memory.extraction as ex
+
+    monkeypatch.setattr(ex, "llm_text_completion", lambda *a, **k: "Expecting comma")
+    out = ex.extract_investigation("prompt here", "result text " * 20, [])
+    assert out.status == "failed"
+    assert out.issue_type == "unknown"
+    assert out.root_cause is None
+
+
+def test_extract_investigation_ok_when_json_parses(monkeypatch):
+    import memory.extraction as ex
+
+    monkeypatch.setattr(
+        ex,
+        "llm_text_completion",
+        lambda *a, **k: '{"issue_type":"crashloop-backoff","issue_description":"pods down","severity":"warning","components":[],"root_cause":"oom","resolved":true,"summary":"oom"}',
+    )
+    out = ex.extract_investigation("pods crashing", "OOMKilled " * 10, [])
+    assert out.status == "ok"
+    assert out.issue_type == "crashloop-backoff"
+    assert out.root_cause == "oom"
+
+
+def test_llm_uses_output_config_on_anthropic(monkeypatch):
+    import memory.extraction as ex
+
+    captured = {}
+
+    class FakeMsg:
+        content = [type("B", (), {"type": "text", "text": '{"issue_type":"x"}'})()]
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return FakeMsg()
+
+    class FakeClient:
+        messages = FakeMessages()
+
+    monkeypatch.setattr(ex, "_structured_cap", "json_schema")
+    monkeypatch.setenv("MEMORY_LLM_PROVIDER", "anthropic")
+    monkeypatch.setattr(ex, "_anthropic_client", lambda: FakeClient())
+    ex.llm_text_completion("p", json_schema=ex.EXTRACTION_JSON_SCHEMA)
+    assert captured["output_config"]["format"]["type"] == "json_schema"
+
+
+def test_llm_demotes_after_unsupported_format(monkeypatch):
+    import memory.extraction as ex
+
+    class Boom(Exception):
+        status_code = 400
+
+    calls = {"n": 0}
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            calls["n"] += 1
+            if "output_config" in kwargs:
+                raise Boom("output_config not supported")
+            return type(
+                "M",
+                (),
+                {"content": [type("B", (), {"type": "text", "text": '{"ok":true}'})()]},
+            )()
+
+    class FakeClient:
+        messages = FakeMessages()
+
+    monkeypatch.setattr(ex, "_structured_cap", "json_schema")
+    monkeypatch.setenv("MEMORY_LLM_PROVIDER", "anthropic")
+    monkeypatch.setattr(ex, "_anthropic_client", lambda: FakeClient())
+    text = ex.llm_text_completion("p", json_schema=ex.EXTRACTION_JSON_SCHEMA)
+    assert calls["n"] == 2
+    assert ex._structured_cap == "prompt"
+    assert "ok" in text
+
+
+def test_llm_demotes_after_extra_body_rejected(monkeypatch):
+    import memory.extraction as ex
+
+    class Bad400(Exception):
+        status_code = 400
+
+    calls = {"n": 0}
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise TypeError("unexpected keyword argument 'output_config'")
+            if calls["n"] == 2:
+                if "extra_body" not in kwargs:
+                    raise AssertionError("expected extra_body on second call")
+                raise Bad400("output_config not supported")
+            if "output_config" in kwargs or "extra_body" in kwargs:
+                raise AssertionError("demoted call must not use structured output")
+            return type(
+                "M",
+                (),
+                {"content": [type("B", (), {"type": "text", "text": '{"ok":true}'})()]},
+            )()
+
+    class FakeClient:
+        messages = FakeMessages()
+
+    monkeypatch.setattr(ex, "_structured_cap", "json_schema")
+    monkeypatch.setenv("MEMORY_LLM_PROVIDER", "anthropic")
+    monkeypatch.setattr(ex, "_anthropic_client", lambda: FakeClient())
+    text = ex.llm_text_completion("p", json_schema=ex.EXTRACTION_JSON_SCHEMA)
+    assert calls["n"] == 3
+    assert ex._structured_cap == "prompt"
+    assert "ok" in text
+
+
+def test_extract_retries_once_on_empty(monkeypatch):
+    import memory.extraction as ex
+
+    n = {"c": 0}
+
+    def fake(prompt, max_tokens=300, json_schema=None):
+        n["c"] += 1
+        if n["c"] == 1:
+            return ""
+        return '{"issue_type":"latency-spike","issue_description":"slow","severity":null,"components":[],"root_cause":"idx","resolved":true,"summary":"index"}'
+
+    monkeypatch.setattr(ex, "llm_text_completion", fake)
+    out = ex.extract_investigation("slow checkout", "missing index " * 10, [])
+    assert n["c"] == 2
+    assert out.status == "ok"
+    assert out.root_cause == "idx"
+
+
+def test_extract_does_not_retry_on_broken_json(monkeypatch):
+    import memory.extraction as ex
+
+    n = {"c": 0}
+
+    def fake(*a, **k):
+        n["c"] += 1
+        return "not-json {"
+
+    monkeypatch.setattr(ex, "llm_text_completion", fake)
+    out = ex.extract_investigation("p", "result " * 20, [])
+    assert n["c"] == 1
+    assert out.status == "failed"

--- a/sre-agent/tests/test_memory_store.py
+++ b/sre-agent/tests/test_memory_store.py
@@ -79,3 +79,11 @@ def test_get_by_correlation_roundtrip(clean_store):
         and got.root_cause == "dns"
         and got.issue_type == "latency-spike"
     )
+
+
+def test_extraction_status_roundtrip(clean_store):
+    ep = _episode("c-fail", None, False, 0.1)
+    ep.extraction_status = "failed"
+    clean_store.upsert_episode(ep)
+    got = clean_store.get_by_correlation("c-fail")
+    assert got is not None and got.extraction_status == "failed"

--- a/sre-agent/tests/test_server_memory_endpoints.py
+++ b/sre-agent/tests/test_server_memory_endpoints.py
@@ -1,12 +1,15 @@
 import os
+from unittest.mock import MagicMock
 
 import pytest
 
 pytest.importorskip("neo4j")
-pytestmark = pytest.mark.skipif(not os.getenv("NEO4J_URI"), reason="needs Neo4j")
 
 
 def test_memory_stats_endpoint_shape():
+    pytest.importorskip("neo4j")
+    if not os.getenv("NEO4J_URI"):
+        pytest.skip("needs Neo4j")
     import server_simple
     from fastapi.testclient import TestClient
 
@@ -19,6 +22,9 @@ def test_memory_stats_endpoint_shape():
 
 
 def test_memory_overview_endpoint_shape():
+    pytest.importorskip("neo4j")
+    if not os.getenv("NEO4J_URI"):
+        pytest.skip("needs Neo4j")
     import server_simple
     from fastapi.testclient import TestClient
 
@@ -40,3 +46,141 @@ def test_memory_overview_endpoint_shape():
         "latest_strategies",
     ):
         assert key in result
+
+
+def test_reextract_calls_finalize_with_run_data(monkeypatch):
+    import server_simple
+    from fastapi.testclient import TestClient
+    from memory.models import Episode
+
+    ep = Episode(
+        episode_id="e1",
+        correlation_id="corr-1",
+        agent_run_id="run-1",
+        org_id="local",
+        team_node_id="default",
+        issue_type="db",
+        extraction_status="failed",
+        created_at="t",
+        updated_at="t",
+    )
+    updated_ep = Episode(
+        episode_id="e1",
+        correlation_id="corr-1",
+        agent_run_id="run-1",
+        org_id="local",
+        team_node_id="default",
+        issue_type="db",
+        extraction_status="ok",
+        summary="fixed",
+        created_at="t",
+        updated_at="t2",
+    )
+    finalize_kwargs = {}
+
+    def fake_finalize(**kwargs):
+        finalize_kwargs.update(kwargs)
+
+    def fake_get(url, headers=None, timeout=None):
+        resp = MagicMock()
+        if url.endswith("/tool-calls"):
+            resp.is_success = True
+            resp.json.return_value = {
+                "tool_calls": [
+                    {
+                        "tool_name": "Skill",
+                        "tool_input": {"skill": "memory-search"},
+                        "tool_output": "found similar",
+                    }
+                ]
+            }
+        else:
+            resp.status_code = 200
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {
+                "trigger_message": "checkout slow",
+                "output_summary": "root cause was a missing index " * 5,
+            }
+        return resp
+
+    class FakeStore:
+        def __init__(self):
+            self._call = 0
+
+        def get_by_episode_id(self, episode_id, org_id, team_node_id):
+            self._call += 1
+            assert episode_id == "e1"
+            assert org_id == "local"
+            assert team_node_id == "default"
+            if self._call == 1:
+                return ep
+            return updated_ep
+
+    monkeypatch.setattr(server_simple, "_tenancy_from_request", lambda _r: ("local", "default"))
+    monkeypatch.setattr(server_simple, "EpisodeStore", FakeStore)
+    monkeypatch.setattr(server_simple._il, "finalize_investigation", fake_finalize)
+    monkeypatch.setattr(server_simple.httpx, "get", fake_get)
+
+    client = TestClient(server_simple.app)
+    resp = client.post("/memory/episodes/e1/reextract")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["result"]["extraction_status"] == "ok"
+    assert body["result"]["episode_id"] == "e1"
+    assert finalize_kwargs["prompt"] == "checkout slow"
+    assert "missing index" in finalize_kwargs["result_text"]
+    assert finalize_kwargs["correlation_id"] == "corr-1"
+    assert finalize_kwargs["agent_run_id"] == "run-1"
+    assert finalize_kwargs["org_id"] == "local"
+    assert finalize_kwargs["team_node_id"] == "default"
+    assert len(finalize_kwargs["tool_calls"]) == 1
+    assert finalize_kwargs["tool_calls"][0]["tool_name"] == "Skill"
+
+
+def test_reextract_episode_not_found(monkeypatch):
+    import server_simple
+    from fastapi.testclient import TestClient
+
+    class FakeStore:
+        def get_by_episode_id(self, episode_id, org_id, team_node_id):
+            return None
+
+    monkeypatch.setattr(server_simple, "_tenancy_from_request", lambda _r: ("local", "default"))
+    monkeypatch.setattr(server_simple, "EpisodeStore", FakeStore)
+
+    client = TestClient(server_simple.app)
+    resp = client.post("/memory/episodes/missing/reextract")
+
+    assert resp.status_code == 404
+    assert "episode not found" in resp.json()["detail"]
+
+
+def test_reextract_no_agent_run_id(monkeypatch):
+    import server_simple
+    from fastapi.testclient import TestClient
+    from memory.models import Episode
+
+    ep = Episode(
+        episode_id="e1",
+        correlation_id="corr-1",
+        agent_run_id=None,
+        org_id="local",
+        team_node_id="default",
+        created_at="t",
+        updated_at="t",
+    )
+
+    class FakeStore:
+        def get_by_episode_id(self, episode_id, org_id, team_node_id):
+            return ep
+
+    monkeypatch.setattr(server_simple, "_tenancy_from_request", lambda _r: ("local", "default"))
+    monkeypatch.setattr(server_simple, "EpisodeStore", FakeStore)
+
+    client = TestClient(server_simple.app)
+    resp = client.post("/memory/episodes/e1/reextract")
+
+    assert resp.status_code == 409
+    assert "no agent run" in resp.json()["detail"]

--- a/web_ui/src/app/api/memory/episodes/[episodeId]/reextract/route.ts
+++ b/web_ui/src/app/api/memory/episodes/[episodeId]/reextract/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+const AGENT_URL = process.env.AGENT_SERVICE_URL || 'http://localhost:8000';
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ episodeId: string }> },
+) {
+  const token = (await cookies()).get('opensre_session_token')?.value;
+  if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { episodeId } = await params;
+  const res = await fetch(
+    `${AGENT_URL}/memory/episodes/${encodeURIComponent(episodeId)}/reextract`,
+    { method: 'POST', headers: { Authorization: `Bearer ${token}` } },
+  );
+  const data = await res.json();
+  if (!res.ok) {
+    return NextResponse.json(
+      { success: false, error: data?.detail ?? 'Retry failed' },
+      { status: res.status },
+    );
+  }
+  return NextResponse.json({ success: true, episode: data?.result ?? data });
+}

--- a/web_ui/src/app/team/memory/episodes/page.tsx
+++ b/web_ui/src/app/team/memory/episodes/page.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect, useMemo, useRef } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { clsx } from 'clsx';
-import { ChevronDown, Clock, Search } from 'lucide-react';
+import { ChevronDown, Clock, RotateCw, Search } from 'lucide-react';
 import { formatRelativeTime } from '@/lib/formatRelativeTime';
 import { Button, Chip, EmptyState, Panel, Skeleton, listRowHoverClass } from '@/components/ui-flow';
 
@@ -29,6 +29,7 @@ interface Episode {
   effectiveness_score: number | null;
   duration_seconds: number | null;
   created_at: string | null;
+  extraction_status?: 'ok' | 'failed';
 }
 
 const ISSUE_TYPE_INITIAL = 5;
@@ -120,6 +121,7 @@ export default function EpisodesPage() {
   const [sortBy, setSortBy] = useState<'newest' | 'effectiveness'>('newest');
   const [issueTypeVisibleCount, setIssueTypeVisibleCount] = useState(ISSUE_TYPE_INITIAL);
   const [manualExpandedId, setManualExpandedId] = useState<string | null>(null);
+  const [retryingId, setRetryingId] = useState<string | null>(null);
   const scrolledToDeepLink = useRef(false);
 
   useEffect(() => {
@@ -246,6 +248,25 @@ export default function EpisodesPage() {
 
   const toggleExpand = (id: string) => {
     setManualExpandedId((prev) => (prev === id ? null : id));
+  };
+
+  const retryExtract = async (episodeId: string) => {
+    setRetryingId(episodeId);
+    try {
+      const res = await fetch(`/api/memory/episodes/${episodeId}/reextract`, {
+        method: 'POST',
+      });
+      const data = await res.json();
+      if (res.ok && data.episode) {
+        setEpisodes((prev) =>
+          prev.map((ep) => (ep.episode_id === episodeId ? data.episode : ep)),
+        );
+      }
+    } catch {
+      // leave row as failed
+    } finally {
+      setRetryingId(null);
+    }
   };
 
   if (loading) {
@@ -422,6 +443,11 @@ export default function EpisodesPage() {
                           <span className="text-[14.5px] text-slate-900">
                             {ep.issue_type || 'unknown'}
                           </span>
+                          {ep.extraction_status === 'failed' && (
+                            <span className="inline-flex items-center h-5 px-2 rounded-full text-[10px] font-medium tracking-wide bg-slate-100 text-slate-600">
+                              couldn’t summarize
+                            </span>
+                          )}
                           {ep.severity && (
                             <span
                               className={clsx(
@@ -511,6 +537,23 @@ export default function EpisodesPage() {
                               {c.type}:{c.name}
                             </span>
                           ))}
+                        </div>
+                      )}
+                      {ep.extraction_status === 'failed' && (
+                        <div className="flex items-center justify-between gap-3 mb-4">
+                          <p className="text-sm text-slate-500">Couldn’t summarize this investigation.</p>
+                          <button
+                            type="button"
+                            disabled={retryingId === ep.episode_id}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              void retryExtract(ep.episode_id);
+                            }}
+                            className="inline-flex items-center gap-1.5 text-sm text-emerald-700 hover:underline disabled:opacity-50"
+                          >
+                            <RotateCw className="w-3.5 h-3.5" />
+                            Retry
+                          </button>
                         </div>
                       )}
                       {ep.effectiveness_score != null && (


### PR DESCRIPTION
## Summary
- Memory extraction guardrails: salvage failed extraction, structured JSON constraints, extraction_status persistence
- Episode retry from stored agent run (API + Memory list UI)

## Test plan
- [x] Memory extraction handles unparseable output as failed (not unknown RCA)
- [x] Failed episodes excluded from recall/overview stats
- [x] Retry extraction from Memory list works against stored agent run