### PR TITLE
OpenSRE v1.2.4 — SSO and Teams actor identity

### DIFF
--- a/charts/opensre/Chart.yaml
+++ b/charts/opensre/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: opensre
 description: AI-powered SRE platform for automated incident investigation and response
 type: application
-version: 1.2.3
-appVersion: "1.2.3"
+version: 1.2.4
+appVersion: "1.2.4"
 home: https://opensre.in
 icon: https://raw.githubusercontent.com/swapnildahiphale/OpenSRE/main/web_ui/public/brand/opensre-spinner.png
 sources:

--- a/charts/opensre/README.md
+++ b/charts/opensre/README.md
@@ -148,7 +148,7 @@ helm upgrade --install opensre charts/opensre \
 
 ### Self-hosted profile (recommended)
 
-See `charts/opensre/values.self-hosted-simple.yaml` for the supported public self-hosted profile (simple mode with embedded Postgres/Neo4j; Docker Hub image pins for v1.2.3). Full walkthrough: `docs/SELF_HOSTED_SIMPLE_INSTALL.md`.
+See `charts/opensre/values.self-hosted-simple.yaml` for the supported public self-hosted profile (simple mode with embedded Postgres/Neo4j; Docker Hub image pins for v1.2.4). Full walkthrough: `docs/SELF_HOSTED_SIMPLE_INSTALL.md`.
 
 ### Site overlay (hosts, TLS, private registry)
 

--- a/charts/opensre/values.examples/site-overlay.yaml.example
+++ b/charts/opensre/values.examples/site-overlay.yaml.example
@@ -1,5 +1,5 @@
 # Copy to my-site.yaml (local, gitignored). Do not commit secrets.
-# Simple-mode already pins Docker Hub swapnildahiphale/opensre-*:v1.2.3.
+# Simple-mode already pins Docker Hub swapnildahiphale/opensre-*:v1.2.4.
 # Set services.*.image here only when using a private registry.
 
 ingress:

--- a/charts/opensre/values.self-hosted-simple.yaml
+++ b/charts/opensre/values.self-hosted-simple.yaml
@@ -54,7 +54,7 @@ neo4j:
 services:
   configService:
     enabled: true
-    image: swapnildahiphale/opensre-config-service:v1.2.3
+    image: swapnildahiphale/opensre-config-service:v1.2.4
     adminAuthMode: token
     teamAuthMode: token
     migrations:
@@ -69,7 +69,7 @@ services:
 
   teamsBot:
     enabled: false
-    image: swapnildahiphale/opensre-teams-bot:v1.2.3
+    image: swapnildahiphale/opensre-teams-bot:v1.2.4
 
   k8sGateway:
     enabled: false
@@ -109,11 +109,11 @@ services:
       persistence:
         enabled: true
         size: 10Gi
-    image: swapnildahiphale/opensre-sre-agent:v1.2.3
+    image: swapnildahiphale/opensre-sre-agent:v1.2.4
 
   webUi:
     enabled: true
-    image: swapnildahiphale/opensre-web-ui:v1.2.3
+    image: swapnildahiphale/opensre-web-ui:v1.2.4
     cookieSecure: true
     oidc:
       enabled: false

--- a/config_service/alembic/versions/20260909_team_token_display_name.py
+++ b/config_service/alembic/versions/20260909_team_token_display_name.py
@@ -1,0 +1,27 @@
+"""Add team_tokens.display_name for SSO persona.
+
+Revision ID: 20260909_token_disp_name
+Revises: 20260901_sso_configs_oidc
+Create Date: 2026-09-09
+
+alembic_version.version_num is varchar(32); keep the revision id short.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260909_token_disp_name"
+down_revision = "20260901_sso_configs_oidc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "team_tokens",
+        sa.Column("display_name", sa.String(length=256), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("team_tokens", "display_name")

--- a/config_service/src/api/routes/auth_me.py
+++ b/config_service/src/api/routes/auth_me.py
@@ -32,8 +32,27 @@ class AuthMeResponse(BaseModel):
     team_node_id: Optional[str] = None
     subject: Optional[str] = None
     email: Optional[str] = None
+    name: Optional[str] = None
     can_write: bool = False
     permissions: List[str] = Field(default_factory=list)
+
+
+def sso_persona_from_token(
+    label: Optional[str], display_name: Optional[str]
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Return (email, name, subject) for sso:{email} labels. Else all None.
+
+    Do not treat an arbitrary token label as an email.
+    """
+    if not isinstance(label, str) or not label.startswith("sso:"):
+        return None, None, None
+    remainder = label[4:]
+    if "@" not in remainder:
+        return None, None, None
+    name = None
+    if isinstance(display_name, str) and display_name.strip():
+        name = display_name.strip()
+    return remainder, name, remainder
 
 
 def _extract_token(authorization: str, x_admin_token: str) -> str:
@@ -142,11 +161,27 @@ def auth_me_impl(
             raise HTTPException(status_code=503, detail=str(e))
         except ValueError:
             raise HTTPException(status_code=401, detail="Invalid token")
+
+        from sqlalchemy import select
+
+        from src.db.models import TeamToken
+
+        token_id = raw.split(".", 1)[0]
+        row = session.execute(
+            select(TeamToken).where(TeamToken.token_id == token_id)
+        ).scalar_one_or_none()
+        email, name, subject = sso_persona_from_token(
+            getattr(row, "label", None) if row is not None else None,
+            getattr(row, "display_name", None) if row is not None else None,
+        )
         return AuthMeResponse(
             role="team",
             auth_kind="team_token",
             org_id=principal.org_id,
             team_node_id=principal.team_node_id,
+            email=email,
+            name=name,
+            subject=subject,
             can_write=True,
             permissions=["team:read", "team:write"],
         )

--- a/config_service/src/api/routes/sso.py
+++ b/config_service/src/api/routes/sso.py
@@ -98,6 +98,16 @@ def _resolve_sso_email(
     return None
 
 
+def _apply_sso_display_name(token: TeamToken, name: object) -> None:
+    """Persist Entra display name when present. Never clear a stored name."""
+    if not isinstance(name, str):
+        return
+    stripped = name.strip()
+    if not stripped:
+        return
+    token.display_name = stripped[:256]
+
+
 @router.post("/exchange", response_model=TokenExchangeResponse)
 async def exchange_auth_code(
     body: TokenExchangeRequest,
@@ -243,6 +253,7 @@ async def exchange_auth_code(
         existing_token.token_hash = _sso_token_hash(token_secret)
         existing_token.last_used_at = datetime.utcnow()
         existing_token.expires_at = datetime.utcnow() + timedelta(days=7)
+        _apply_sso_display_name(existing_token, name)
         token_id = existing_token.token_id
     else:
         # Create new token
@@ -269,6 +280,7 @@ async def exchange_auth_code(
             expires_at=datetime.utcnow() + timedelta(days=7),
             issued_by=f"sso:{email}",
         )
+        _apply_sso_display_name(new_token, name)
         db.add(new_token)
 
     db.commit()

--- a/config_service/src/db/models.py
+++ b/config_service/src/db/models.py
@@ -124,6 +124,8 @@ class TeamToken(Base):
         default=lambda: TokenPermission.DEFAULT_TEAM,
     )
     label: Mapped[Optional[str]] = mapped_column(String(256), nullable=True)
+    # Entra display name for SSO-minted tokens (label sso:{email}). Null for minted team tokens.
+    display_name: Mapped[Optional[str]] = mapped_column(String(256), nullable=True)
 
     __table_args__ = (
         ForeignKeyConstraint(

--- a/config_service/tests/test_auth_me.py
+++ b/config_service/tests/test_auth_me.py
@@ -12,9 +12,30 @@ jwt = pytest.importorskip("jwt")
 cryptography = pytest.importorskip("cryptography")
 from cryptography.hazmat.primitives.asymmetric import rsa
 from src.api.main import create_app
+from src.api.routes.auth_me import sso_persona_from_token
 from src.core.security import hash_token
-from src.db.base import Base
-from src.db.models import NodeConfig, NodeType, OrgNode, TeamToken
+from src.db.models import NodeType, OrgNode, TeamToken
+
+
+def test_sso_persona_from_sso_label_with_name():
+    email, name, subject = sso_persona_from_token("sso:jane@example.com", "Jane Doe")
+    assert email == "jane@example.com"
+    assert name == "Jane Doe"
+    assert subject == "jane@example.com"
+
+
+def test_sso_persona_from_sso_label_without_name():
+    email, name, subject = sso_persona_from_token("sso:jane@example.com", None)
+    assert email == "jane@example.com"
+    assert name is None
+    assert subject == "jane@example.com"
+
+
+def test_sso_persona_ignores_non_sso_label():
+    assert sso_persona_from_token("local-dev", "ShouldIgnore") == (None, None, None)
+    assert sso_persona_from_token("jane@example.com", None) == (None, None, None)
+    assert sso_persona_from_token("sso:not-an-email", "Jane") == (None, None, None)
+    assert sso_persona_from_token(None, "Jane") == (None, None, None)
 
 
 @pytest.fixture()
@@ -24,7 +45,9 @@ def app_db_team(monkeypatch):
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
-    Base.metadata.create_all(bind=engine)
+    # Only create tables needed for token auth; full create_all fails on SQLite JSONB.
+    for table in (OrgNode, TeamToken):
+        table.__table__.create(bind=engine)
     SessionLocal = sessionmaker(bind=engine)
 
     monkeypatch.setenv("TOKEN_PEPPER", "test-pepper")
@@ -49,8 +72,6 @@ def app_db_team(monkeypatch):
                 name="Team A",
             )
         )
-        s.add(NodeConfig(org_id="org1", node_id="root", config_json={}, version=1))
-        s.add(NodeConfig(org_id="org1", node_id="teamA", config_json={}, version=1))
         s.add(
             TeamToken(
                 org_id="org1",
@@ -61,7 +82,7 @@ def app_db_team(monkeypatch):
         )
         s.commit()
 
-    from src.api.routes import auth_me, config_me
+    from src.api.routes import auth_me
 
     def override_get_db():
         with SessionLocal() as s:
@@ -73,7 +94,6 @@ def app_db_team(monkeypatch):
                 raise
 
     app = create_app()
-    app.dependency_overrides[config_me.get_db] = override_get_db
     app.dependency_overrides[auth_me.get_db] = override_get_db
     return app
 
@@ -90,6 +110,95 @@ def test_auth_me_team_token(app_db_team):
     assert body["org_id"] == "org1"
     assert body["team_node_id"] == "teamA"
     assert body["can_write"] is True
+    assert body.get("name") is None
+    assert body.get("email") is None
+    assert body.get("subject") is None
+
+
+def test_auth_me_team_token_has_no_persona(app_db_team):
+    client = TestClient(app_db_team)
+    r = client.get(
+        "/api/v1/auth/me", headers={"Authorization": "Bearer tokid.toksecret"}
+    )
+    body = r.json()
+    assert body.get("name") is None
+    assert body.get("email") is None
+    assert body.get("subject") is None
+
+
+@pytest.fixture()
+def app_db_sso(monkeypatch):
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    # Only create tables needed for token auth; full create_all fails on SQLite JSONB.
+    for table in (OrgNode, TeamToken):
+        table.__table__.create(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+
+    monkeypatch.setenv("TOKEN_PEPPER", "test-pepper")
+    monkeypatch.setenv("TEAM_AUTH_MODE", "token")
+
+    with SessionLocal() as s:
+        s.add(
+            OrgNode(
+                org_id="org1",
+                node_id="root",
+                parent_id=None,
+                node_type=NodeType.org,
+                name="Root",
+            )
+        )
+        s.add(
+            OrgNode(
+                org_id="org1",
+                node_id="default",
+                parent_id="root",
+                node_type=NodeType.team,
+                name="Default",
+            )
+        )
+        s.add(
+            TeamToken(
+                org_id="org1",
+                team_node_id="default",
+                token_id="ssotok",
+                token_hash=hash_token("ssosecret", pepper="test-pepper"),
+                label="sso:jane@example.com",
+                display_name="Jane Doe",
+            )
+        )
+        s.commit()
+
+    from src.api.routes import auth_me
+
+    def override_get_db():
+        with SessionLocal() as s:
+            try:
+                yield s
+                s.commit()
+            except Exception:
+                s.rollback()
+                raise
+
+    app = create_app()
+    app.dependency_overrides[auth_me.get_db] = override_get_db
+    return app
+
+
+def test_auth_me_sso_token_returns_name_and_email(app_db_sso):
+    client = TestClient(app_db_sso)
+    r = client.get(
+        "/api/v1/auth/me", headers={"Authorization": "Bearer ssotok.ssosecret"}
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["role"] == "team"
+    assert body["email"] == "jane@example.com"
+    assert body["name"] == "Jane Doe"
+    assert body["subject"] == "jane@example.com"
 
 
 def test_auth_me_admin_token(monkeypatch):

--- a/config_service/tests/test_sso_exchange.py
+++ b/config_service/tests/test_sso_exchange.py
@@ -1,10 +1,12 @@
 from src.api.routes.sso import (
+    _apply_sso_display_name,
     _resolve_sso_email,
     _sso_client_secret,
     _sso_team_node_id,
     _sso_token_hash,
 )
 from src.core.security import hash_token
+from src.db.models import TeamToken
 
 
 def test_resolve_sso_email_prefers_email_claim():
@@ -74,3 +76,34 @@ def test_sso_client_secret_empty_when_unset(monkeypatch):
 def test_sso_client_secret_empty_when_blank(monkeypatch):
     monkeypatch.setenv("SSO_CLIENT_SECRET", "   ")
     assert _sso_client_secret() == ""
+
+
+def _token() -> TeamToken:
+    return TeamToken(
+        org_id="org1",
+        team_node_id="default",
+        token_id="sso_tok",
+        token_hash="hash",
+        label="sso:jane@example.com",
+    )
+
+
+def test_apply_sso_display_name_sets_stripped_name():
+    token = _token()
+    _apply_sso_display_name(token, "  Jane Doe  ")
+    assert token.display_name == "Jane Doe"
+
+
+def test_apply_sso_display_name_ignores_blank_and_non_string():
+    token = _token()
+    token.display_name = "Jane Doe"
+    _apply_sso_display_name(token, "   ")
+    _apply_sso_display_name(token, None)
+    _apply_sso_display_name(token, 123)
+    assert token.display_name == "Jane Doe"
+
+
+def test_apply_sso_display_name_truncates_to_256():
+    token = _token()
+    _apply_sso_display_name(token, "x" * 300)
+    assert token.display_name == "x" * 256

--- a/docs/SELF_HOSTED_SIMPLE_INSTALL.md
+++ b/docs/SELF_HOSTED_SIMPLE_INSTALL.md
@@ -9,12 +9,12 @@ Deploy OpenSRE in **simple mode** (`server_simple.py`) using the umbrella Helm c
 - Optional: Ingress controller (nginx, Apisix, or ALB)
 - Container registry with pull access for your chosen image references (public Docker Hub defaults work out of the box)
 
-Simple-mode image defaults (tag **v1.2.2**):
+Simple-mode image defaults (tag **v1.2.4**):
 
-- `swapnildahiphale/opensre-sre-agent:v1.2.2`
-- `swapnildahiphale/opensre-config-service:v1.2.2`
-- `swapnildahiphale/opensre-web-ui:v1.2.2`
-- `swapnildahiphale/opensre-teams-bot:v1.2.2` (chart service off unless you enable `teamsBot`)
+- `swapnildahiphale/opensre-sre-agent:v1.2.4`
+- `swapnildahiphale/opensre-config-service:v1.2.4`
+- `swapnildahiphale/opensre-web-ui:v1.2.4`
+- `swapnildahiphale/opensre-teams-bot:v1.2.4` (chart service off unless you enable `teamsBot`)
 
 Override only in a local `my-site.yaml` if you use a private registry.
 

--- a/sre-agent/k8s/sandbox-template-warmpool.yaml
+++ b/sre-agent/k8s/sandbox-template-warmpool.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
       # Main agent container
       - name: agent
-        image: swapnildahiphale/opensre-sre-agent:v1.2.3
+        image: swapnildahiphale/opensre-sre-agent:v1.2.4
         imagePullPolicy: Always
         ports:
         - containerPort: 8888

--- a/sre-agent/server_simple.py
+++ b/sre-agent/server_simple.py
@@ -129,20 +129,10 @@ _TEAM_NODE_ID = os.getenv("OPENSRE_TEAM_ID", "default")
 
 def _resolve_team_identity(token: str) -> tuple[str, str]:
     """Resolve org_id and team_node_id from config-service auth/me; env fallback on failure."""
-    try:
-        resp = httpx.get(
-            f"{_CONFIG_SERVICE_URL}/api/v1/auth/me",
-            headers={"Authorization": f"Bearer {token}"},
-            timeout=5.0,
-        )
-        resp.raise_for_status()
-        data = resp.json()
-        org_id = (data.get("org_id") or "").strip() or _ORG_ID
-        team_node_id = (data.get("team_node_id") or "").strip() or _TEAM_NODE_ID
-        return org_id, team_node_id
-    except Exception as e:
-        logger.warning("[AUTH] resolve_team_identity failed, using env fallback: %s", e)
-        return _ORG_ID, _TEAM_NODE_ID
+    data = _fetch_auth_me(token)
+    org_id = (data.get("org_id") or "").strip() or _ORG_ID
+    team_node_id = (data.get("team_node_id") or "").strip() or _TEAM_NODE_ID
+    return org_id, team_node_id
 
 
 def _thread_tenancy(thread_id: str) -> tuple[str, str]:
@@ -164,6 +154,44 @@ def _normalize_trigger_source(value: Optional[str]) -> str:
     return v if v in _ALLOWED_TRIGGER_SOURCES else "web_ui"
 
 
+_TRIGGER_ACTOR_MAX = 128
+
+
+def _normalize_trigger_actor(value: Optional[str]) -> Optional[str]:
+    """Strip and cap trigger_actor. Empty → None so the DB column stays null."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    return stripped[:_TRIGGER_ACTOR_MAX]
+
+
+def _fetch_auth_me(token: str) -> dict:
+    """GET /auth/me as a dict. Empty dict on failure (do not raise)."""
+    try:
+        resp = httpx.get(
+            f"{_CONFIG_SERVICE_URL}/api/v1/auth/me",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=5.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data if isinstance(data, dict) else {}
+    except Exception as e:
+        logger.warning("[AUTH] fetch_auth_me failed: %s", e)
+        return {}
+
+
+def _actor_from_auth_me(data: dict) -> Optional[str]:
+    """Web SSO actor: display name if present, else email. Token-paste → None."""
+    if not isinstance(data, dict):
+        return None
+    return _normalize_trigger_actor(data.get("name")) or _normalize_trigger_actor(
+        data.get("email")
+    )
+
+
 def _create_agent_run(
     thread_id: str, prompt: str, agent_name: str = "sre-agent"
 ) -> Optional[str]:
@@ -178,7 +206,7 @@ def _create_agent_run(
             "team_node_id": team_node_id,
             "correlation_id": thread_id,
             "trigger_source": trigger_source,
-            "trigger_actor": None,
+            "trigger_actor": _trigger_actor_by_thread.get(thread_id),
             "trigger_message": prompt,
             "trigger_channel_id": None,
             "agent_name": agent_name,
@@ -487,6 +515,7 @@ _ALLOWED_TRIGGER_SOURCES = frozenset(
     {"web_ui", "teams", "slack", "api", "scheduled", "manual"}
 )
 _trigger_source_by_thread: Dict[str, str] = {}
+_trigger_actor_by_thread: Dict[str, str] = {}
 _active_sessions: Dict[str, object] = (
     {}
 )  # Thread ID -> agent session (for interrupt/answer)
@@ -574,6 +603,8 @@ class InvestigateRequest(BaseModel):
     resume_session_id: Optional[str] = None
     # Optional. teams-bot sends "teams"; web console omits and we store web_ui.
     trigger_source: Optional[str] = None
+    # Optional. Teams sends activity.from.name. Web omits; we infer from /auth/me.
+    trigger_actor: Optional[str] = None
 
 
 class InterruptRequest(BaseModel):
@@ -1131,6 +1162,16 @@ async def investigate(investigate_request: InvestigateRequest, http_request: Req
         _trigger_source_by_thread[thread_id] = _normalize_trigger_source(
             investigate_request.trigger_source
         )
+
+    body_actor = _normalize_trigger_actor(investigate_request.trigger_actor)
+    inferred = None
+    if not body_actor and team_token:
+        inferred = _actor_from_auth_me(_fetch_auth_me(team_token))
+    actor = body_actor or inferred
+    if actor:
+        _trigger_actor_by_thread[thread_id] = actor
+    else:
+        _trigger_actor_by_thread.pop(thread_id, None)
 
     print(f"🔍 Investigation: thread={thread_id}, new={is_new}")
 

--- a/sre-agent/tests/test_server_simple_team_token.py
+++ b/sre-agent/tests/test_server_simple_team_token.py
@@ -239,3 +239,190 @@ def test_finalize_investigation_strips_fence_and_attaches_structured_report(monk
     assert patched["body"]["output_json"] == {"title": "Headline"}
     assert "```json" not in patched["body"]["output_summary"]
     assert patched["body"]["output_summary"] == "**Headline**\n\nbody"
+
+
+def test_normalize_trigger_actor():
+    import server_simple
+
+    assert server_simple._normalize_trigger_actor(None) is None
+    assert server_simple._normalize_trigger_actor("   ") is None
+    assert server_simple._normalize_trigger_actor("  Jane Doe  ") == "Jane Doe"
+    assert server_simple._normalize_trigger_actor("x" * 200) == "x" * 128
+
+
+def test_actor_from_auth_me_prefers_name():
+    import server_simple
+
+    assert server_simple._actor_from_auth_me({"name": "Jane", "email": "j@x.com"}) == "Jane"
+    assert server_simple._actor_from_auth_me({"email": "j@x.com"}) == "j@x.com"
+    assert server_simple._actor_from_auth_me({}) is None
+    assert server_simple._actor_from_auth_me({"name": "  "}) is None
+
+
+def test_create_agent_run_uses_per_thread_actor(monkeypatch):
+    monkeypatch.setenv("OPENSRE_TENANT_ID", "local")
+    monkeypatch.setenv("OPENSRE_TEAM_ID", "default")
+    import server_simple
+
+    server_simple._team_identity_by_thread["thread-actor"] = ("pilot", "SRE")
+    server_simple._trigger_actor_by_thread["thread-actor"] = "Jane Doe"
+    posted = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        posted["body"] = json
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    with patch.object(server_simple.httpx, "post", side_effect=fake_post):
+        run_id = server_simple._create_agent_run(
+            thread_id="thread-actor",
+            prompt="check pods",
+        )
+
+    assert run_id is not None
+    assert posted["body"]["trigger_actor"] == "Jane Doe"
+
+
+def test_create_agent_run_actor_none_when_unset(monkeypatch):
+    monkeypatch.setenv("OPENSRE_TENANT_ID", "local")
+    monkeypatch.setenv("OPENSRE_TEAM_ID", "default")
+    import server_simple
+
+    server_simple._team_identity_by_thread["thread-no-actor"] = ("pilot", "SRE")
+    server_simple._trigger_actor_by_thread.pop("thread-no-actor", None)
+    posted = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        posted["body"] = json
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    with patch.object(server_simple.httpx, "post", side_effect=fake_post):
+        server_simple._create_agent_run(thread_id="thread-no-actor", prompt="x")
+
+    assert posted["body"]["trigger_actor"] is None
+
+
+def test_investigate_explicit_trigger_actor_wins(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    import server_simple
+
+    async def fake_bg(thread_id, resume_session_id=None):
+        pass
+
+    monkeypatch.setattr(server_simple, "agent_background_task", fake_bg)
+    monkeypatch.setattr(server_simple, "_background_tasks", {})
+    monkeypatch.setattr(server_simple, "_message_queues", {})
+    monkeypatch.setattr(server_simple, "_response_queues", {})
+    monkeypatch.setattr(server_simple, "_team_identity_by_thread", {})
+    monkeypatch.setattr(server_simple, "_trigger_actor_by_thread", {})
+    monkeypatch.setattr(
+        server_simple,
+        "_resolve_team_identity",
+        lambda _t: ("pilot", "SRE"),
+    )
+    monkeypatch.setattr(
+        server_simple,
+        "_actor_from_auth_me",
+        lambda _d: "Service Token User",
+    )
+    monkeypatch.setattr(
+        server_simple,
+        "_fetch_auth_me",
+        lambda _t: {"name": "Service Token User", "email": "bot@example.com"},
+    )
+
+    client = TestClient(server_simple.app)
+    with patch.object(
+        server_simple, "create_investigation_stream", return_value=iter([])
+    ):
+        resp = client.post(
+            "/investigate",
+            json={
+                "prompt": "oc-1234",
+                "thread_id": "thread-teams-actor",
+                "trigger_source": "teams",
+                "trigger_actor": "Jane Doe",
+            },
+            headers={"Authorization": "Bearer service-token"},
+        )
+    assert resp.status_code == 200
+    assert server_simple._trigger_actor_by_thread["thread-teams-actor"] == "Jane Doe"
+
+
+def test_investigate_infers_actor_from_auth_me(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    import server_simple
+
+    async def fake_bg(thread_id, resume_session_id=None):
+        pass
+
+    monkeypatch.setattr(server_simple, "agent_background_task", fake_bg)
+    monkeypatch.setattr(server_simple, "_background_tasks", {})
+    monkeypatch.setattr(server_simple, "_message_queues", {})
+    monkeypatch.setattr(server_simple, "_response_queues", {})
+    monkeypatch.setattr(server_simple, "_team_identity_by_thread", {})
+    monkeypatch.setattr(server_simple, "_trigger_actor_by_thread", {})
+    monkeypatch.setattr(
+        server_simple,
+        "_resolve_team_identity",
+        lambda _t: ("pilot", "SRE"),
+    )
+    monkeypatch.setattr(
+        server_simple,
+        "_fetch_auth_me",
+        lambda _t: {"name": "Jane Doe", "email": "jane@example.com"},
+    )
+
+    client = TestClient(server_simple.app)
+    with patch.object(
+        server_simple, "create_investigation_stream", return_value=iter([])
+    ):
+        resp = client.post(
+            "/investigate",
+            json={"prompt": "test", "thread_id": "thread-web-actor"},
+            headers={"Authorization": "Bearer sso-token"},
+        )
+    assert resp.status_code == 200
+    assert server_simple._trigger_actor_by_thread["thread-web-actor"] == "Jane Doe"
+
+
+def test_investigate_empty_actor_clears_thread(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    import server_simple
+
+    async def fake_bg(thread_id, resume_session_id=None):
+        pass
+
+    monkeypatch.setattr(server_simple, "agent_background_task", fake_bg)
+    monkeypatch.setattr(server_simple, "_background_tasks", {})
+    monkeypatch.setattr(server_simple, "_message_queues", {})
+    monkeypatch.setattr(server_simple, "_response_queues", {})
+    monkeypatch.setattr(server_simple, "_team_identity_by_thread", {})
+    monkeypatch.setattr(
+        server_simple, "_trigger_actor_by_thread", {"thread-clear-actor": "Old"}
+    )
+    monkeypatch.setattr(
+        server_simple,
+        "_resolve_team_identity",
+        lambda _t: ("pilot", "SRE"),
+    )
+    monkeypatch.setattr(server_simple, "_fetch_auth_me", lambda _t: {})
+
+    client = TestClient(server_simple.app)
+    with patch.object(
+        server_simple, "create_investigation_stream", return_value=iter([])
+    ):
+        resp = client.post(
+            "/investigate",
+            json={
+                "prompt": "test",
+                "thread_id": "thread-clear-actor",
+                "trigger_actor": "   ",
+            },
+            headers={"Authorization": "Bearer minted-token"},
+        )
+    assert resp.status_code == 200
+    assert "thread-clear-actor" not in server_simple._trigger_actor_by_thread

--- a/teams-bot/bot_handlers.py
+++ b/teams-bot/bot_handlers.py
@@ -2,7 +2,7 @@
 
 import logging
 import re
-from typing import Any
+from typing import Any, Optional
 
 import aiohttp
 from card_builder import build_welcome_card
@@ -45,6 +45,22 @@ def should_handle_message(
     if is_direct_bot_chat(conversation_type, channel_id):
         return bool((text or "").strip())
     return mentioned and bool((text or "").strip())
+
+
+def activity_sender_name(activity: Any) -> Optional[str]:
+    """Teams display name from the activity sender. Never return the user id."""
+    sender = getattr(activity, "from_property", None)
+    if sender is None:
+        sender = getattr(activity, "from", None)
+    name = getattr(sender, "name", None) if sender is not None else None
+    if isinstance(sender, dict):
+        name = sender.get("name")
+    if not isinstance(name, str):
+        return None
+    stripped = name.strip()
+    if not stripped:
+        return None
+    return stripped[:128]
 
 
 def strip_bot_mention(text: str, bot_name: str = "OpenSRE") -> str:
@@ -190,6 +206,7 @@ def register_handlers(app) -> None:
             send_text=send_text,
             update_card=update_card,
             plain_text_final=not use_stream,
+            trigger_actor=activity_sender_name(activity),
         )
 
     @app.on_card_action_execute(SUBMIT_VERB)

--- a/teams-bot/investigation_runner.py
+++ b/teams-bot/investigation_runner.py
@@ -107,6 +107,7 @@ async def run_investigation(
     send_text: SendText,
     update_card: UpdateCard,
     plain_text_final: bool = False,
+    trigger_actor: Optional[str] = None,
 ) -> None:
     active_investigations.add(thread_id)
     try:
@@ -119,6 +120,7 @@ async def run_investigation(
             send_text=send_text,
             update_card=update_card,
             plain_text_final=plain_text_final,
+            trigger_actor=trigger_actor,
         )
     finally:
         active_investigations.discard(thread_id)
@@ -134,6 +136,7 @@ async def _run_investigation_body(
     send_text: SendText,
     update_card: UpdateCard,
     plain_text_final: bool,
+    trigger_actor: Optional[str] = None,
 ) -> None:
     cfg = Config()
     state = InvestigationState(thread_id=thread_id)
@@ -143,6 +146,9 @@ async def _run_investigation_body(
         "thread_id": thread_id,
         "trigger_source": "teams",
     }
+    actor = (trigger_actor or "").strip()
+    if actor:
+        payload["trigger_actor"] = actor[:128]
     last_update = 0.0
 
     async def send_final_reply() -> None:

--- a/teams-bot/tests/test_bot_handlers.py
+++ b/teams-bot/tests/test_bot_handlers.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from bot_handlers import (
+    activity_sender_name,
     is_azure_webchat,
     is_direct_bot_chat,
     is_personal_chat,
@@ -11,6 +12,29 @@ from bot_handlers import (
 )
 from investigation_runner import sanitize_thread_id
 from state import active_investigations
+
+
+def test_activity_sender_name_from_property():
+    # MagicMock(name=...) sets the mock id, not ChannelAccount.name.
+    sender = MagicMock()
+    sender.name = "Jane Doe"
+    activity = MagicMock()
+    activity.from_property = sender
+    assert activity_sender_name(activity) == "Jane Doe"
+
+
+def test_activity_sender_name_missing():
+    activity = MagicMock(spec=["text"])
+    assert activity_sender_name(activity) is None
+
+
+def test_activity_sender_name_strips_and_caps():
+    activity = MagicMock()
+    activity.from_property = MagicMock()
+    activity.from_property.name = "  " + ("x" * 200)
+    got = activity_sender_name(activity)
+    assert got is not None
+    assert len(got) == 128
 
 
 def test_strip_bot_mention():
@@ -75,11 +99,14 @@ async def test_channel_investigation_does_not_use_activity_stream():
         channel_id="msteams",
         channelId="msteams",
     )
+    ctx.activity.from_property = MagicMock()
+    ctx.activity.from_property.name = "Jane Doe"
     with patch("bot_handlers.run_investigation", new_callable=AsyncMock) as mock_run:
         await on_message_handler(ctx)
 
     mock_run.assert_awaited_once()
     kwargs = mock_run.await_args.kwargs
+    assert kwargs["trigger_actor"] == "Jane Doe"
     assert kwargs["plain_text_final"] is True
     ctx.stream.update.assert_not_called()
     # Ack is one send; progress edits reuse that activity id (PUT, not stream).
@@ -141,6 +168,45 @@ async def test_personal_investigation_keeps_activity_stream():
     ctx.stream.update.assert_called_once()
     ctx.stream.close.assert_called_once()
     assert kwargs["plain_text_final"] is False
+
+
+@pytest.mark.asyncio
+async def test_personal_investigation_omits_actor_when_name_missing():
+    on_message_handler = None
+
+    class FakeApp:
+        def on_message(self, fn):
+            nonlocal on_message_handler
+            on_message_handler = fn
+            return fn
+
+        def on_card_action_execute(self, _verb):
+            def decorator(fn):
+                return fn
+
+            return decorator
+
+    register_handlers(FakeApp())
+    ctx = MagicMock()
+    ctx.send = AsyncMock(return_value=MagicMock(id="act-p"))
+    ctx.stream = MagicMock()
+    ctx.stream.update = MagicMock()
+    ctx.stream.close = MagicMock()
+    ctx.activity = MagicMock(
+        text="check redis",
+        entities=[],
+        conversation=MagicMock(
+            id="a:personal-synthetic",
+            conversation_type="personal",
+            conversationType=None,
+        ),
+        channel_id="msteams",
+        channelId="msteams",
+        from_property=None,
+    )
+    with patch("bot_handlers.run_investigation", new_callable=AsyncMock) as mock_run:
+        await on_message_handler(ctx)
+    assert mock_run.await_args.kwargs.get("trigger_actor") in (None, "")
 
 
 def test_is_personal_chat():

--- a/teams-bot/tests/test_investigation_runner.py
+++ b/teams-bot/tests/test_investigation_runner.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -79,6 +80,7 @@ async def _make_sse_runner(
     send_text=None,
     plain_text_final: bool = False,
     web_ui_base_url: str = "",
+    trigger_actor: Optional[str] = None,
 ):
     """Helper: mock aiohttp to stream sse_lines then close, run investigation."""
     if send_text is None:
@@ -119,9 +121,53 @@ async def _make_sse_runner(
                 send_text=send_text,
                 update_card=AsyncMock(),
                 plain_text_final=plain_text_final,
+                trigger_actor=trigger_actor,
             )
             assert mock_session.post.call_args.kwargs["json"]["trigger_source"] == "teams"
     return send_text
+
+
+@pytest.mark.asyncio
+async def test_run_investigation_includes_trigger_actor():
+    send_card = AsyncMock()
+    sse_lines = ['data: {"type": "result", "data": {"text": "done"}}']
+    sse_bytes = ("\n".join(sse_lines) + "\n").encode()
+
+    async def _iter_any():
+        yield sse_bytes
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.content.iter_any = _iter_any
+    mock_post_ctx = AsyncMock()
+    mock_post_ctx.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_post_ctx.__aexit__ = AsyncMock(return_value=None)
+    mock_session = MagicMock()
+    mock_session.post = MagicMock(return_value=mock_post_ctx)
+    mock_session_ctx = AsyncMock()
+    mock_session_ctx.__aenter__.return_value = mock_session
+    mock_session_ctx.__aexit__.return_value = None
+
+    with patch(
+        "investigation_runner.aiohttp.ClientSession", return_value=mock_session_ctx
+    ):
+        with patch("investigation_runner.Config") as mock_cfg:
+            mock_cfg.return_value.SRE_AGENT_URL = "http://agent:8001"
+            mock_cfg.return_value.INVESTIGATE_AUTH_TOKEN = ""
+            mock_cfg.return_value.WEB_UI_PUBLIC_BASE_URL = ""
+            await run_investigation(
+                thread_id="teams-test",
+                prompt="investigate latency",
+                stream_update=AsyncMock(),
+                stream_close=AsyncMock(),
+                send_card=send_card,
+                send_text=AsyncMock(),
+                update_card=AsyncMock(),
+                trigger_actor="Jane Doe",
+            )
+    payload = mock_session.post.call_args.kwargs["json"]
+    assert payload["trigger_source"] == "teams"
+    assert payload["trigger_actor"] == "Jane Doe"
 
 
 @pytest.mark.asyncio

--- a/web_ui/src/app/team/agent-runs/[runId]/page.tsx
+++ b/web_ui/src/app/team/agent-runs/[runId]/page.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/RunStatusBadge';
 import { Skeleton, TeamPageShell } from '@/components/ui-flow';
 import { ArrowLeft } from 'lucide-react';
+import { formatTriggerMeta } from '@/lib/triggerMeta';
 
 const NO_RESUME = "This conversation can't be continued (no saved session). Start a new investigation.";
 const INTERRUPTED_HALT =
@@ -28,7 +29,7 @@ export default function AgentRunDetailPage() {
     turns: historicalTurns, title, status,
     sessionId, threadId, sessionAlive, continuable, errorMessage, loading, error, reload,
     activeKnown, consecutiveInactivePolls,
-    episode, triggerSource,
+    episode, triggerSource, triggerActor,
   } = useConversation(runId);
 
   const stream = useAgentStream({
@@ -135,7 +136,6 @@ export default function AgentRunDetailPage() {
     displayStatus === 'timeout' || displayStatus === 'failed' || displayStatus === 'interrupted'
   );
 
-  const channelLabel = (triggerSource ?? 'web_ui').replace(/_/g, ' ');
   const turnLabel = `${turns.length} turn${turns.length === 1 ? '' : 's'}`;
 
   return (
@@ -190,7 +190,7 @@ export default function AgentRunDetailPage() {
               />
             )}
             <span className="text-xs text-slate-400 font-mono tabular-nums">
-              · {turnLabel} · {channelLabel}
+              · {turnLabel} · {formatTriggerMeta(triggerSource, triggerActor)}
             </span>
           </div>
         </header>

--- a/web_ui/src/app/team/agent-runs/page.tsx
+++ b/web_ui/src/app/team/agent-runs/page.tsx
@@ -524,6 +524,12 @@ export default function TeamAgentRunsPage() {
                                 {triggerIcon(conv.latestRun.triggerSource)}
                                 {conv.latestRun.triggerSource.replace(/_/g, ' ')}
                               </span>
+                              {conv.firstRun.triggerActor?.trim() ? (
+                                <>
+                                  <span>·</span>
+                                  <span>{conv.firstRun.triggerActor.trim()}</span>
+                                </>
+                              ) : null}
                               {duration && !isRunning && (
                                 <>
                                   <span>·</span>

--- a/web_ui/src/components/AccountMenu.test.tsx
+++ b/web_ui/src/components/AccountMenu.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AccountMenu } from './AccountMenu';
+import { useIdentity } from '@/lib/useIdentity';
+
+vi.mock('@/lib/useIdentity', () => ({
+  useIdentity: vi.fn(),
+}));
+
+const baseTeam = {
+  role: 'team' as const,
+  auth_kind: 'team_token' as const,
+  org_id: 'local',
+  team_node_id: 'default',
+  can_write: true,
+  permissions: [] as string[],
+};
+
+describe('AccountMenu', () => {
+  beforeEach(() => {
+    vi.mocked(useIdentity).mockReset();
+  });
+
+  it('shows display name with email tooltip for SSO', () => {
+    vi.mocked(useIdentity).mockReturnValue({
+      identity: { ...baseTeam, name: 'Jane Doe', email: 'jane@example.com' },
+      error: null,
+      loading: false,
+      refresh: vi.fn(),
+    });
+    render(<AccountMenu />);
+    const persona = screen.getByText('Jane Doe');
+    expect(persona).toBeInTheDocument();
+    expect(persona).toHaveAttribute('title', 'jane@example.com');
+    expect(screen.getByText('local')).toBeInTheDocument();
+    expect(screen.getByText('default')).toBeInTheDocument();
+  });
+
+  it('falls back to email when name is missing', () => {
+    vi.mocked(useIdentity).mockReturnValue({
+      identity: { ...baseTeam, name: null, email: 'jane@example.com' },
+      error: null,
+      loading: false,
+      refresh: vi.fn(),
+    });
+    render(<AccountMenu />);
+    expect(screen.getByText('jane@example.com')).toBeInTheDocument();
+    expect(screen.queryByText('Jane Doe')).not.toBeInTheDocument();
+  });
+
+  it('omits a persona row for token-paste team login', () => {
+    vi.mocked(useIdentity).mockReturnValue({
+      identity: baseTeam,
+      error: null,
+      loading: false,
+      refresh: vi.fn(),
+    });
+    render(<AccountMenu />);
+    expect(screen.queryByText('jane@example.com')).not.toBeInTheDocument();
+    expect(screen.getByText('local')).toBeInTheDocument();
+    expect(screen.getByText('default')).toBeInTheDocument();
+    expect(screen.queryByText('—')).not.toBeInTheDocument();
+  });
+});

--- a/web_ui/src/components/AccountMenu.tsx
+++ b/web_ui/src/components/AccountMenu.tsx
@@ -35,6 +35,14 @@ export function AccountMenu() {
         className="w-full flex items-center justify-between gap-2 px-2 py-2 rounded-lg hover:bg-white/5 transition-colors"
       >
         <div className="min-w-0 text-left">
+          {(identity?.name || identity?.email) && (
+            <div
+              className="text-sm font-semibold text-white truncate"
+              title={identity.name ? (identity.email ?? undefined) : undefined}
+            >
+              {identity.name || identity.email}
+            </div>
+          )}
           <div className="flex items-center gap-1.5">
             <span className="text-[10px] uppercase tracking-wider text-stone-500 font-medium">Org</span>
             <span className="text-sm font-semibold text-white truncate">

--- a/web_ui/src/lib/triggerMeta.test.ts
+++ b/web_ui/src/lib/triggerMeta.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { formatTriggerMeta } from './triggerMeta';
+
+describe('formatTriggerMeta', () => {
+  it('returns channel only when actor is missing', () => {
+    expect(formatTriggerMeta('web_ui')).toBe('web ui');
+    expect(formatTriggerMeta('teams', null)).toBe('teams');
+    expect(formatTriggerMeta('teams', '  ')).toBe('teams');
+  });
+
+  it('appends first-run actor when set', () => {
+    expect(formatTriggerMeta('web_ui', 'Jane Doe')).toBe('web ui · Jane Doe');
+    expect(formatTriggerMeta('teams', ' Jane ')).toBe('teams · Jane');
+  });
+
+  it('defaults missing source to web_ui', () => {
+    expect(formatTriggerMeta(undefined, 'Jane Doe')).toBe('web ui · Jane Doe');
+  });
+});

--- a/web_ui/src/lib/triggerMeta.ts
+++ b/web_ui/src/lib/triggerMeta.ts
@@ -1,0 +1,9 @@
+/** Channel label, plus actor when the first run recorded one. */
+export function formatTriggerMeta(
+  source?: string | null,
+  actor?: string | null,
+): string {
+  const channel = (source ?? 'web_ui').replace(/_/g, ' ');
+  const name = actor?.trim();
+  return name ? `${channel} · ${name}` : channel;
+}

--- a/web_ui/src/lib/useConversation.ts
+++ b/web_ui/src/lib/useConversation.ts
@@ -13,6 +13,7 @@ interface ListRun {
   id: string; correlationId: string; agentName: string; status: string;
   startedAt: string; triggerMessage?: string;
   triggerSource?: string;
+  triggerActor?: string;
   outputSummary?: string | null; outputJson?: Record<string, unknown> | null;
   errorMessage?: string | null;
   sdkSessionId?: string | null;
@@ -45,6 +46,7 @@ export function useConversation(runId: string | undefined) {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [episode, setEpisode] = useState<ThreadEpisode | null>(null);
   const [triggerSource, setTriggerSource] = useState<string | null>(null);
+  const [triggerActor, setTriggerActor] = useState<string | null>(null);
 
   // isCancelled defaults to () => false for the public reload path.
   // The polling effect passes its own cancelled flag so in-flight fetches
@@ -137,6 +139,7 @@ export function useConversation(runId: string | undefined) {
       setStatus(asRunStatus(runs[runs.length - 1]?.status ?? 'idle'));
       setEpisode(episode ?? null);
       setTriggerSource(runs[0]?.triggerSource ?? null);
+      setTriggerActor(runs[0]?.triggerActor ?? null);
     } catch (e) {
       if (!isCancelled()) setError(e instanceof Error ? e.message : 'Failed to load conversation');
     } finally {
@@ -161,7 +164,7 @@ export function useConversation(runId: string | undefined) {
   return {
     turns, title, agentName, status,
     sessionId, threadId, sessionAlive, errorMessage,
-    episode, triggerSource,
+    episode, triggerSource, triggerActor,
     continuable: canContinueConversation({
       sessionId,
       sessionAlive,

--- a/web_ui/src/lib/useIdentity.ts
+++ b/web_ui/src/lib/useIdentity.ts
@@ -6,6 +6,9 @@ export type Identity = {
   auth_kind: "admin_token" | "team_token" | "oidc" | "impersonation";
   org_id?: string | null;
   team_node_id?: string | null;
+  subject?: string | null;
+  email?: string | null;
+  name?: string | null;
   can_write: boolean;
   permissions: string[];
 };


### PR DESCRIPTION
## Summary
- SSO web console: account menu shows Entra display name (email fallback); investigations record initiator via `trigger_actor`
- Teams bot forwards sender display name as `trigger_actor`
- Token-paste login unchanged (no fabricated persona)
- DB migration: `team_tokens.display_name` (nullable)
- Hub images: `swapnildahiphale/opensre-{sre-agent,config-service,web-ui,teams-bot}:v1.2.4`

## Test plan
- [ ] No secrets, ARNs, ghixqa, vimolabs, platform-kronos, deploy/
- [ ] `CLAUDE.md` is public transform (not private AGENTS.md)
- [ ] Migration + SSO/actor code in config_service, sre-agent, teams-bot, web_ui
- [ ] charts/opensre at 1.2.4 with Hub image pins
- [ ] docker-publish.yml and docs/index.html present after merge