### PR TITLE
OpenSRE v1.2.5 — Teams actor identity fix

### DIFF
--- a/charts/opensre/Chart.yaml
+++ b/charts/opensre/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: opensre
 description: AI-powered SRE platform for automated incident investigation and response
 type: application
-version: 1.2.4
-appVersion: "1.2.4"
+version: 1.2.5
+appVersion: "1.2.5"
 home: https://opensre.in
 icon: https://raw.githubusercontent.com/swapnildahiphale/OpenSRE/main/web_ui/public/brand/opensre-spinner.png
 sources:

--- a/charts/opensre/README.md
+++ b/charts/opensre/README.md
@@ -148,7 +148,7 @@ helm upgrade --install opensre charts/opensre \
 
 ### Self-hosted profile (recommended)
 
-See `charts/opensre/values.self-hosted-simple.yaml` for the supported public self-hosted profile (simple mode with embedded Postgres/Neo4j; Docker Hub image pins for v1.2.4). Full walkthrough: `docs/SELF_HOSTED_SIMPLE_INSTALL.md`.
+See `charts/opensre/values.self-hosted-simple.yaml` for the supported public self-hosted profile (simple mode with embedded Postgres/Neo4j; Docker Hub image pins for v1.2.5). Full walkthrough: `docs/SELF_HOSTED_SIMPLE_INSTALL.md`.
 
 ### Site overlay (hosts, TLS, private registry)
 

--- a/charts/opensre/values.examples/site-overlay.yaml.example
+++ b/charts/opensre/values.examples/site-overlay.yaml.example
@@ -1,5 +1,5 @@
 # Copy to my-site.yaml (local, gitignored). Do not commit secrets.
-# Simple-mode already pins Docker Hub swapnildahiphale/opensre-*:v1.2.4.
+# Simple-mode already pins Docker Hub swapnildahiphale/opensre-*:v1.2.5.
 # Set services.*.image here only when using a private registry.
 
 ingress:

--- a/charts/opensre/values.self-hosted-simple.yaml
+++ b/charts/opensre/values.self-hosted-simple.yaml
@@ -54,7 +54,7 @@ neo4j:
 services:
   configService:
     enabled: true
-    image: swapnildahiphale/opensre-config-service:v1.2.4
+    image: swapnildahiphale/opensre-config-service:v1.2.5
     adminAuthMode: token
     teamAuthMode: token
     migrations:
@@ -69,7 +69,7 @@ services:
 
   teamsBot:
     enabled: false
-    image: swapnildahiphale/opensre-teams-bot:v1.2.4
+    image: swapnildahiphale/opensre-teams-bot:v1.2.5
 
   k8sGateway:
     enabled: false
@@ -109,11 +109,11 @@ services:
       persistence:
         enabled: true
         size: 10Gi
-    image: swapnildahiphale/opensre-sre-agent:v1.2.4
+    image: swapnildahiphale/opensre-sre-agent:v1.2.5
 
   webUi:
     enabled: true
-    image: swapnildahiphale/opensre-web-ui:v1.2.4
+    image: swapnildahiphale/opensre-web-ui:v1.2.5
     cookieSecure: true
     oidc:
       enabled: false

--- a/docs/SELF_HOSTED_SIMPLE_INSTALL.md
+++ b/docs/SELF_HOSTED_SIMPLE_INSTALL.md
@@ -9,12 +9,12 @@ Deploy OpenSRE in **simple mode** (`server_simple.py`) using the umbrella Helm c
 - Optional: Ingress controller (nginx, Apisix, or ALB)
 - Container registry with pull access for your chosen image references (public Docker Hub defaults work out of the box)
 
-Simple-mode image defaults (tag **v1.2.4**):
+Simple-mode image defaults (tag **v1.2.5**):
 
-- `swapnildahiphale/opensre-sre-agent:v1.2.4`
-- `swapnildahiphale/opensre-config-service:v1.2.4`
-- `swapnildahiphale/opensre-web-ui:v1.2.4`
-- `swapnildahiphale/opensre-teams-bot:v1.2.4` (chart service off unless you enable `teamsBot`)
+- `swapnildahiphale/opensre-sre-agent:v1.2.5`
+- `swapnildahiphale/opensre-config-service:v1.2.5`
+- `swapnildahiphale/opensre-web-ui:v1.2.5`
+- `swapnildahiphale/opensre-teams-bot:v1.2.5` (chart service off unless you enable `teamsBot`)
 
 Override only in a local `my-site.yaml` if you use a private registry.
 

--- a/sre-agent/k8s/sandbox-template-warmpool.yaml
+++ b/sre-agent/k8s/sandbox-template-warmpool.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
       # Main agent container
       - name: agent
-        image: swapnildahiphale/opensre-sre-agent:v1.2.4
+        image: swapnildahiphale/opensre-sre-agent:v1.2.5
         imagePullPolicy: Always
         ports:
         - containerPort: 8888

--- a/teams-bot/bot_handlers.py
+++ b/teams-bot/bot_handlers.py
@@ -49,7 +49,10 @@ def should_handle_message(
 
 def activity_sender_name(activity: Any) -> Optional[str]:
     """Teams display name from the activity sender. Never return the user id."""
-    sender = getattr(activity, "from_property", None)
+    # microsoft-teams-apps 2.x exposes JSON "from" as from_ on MessageActivity.
+    sender = getattr(activity, "from_", None)
+    if sender is None:
+        sender = getattr(activity, "from_property", None)
     if sender is None:
         sender = getattr(activity, "from", None)
     name = getattr(sender, "name", None) if sender is not None else None

--- a/teams-bot/tests/test_bot_handlers.py
+++ b/teams-bot/tests/test_bot_handlers.py
@@ -18,8 +18,26 @@ def test_activity_sender_name_from_property():
     # MagicMock(name=...) sets the mock id, not ChannelAccount.name.
     sender = MagicMock()
     sender.name = "Jane Doe"
-    activity = MagicMock()
+    activity = MagicMock(spec=["from_property", "from"])
     activity.from_property = sender
+    assert activity_sender_name(activity) == "Jane Doe"
+
+
+def test_activity_sender_name_message_activity_from_alias():
+    """Real SDK MessageActivity stores sender on from_, not from_property."""
+    from microsoft_teams.api import MessageActivity
+
+    activity = MessageActivity.model_validate(
+        {
+            "type": "message",
+            "id": "msg-1",
+            "timestamp": "2026-09-10T07:30:00Z",
+            "from": {"id": "user1", "name": "Jane Doe"},
+            "recipient": {"id": "bot-1", "name": "OpenSRE"},
+            "conversation": {"id": "conv-1"},
+            "text": "hello",
+        }
+    )
     assert activity_sender_name(activity) == "Jane Doe"
 
 
@@ -29,9 +47,9 @@ def test_activity_sender_name_missing():
 
 
 def test_activity_sender_name_strips_and_caps():
-    activity = MagicMock()
-    activity.from_property = MagicMock()
-    activity.from_property.name = "  " + ("x" * 200)
+    activity = MagicMock(spec=["from_"])
+    activity.from_ = MagicMock()
+    activity.from_.name = "  " + ("x" * 200)
     got = activity_sender_name(activity)
     assert got is not None
     assert len(got) == 128
@@ -99,8 +117,8 @@ async def test_channel_investigation_does_not_use_activity_stream():
         channel_id="msteams",
         channelId="msteams",
     )
-    ctx.activity.from_property = MagicMock()
-    ctx.activity.from_property.name = "Jane Doe"
+    ctx.activity.from_ = MagicMock()
+    ctx.activity.from_.name = "Jane Doe"
     with patch("bot_handlers.run_investigation", new_callable=AsyncMock) as mock_run:
         await on_message_handler(ctx)
 


### PR DESCRIPTION
## Summary
- Fix Teams `trigger_actor`: read sender display name from `MessageActivity.from_` (microsoft-teams-apps 2.x)
- Bump chart and Docker Hub image pins to v1.2.5

## Test plan
- [ ] Merge and tag `v1.2.5` on public `main`
- [ ] Verify `docker pull swapnildahiphale/opensre-teams-bot:v1.2.5`
- [ ] Confirm Investigations list shows Teams sender display name