### PR TITLE
docs: document simple-mode TLS and DoS posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ OpenSRE is an open-source AI SRE agent that automatically investigates productio
 
 ## Quick Start
 
+> **⚠️ Local-dev mode — not for production exposure.**
+> `make dev` starts the agent in **simple-mode** (cleartext HTTP, no rate limiting, no sandbox isolation). It is designed for use on `localhost` only. Before exposing OpenSRE on any network, read the [Simple-Mode / Local-Dev Security Posture](SECURITY.md#simple-mode--local-dev-security-posture) and [Hardening Checklist](SECURITY.md#hardening-checklist) in [SECURITY.md](SECURITY.md).
+
 ```bash
 git clone https://github.com/swapnildahiphale/OpenSRE.git
 cd OpenSRE

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,6 +70,88 @@ Security issues in:
 - Theoretical vulnerabilities without proof of concept
 - Brute force attacks without additional vulnerability
 
+## Simple-Mode / Local-Dev Security Posture
+
+> **⚠️ Simple-mode is for local development only.**
+
+`sre-agent/server_simple.py` (activated by `USE_SIMPLE_MODE=true` or `make dev`) runs the agent in-process, without Kubernetes sandboxes, and with **no TLS, no rate limiting, and no request-body size caps** by design. This is intentional for a single-developer laptop workflow where the compose stack is not exposed beyond `localhost`.
+
+### What this means
+
+| Property | Simple-mode behaviour | Production expectation |
+|---|---|---|
+| Transport | Cleartext HTTP (port 8000) | TLS terminated at reverse proxy / ingress |
+| Rate limiting | None | Reverse proxy / ingress (e.g. nginx `limit_req`, Caddy, AWS ALB) |
+| Request body cap | None | Reverse proxy `client_max_body_size` / ALB max payload |
+| Concurrency | Unbounded asyncio tasks | Reverse proxy worker limits / API gateway throttling |
+| Process isolation | Shared process (no sandbox) | `server.py` + Kubernetes sandboxes |
+
+### Recommended setup for self-hosters
+
+If you expose OpenSRE on a network (VM, VPS, cloud instance), follow these steps:
+
+1. **Bind to localhost only** — do not publish port 8000 to `0.0.0.0`:
+
+   ```yaml
+   # docker-compose.yml override
+   services:
+     sre-agent:
+       ports:
+         - "127.0.0.1:8000:8000"   # ✅ loopback only
+         # - "8000:8000"            # ❌ exposed on all interfaces
+   ```
+
+2. **Terminate TLS at a reverse proxy** (nginx, Caddy, Traefik, AWS ALB, GCP Load Balancer, etc.) — do **not** run simple-mode directly on a public port. Simple-mode has no built-in TLS support.
+
+3. **Add rate limiting and body-size caps at the proxy layer** — see the [Hardening Checklist](#hardening-checklist) below.
+
+4. **Prefer `server.py` (Kubernetes sandbox mode) for any shared / production deployment** — it provides process isolation that simple-mode intentionally omits.
+
+---
+
+## Hardening Checklist
+
+Use this checklist before exposing any OpenSRE deployment beyond a personal laptop.
+
+### TLS at the ingress
+
+- [ ] A valid TLS certificate is provisioned (Let's Encrypt / cert-manager / ACM).
+- [ ] HTTP → HTTPS redirect is enforced.
+- [ ] TLS 1.2+ only; TLS 1.0 and 1.1 disabled.
+- [ ] `Strict-Transport-Security` (HSTS) header set (min `max-age=31536000`).
+
+### Rate limiting
+
+- [ ] Per-IP request rate limited at the reverse proxy / API gateway (e.g. nginx `limit_req_zone`, Caddy `rate_limit`, AWS WAF rate-based rules).
+- [ ] `/investigate` (POST) endpoint rate limited more aggressively than read endpoints, as each call triggers an LLM completion.
+- [ ] Burst allowance tuned so legitimate interactive use is not impacted.
+
+### Request body size caps
+
+- [ ] Reverse proxy `client_max_body_size` (nginx) or equivalent set to a reasonable limit (e.g. 10 MB for file attachments).
+- [ ] Server-side validation rejects unexpectedly large payloads before they reach the agent.
+
+### Concurrency limits at the edge
+
+- [ ] Maximum concurrent connections / workers configured at the proxy (e.g. nginx `worker_connections`, ALB target group connection limits).
+- [ ] Gunicorn / Uvicorn worker count tuned to available CPU, not left at default.
+- [ ] Long-running SSE streams accounted for in connection-limit calculations.
+
+### Authentication & network controls
+
+- [ ] Admin token rotated from the auto-generated default before first exposure.
+- [ ] Port 8000 not published to `0.0.0.0`; all traffic enters via the proxy.
+- [ ] Firewall / security group allows only the proxy's IP range to reach the agent.
+- [ ] SSO / OIDC enabled for multi-user deployments (see [docs/SSO_SETUP.md](docs/SSO_SETUP.md)).
+
+### Monitoring
+
+- [ ] Access logs from the proxy shipped to a SIEM or log aggregator.
+- [ ] Anomalous request rates / 4xx spikes trigger an alert.
+- [ ] Agent audit logs (all tool calls) reviewed periodically.
+
+---
+
 ## Security Best Practices
 
 When deploying OpenSRE:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,7 +74,7 @@ Security issues in:
 
 > **⚠️ Simple-mode is for local development only.**
 
-`sre-agent/server_simple.py` (activated by `USE_SIMPLE_MODE=true` or `make dev`) runs the agent in-process, without Kubernetes sandboxes, and with **no TLS, no rate limiting, and no request-body size caps** by design. This is intentional for a single-developer laptop workflow where the compose stack is not exposed beyond `localhost`.
+`sre-agent/server_simple.py` (default via `make dev` / Docker image CMD) runs the agent in-process, without Kubernetes sandboxes, and with **no TLS, no rate limiting, and no request-body size caps** by design. This is intentional for a single-developer laptop workflow where the compose stack is not exposed beyond `localhost`.
 
 ### What this means
 
@@ -90,15 +90,15 @@ Security issues in:
 
 If you expose OpenSRE on a network (VM, VPS, cloud instance), follow these steps:
 
-1. **Bind to localhost only** — do not publish port 8000 to `0.0.0.0`:
+1. **Bind to localhost only** — do not publish host port 8001 to `0.0.0.0`:
 
    ```yaml
    # docker-compose.yml override
    services:
      sre-agent:
        ports:
-         - "127.0.0.1:8000:8000"   # ✅ loopback only
-         # - "8000:8000"            # ❌ exposed on all interfaces
+         - "127.0.0.1:8001:8000"   # ✅ loopback only
+         # - "8001:8000"            # ❌ exposed on all interfaces
    ```
 
 2. **Terminate TLS at a reverse proxy** (nginx, Caddy, Traefik, AWS ALB, GCP Load Balancer, etc.) — do **not** run simple-mode directly on a public port. Simple-mode has no built-in TLS support.
@@ -128,8 +128,7 @@ Use this checklist before exposing any OpenSRE deployment beyond a personal lapt
 
 ### Request body size caps
 
-- [ ] Reverse proxy `client_max_body_size` (nginx) or equivalent set to a reasonable limit (e.g. 10 MB for file attachments).
-- [ ] Server-side validation rejects unexpectedly large payloads before they reach the agent.
+- [ ] Reverse proxy `client_max_body_size` (nginx) or equivalent set to a reasonable limit (e.g. 10 MB for file attachments), as simple-mode does not enforce in-app body size limits.
 
 ### Concurrency limits at the edge
 
@@ -140,7 +139,7 @@ Use this checklist before exposing any OpenSRE deployment beyond a personal lapt
 ### Authentication & network controls
 
 - [ ] Admin token rotated from the auto-generated default before first exposure.
-- [ ] Port 8000 not published to `0.0.0.0`; all traffic enters via the proxy.
+- [ ] Agent port (8001/8000) not published to `0.0.0.0`; all traffic enters via the proxy.
 - [ ] Firewall / security group allows only the proxy's IP range to reach the agent.
 - [ ] SSO / OIDC enabled for multi-user deployments (see [docs/SSO_SETUP.md](docs/SSO_SETUP.md)).
 

--- a/sre-agent/server_simple.py
+++ b/sre-agent/server_simple.py
@@ -398,6 +398,31 @@ app = FastAPI(
     description="AI SRE agent for incident investigation - in-process mode (no sandboxes)",
     version="0.3.0",
 )
+# ---------------------------------------------------------------------------
+# ⚠️  DoS / hardening note (follow-up: issue #36)
+#
+# This server intentionally omits network-level protections that are the
+# responsibility of the reverse proxy / ingress in any production-adjacent
+# deployment:
+#
+#   • Rate limiting   — add per-IP limits at nginx/Caddy/AWS ALB/WAF in front
+#                       of this service.  The /investigate endpoint in particular
+#                       triggers expensive LLM completions and should be throttled
+#                       aggressively (e.g. nginx limit_req_zone, Caddy rate_limit).
+#
+#   • Request body caps — set client_max_body_size (nginx) or equivalent at the
+#                         proxy; no cap is enforced here.
+#
+#   • Concurrency limits — Uvicorn worker count and max-connections should be
+#                          tuned at the proxy/process level; asyncio tasks are
+#                          currently unbounded.
+#
+#   • TLS              — simple-mode serves cleartext HTTP and is designed for
+#                        localhost use only.  Terminate TLS at the ingress.
+#
+# See SECURITY.md §"Simple-Mode / Local-Dev Security Posture" and
+# §"Hardening Checklist" for guidance before exposing this service on a network.
+# ---------------------------------------------------------------------------
 
 
 @app.on_event("startup")


### PR DESCRIPTION
## Description

Default local compose and simple-mode deployments (`server_simple.py`) use cleartext HTTP and lack rate limiting or request body size caps by design. This is suitable for a single-developer workflow on `localhost`, but self-hosters deploying on VMs, VPS instances, or clouds might expose it without understanding the security implications.

This PR documents the simple-mode TLS and DoS posture, provides actionable advice for binding to localhost and terminating TLS at a reverse proxy/ingress, introduces a production hardening checklist, adds a warning callout in the `README.md` Quick Start section, and adds a follow-up comment in `sre-agent/server_simple.py`.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring / code cleanup
- [ ] 🧪 Test improvements
- [ ] 🚀 Performance improvement
- [ ] 🔒 Security fix

## Related Issues

Closes #36

## Changes Made

- **`SECURITY.md`**:
  - Added a **"Simple-Mode / Local-Dev Security Posture"** section explaining that cleartext HTTP, absence of rate limiting, and unbounded request sizes are intentional for local laptop development only.
  - Added self-hoster recommendations: bind to loopback (`127.0.0.1:8000:8000`), terminate TLS at a reverse proxy/ingress (nginx, Caddy, Traefik, AWS ALB), and prefer `server.py` with K8s sandboxes for shared production environments.
  - Added a **"Hardening Checklist"** covering:
    - TLS at the ingress (valid certificates, HTTP→HTTPS redirect, TLS 1.2+, HSTS)
    - Rate limiting (per-IP limits, aggressive throttling on `/investigate`)
    - Request body size caps (`client_max_body_size`)
    - Concurrency limits at the edge (worker connections, Uvicorn tuning, SSE stream handling)
    - Authentication and network boundary controls
    - Monitoring and audit logs
- **`README.md`**:
  - Added a security warning callout directly under `## Quick Start` noting that `make dev` uses simple-mode on cleartext HTTP, and linking to `SECURITY.md` before exposing the stack on any network.
- **`sre-agent/server_simple.py`**:
  - Added a follow-up comment block on the `FastAPI` instance outlining the DoS/hardening responsibilities that belong at the reverse proxy/ingress layer and cross-referencing Issue #36 and `SECURITY.md`.

## Testing

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested locally with Docker Compose
- [ ] Tested in Kubernetes environment (if applicable)

### Testing Steps

1. Verified Python syntax on `sre-agent/server_simple.py` with `python3 -m py_compile sre-agent/server_simple.py`.
2. Verified markdown syntax, internal anchor links (`#simple-mode--local-dev-security-posture`, `#hardening-checklist`), and cross-file links between `README.md` and `SECURITY.md`.
3. Inspected `git diff` to ensure strictly documentation/comment changes with zero impact on runtime logic.

## Screenshots / Videos

N/A (Documentation changes only)

## Checklist

- [x] Code follows the project's style guidelines (`black` and `ruff` for Python)
- [x] Self-review of code completed
- [x] Comments added for complex logic
- [x] Documentation updated (README, docs/, etc.)
- [x] No new warnings introduced
- [ ] Tests added/updated and passing
- [ ] All CI checks passing
- [x] Changes comply with [Apache 2.0 license](LICENSE)
- [x] Branch is up to date with `main`

## Additional Context

As outlined in issue #36, actual in-code rate limiting and mTLS/service mesh integrations are intentionally out of scope for this documentation PR.

## Deployment Notes

- [ ] Requires database migration
- [ ] Requires configuration changes
- [ ] Requires environment variable updates
- [ ] Requires new secrets/credentials
- [x] Backward compatible
- [ ] None of the above